### PR TITLE
Find Qubes root with /dev/mapper instead of label

### DIFF
--- a/initrd/bin/start-xen
+++ b/initrd/bin/start-xen
@@ -21,7 +21,7 @@ gpgv "${KERNEL}.asc" "${KERNEL}" || die "Kernel signature failed"
 
 kexec \
 	-l \
-	--module "${KERNEL} root=LABEL=root rhgb" \
+	--module "${KERNEL} root=/dev/mapper/qubes_dom0-root rhgb" \
 	--module "${INITRD}" \
 	--command-line "no-real-mode reboot=no console=vga dom0_mem=min:1024M dom0_mem=max:4096M" \
 	"${XEN}"


### PR DESCRIPTION
Avoids having to assign labels during Qubes installation and avoids
having to deal with UUIDs.

See https://github.com/osresearch/heads/issues/110 for discussion.