### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Building heads
 In order to build reproducible firmware images, Heads builds a specific
 version of gcc and uses it to compile the Linux kernel and various tools
 that go into the initrd.  Unfortunately this means the first step is a
-little slow since it will clone the `musl-cross` tree and build gcc... 
+little slow since it will clone the `musl-cross` tree and build gcc...
 
 Once that is done, the top level `Makefile` will handle most of the
 remaining details -- it downloads the various packages, verifies the

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Notes:
 
 * Building coreboot's cross compilers can take a while.  Luckily this is only done once.
 * Builds are finally reproducible! The [reproduciblebuilds tag](https://github.com/osresearch/heads/issues?q=is%3Aopen+is%3Aissue+milestone%3Areproduciblebuilds) tracks any regressions.
-* Currently only tested in Qemu, the Thinkpad x230 and the Chell chromebook.
-** Xen and the TPM do not work in Qemu, so it is only for testing the `initrd` image.
+* Currently only tested in QEMU, the Thinkpad x230 and the Chell chromebook.
+** Xen and the TPM do not work in QEMU, so it is only for testing the `initrd` image.
 * Booting Qubes requires patching Xen's real mode startup code
 see `patches/xen-4.6.3.patch` and adding `no-real-mode` to start
 of the Xen command line.  Booting or installing Qubes is a bit hacky and needs to be documented.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ directory and include:
 * [kexec](https://wiki.archlinux.org/index.php/kexec)
 * [mbedtls](https://tls.mbed.org/)
 * [tpmtotp](https://trmm.net/Tpmtotp)
-* [coreboot](http://coreboot.org/)
+* [coreboot](https://coreboot.org/)
 * [cryptsetup](https://gitlab.com/cryptsetup/cryptsetup)
 * [lvm2](https://sourceware.org/lvm2/)
 * [gnupg](https://www.gnupg.org/)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ directory and include:
 * [kexec](https://wiki.archlinux.org/index.php/kexec)
 * [mbedtls](https://tls.mbed.org/)
 * [tpmtotp](https://trmm.net/Tpmtotp)
-* [coreboot](https://coreboot.org/)
+* [coreboot](https://www.coreboot.org/)
 * [cryptsetup](https://gitlab.com/cryptsetup/cryptsetup)
 * [lvm2](https://sourceware.org/lvm2/)
 * [gnupg](https://www.gnupg.org/)


### PR DESCRIPTION
Spell *QEMU* all uppercase, and remove trailing space.