### PR TITLE
Fix coreboot build where gcc defaults to pie (issue #177)

### DIFF
--- a/patches/coreboot-4.5.patch
+++ b/patches/coreboot-4.5.patch
@@ -493,3 +493,21 @@ index a2ca1c1..df80286 100644
 +	}
 +}
 +
+diff --git a/util/crossgcc/buildgcc b/util/crossgcc/buildgcc
+index 4883754..1037fe0 100755
+--- a/util/crossgcc/buildgcc
++++ b/util/crossgcc/buildgcc
+@@ -502,6 +502,13 @@ set_hostcflags_from_gmp() {
+ }
+
+ build_GMP() {
++	# Check if GCC enables `-pie` by default (possible since GCC 6).
++	# We need PIC in all static libraries then.
++	if "${CC}" -dumpspecs 2>/dev/null | grep -q '[{;][[:space:]]*:-pie\>'
++	then
++		OPTIONS="$OPTIONS --with-pic"
++	fi
++
+	CC="$CC" ../${GMP_DIR}/configure --disable-shared --enable-fat \
+		--prefix=$TARGETDIR $OPTIONS \
+		|| touch .failed


### PR DESCRIPTION
See https://github.com/coreboot/coreboot/commit/8bbd596de631adc8b677e69603e978b848eb1708