### PR TITLE
Replace musl-cross with maintained GitHub mirror

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -11,7 +11,7 @@ die() { echo >&2 "$@"; exit 1; }
 
 if [ ! -d build/musl-cross ]; then
 	cd build
-	hg clone https://bitbucket.org/GregorR/musl-cross \
+	git clone https://github.com/GregorR/musl-cross.git \
 		|| die "clone failed"
 
 	cd musl-cross

--- a/patches/musl-cross.patch
+++ b/patches/musl-cross.patch
@@ -26,15 +26,3 @@ diff -r c004067a7b34 config.sh
 +
 +# Build GMP, MPFR and MPC
 +GCC_BUILTIN_PREREQS=yes
-diff -r c004067a7b34 defs.sh
---- a/defs.sh	Sun Oct 02 20:51:04 2016 -0400
-+++ b/defs.sh	Fri Jan 27 17:47:25 2017 -0500
-@@ -46,7 +46,7 @@
- 
- # musl can optionally be checked out from GIT, in which case MUSL_VERSION must
- # be set to a git tag and MUSL_GIT set to yes in config.sh
--MUSL_DEFAULT_VERSION=1.1.12
-+MUSL_DEFAULT_VERSION=1.1.15
- MUSL_GIT_VERSION=615629bd6fcd6ddb69ad762e679f088c7bd878e2
- MUSL_GIT_REPO='git://repo.or.cz/musl.git'
- MUSL_VERSION="$MUSL_DEFAULT_VERSION"


### PR DESCRIPTION
Changing musl-cross to the maintained GitHub mirror as recommended by [rofl0r](https://github.com/rofl0r) at [https://github.com/osresearch/heads/commit/2213500000771a8791553b91ec1b9ca24f35b0d3](https://github.com/osresearch/heads/commit/2213500000771a8791553b91ec1b9ca24f35b0d3).

This should also resolve #98.

The `defs.sh` patch could be removed because the GitHub mirror has the `MUSL_DEFAULT_VERSION=1.1.16`.
