### PR TITLE
Automatically load network kernel modules and request DHCP

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -28,6 +28,11 @@ if ! unsealtotp.sh ; then
 fi
 echo
 
+# Load the network modules and get an IP address
+insmod /lib/modules/e1000.ko
+insmod /lib/modules/e1000e.ko
+udhcpc -n
+
 # Start an interactive shell
 export PATH=/sbin:/usr/sbin:/bin:/usr/bin
 exec /bin/ash


### PR DESCRIPTION
This loads the kernel modules for the Thinkpad NICs and then starts up udhcp inside init. I wasn't sure whether to use -b or -n with udhcp, but I did find that having neither hangs up the system if you don't have an ethernet cable plugged in.