### PR TITLE
Add Tails boot option

### DIFF
--- a/config/purism13v1-qubes.config
+++ b/config/purism13v1-qubes.config
@@ -19,6 +19,8 @@ CONFIG_LINUX_USB=y
 
 CONFIG_BOOTSCRIPT=/bin/qubes-init
 
+CONFIG_USB_BOOT_DEV="dev/sdb1"
+
 # Disks encrypted by the TPM LUKS key
 CONFIG_QUBES_BOOT_DEV="/dev/sda1"
 CONFIG_QUBES_VG="qubes_dom0"

--- a/config/x230-qubes.config
+++ b/config/x230-qubes.config
@@ -20,6 +20,8 @@ CONFIG_LINUX_E1000E=y
 
 CONFIG_BOOTSCRIPT=/bin/qubes-init
 
+CONFIG_USB_BOOT_DEV="/dev/sdb1"
+
 # Disks encrypted by the TPM LUKS key
 CONFIG_QUBES_BOOT_DEV="/dev/sda1"
 CONFIG_QUBES_VG="qubes_dom0"

--- a/initrd/bin/tails-boot
+++ b/initrd/bin/tails-boot
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Final stage to start Tails
+. /etc/functions
+. /etc/config
+
+KERNEL="$1"
+INITRD="$2"
+
+if [ -z "$KERNEL" -o -z "$INITRD" ]; then
+	die "Usage: $0 /media/live/vmlinuz2 /media/live/initrd2.img "
+fi
+
+# TODO: parse commandline from sysconfig/liveamd64.cfg (replace quiet w/ intel_iommu=on vga=normal)
+
+echo '+++ Loading kernel and initrd'
+kexec \
+	-l ${KERNEL} \
+	--initrd=${INITRD} \
+	--append="boot=live config live-media=removable apparmor=1 security=apparmor nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 noautologin module=Tails kaslr slab_nomerge slub_debug=FZ mce=0 vsyscall=none  intel_iommu=on vga=normal" \
+|| die "kexec load failed"
+
+echo "+++ Starting Tails..."
+exec kexec -e

--- a/initrd/bin/tails-init
+++ b/initrd/bin/tails-init
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Boot a Tails installation that has already been setup.
+
+. /etc/functions
+. /etc/config
+
+# TODO: Do a scan of USB devices to detect the Tails USB
+mount-usb "$CONFIG_USB_BOOT_DEV"
+LIVE_DIR=/media/live
+
+BOOT_HASHES=$LIVE_DIR/boot.hashes
+if [ ! -r "$BOOT_HASHES" ]; then
+	recovery "$BOOT_HASHES does not exist; re-run tails-update"
+fi
+
+# Verify the signature on the hashes
+gpgv "$BOOT_HASHES.asc" "$BOOT_HASHES" \
+	|| recovery 'boot hashes signature failed'
+
+# Retrieve the TPM counter ID and generate its current value
+TPM_COUNTER=`grep counter $BOOT_HASHES | cut -d- -f2`
+if [ -z "$TPM_COUNTER" ]; then
+	recovery "$BOOT_HASHES: TPM counter not found?"
+fi
+
+tpm counter_read -ix "$TPM_COUNTER" | tee "/tmp/counter-$TPM_COUNTER"
+
+# Check the hashes of all the files
+sha256sum -c "$BOOT_HASHES" \
+|| recovery "$BOOT_HASHES: hash mismatch"
+
+KERNEL=`grep $LIVE_DIR/vmlin $BOOT_HASHES | cut -d\  -f3 | tail -1`
+INITRD=`grep $LIVE_DIR/initr $BOOT_HASHES | cut -d\  -f3 | tail -1`
+
+echo "+++ Booting Tails with $KERNEL and $INITRD"
+/bin/tails-boot "$KERNEL" "$INITRD"
+
+recovery "Something failed..."

--- a/initrd/bin/tails-update
+++ b/initrd/bin/tails-update
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Update the Tails live directory signatures
+set -o pipefail
+. /etc/functions
+
+USB_DIR="$1"
+if [ -z "$USB_DIR" ]; then
+	die "Usage: $0 /media "
+fi
+
+LIVE_DIR="$USB_DIR/live"
+if ! [ -d "$LIVE_DIR" ]; then
+	die "Tails live directory not found at $USB_DIR"
+fi
+
+# setup the USB so we can reach the GPG card
+if ! lsmod | grep -q ehci_hcd; then
+	insmod /lib/modules/ehci-hcd.ko \
+	|| die "ehci_hcd: module load failed"
+fi
+if ! lsmod | grep -q ehci_pci; then
+	insmod /lib/modules/ehci-pci.ko \
+	|| die "ehci_pci: module load failed"
+fi
+if ! lsmod | grep -q xhci_hcd; then
+	insmod /lib/modules/xhci-hcd.ko \
+	|| die "ehci_hcd: module load failed"
+fi
+if ! lsmod | grep -q xhci_pci; then
+	insmod /lib/modules/xhci-pci.ko \
+	|| die "ehci_pci: module load failed"
+	sleep 2
+fi
+
+gpg --card-status \
+|| die "gpg card read failed"
+
+KERNEL="$LIVE_DIR/vmlinuz2"
+if ! [ -f "$KERNEL" ]; then
+	die "Tails kernel missing"
+fi
+INITRD="$LIVE_DIR/initrd2.img"
+if ! [ -f "$INITRD" ]; then
+	die "Tails initram missing"
+fi
+MODULE="$LIVE_DIR/Tails.module"
+if ! [ -f "$MODULE" ]; then
+	die "Tails module missing"
+fi
+
+BOOT_HASHES="$LIVE_DIR/boot.hashes"
+
+# if the /boot.hashes file already exists, read the TPM counter ID
+# from it.
+if [ -r "$BOOT_HASHES" ]; then
+	TPM_COUNTER=`grep counter- "$BOOT_HASHES" | cut -d- -f2`
+else
+	warn "$BOOT_HASHES does not exist; creating new TPM counter"
+	read -s -p "TPM Owner password: " tpm_password
+	echo
+	tpm counter_create \
+		-pwdo "$tpm_password" \
+		-pwdc '' \
+		-la 2098540983 \
+	| tee /tmp/counter \
+	|| die "Unable to create TPM counter"
+	TPM_COUNTER=`cut -d: -f1 < /tmp/counter`
+fi
+
+if [ -z "$TPM_COUNTER" ]; then
+	die "$BOOT_HASHES: TPM Counter not found?"
+fi
+
+mount -o rw,remount $USB_DIR \
+|| die "Could not remount $USB_DIR"
+
+tpm counter_increment -ix "$TPM_COUNTER" -pwdc '' \
+	| tee /tmp/counter-$TPM_COUNTER \
+|| die "Counter increment failed"
+
+sha256sum \
+	"$KERNEL" \
+	"$INITRD" \
+	"$MODULE" \
+	"/tmp/counter-$TPM_COUNTER" \
+| tee "$BOOT_HASHES"
+
+while read FILE; do
+	if ! [ -f "$LIVE_DIR/$FILE" ]; then
+		die "Tails module file missing: $FILE"
+	fi
+	sha256sum $LIVE_DIR/$FILE \
+	| tee -a "$BOOT_HASHES"
+done < "$MODULE"
+
+for tries in 1 2 3; do
+	if gpg --detach-sign -a "$BOOT_HASHES"; then
+		mount -o ro,remount $USB_DIR
+		exit 0
+	fi
+done
+
+warn "$BOOT_HASHES: Unable to sign boot hashes"
+mount -o ro,remount $USB_DIR
+exit 1

--- a/initrd/init
+++ b/initrd/init
@@ -32,14 +32,14 @@ hwclock -l -s
 if [ ! -x "$CONFIG_BOOTSCRIPT" ]; then
 	recovery 'Boot script missing?  Entering recovery shell'
 	# just in case...
-	tpm extend -ix 4 recovery
+	tpm extend -ix 4 -ic recovery
 	exec /bin/ash
 fi
 
 # Give the user a second to enter a recovery shell
 read \
 	-t "1" \
-	-p "Press 'r' for recovery shell: " \
+	-p "Press 'r' for recovery shell or 't' for Tails: " \
 	-n 1 \
 	boot_option
 echo
@@ -48,8 +48,13 @@ if [ "$boot_option" = "r" ]; then
 	# Start an interactive shell
 	recovery 'User requested recovery shell'
 	# just in case...
-	tpm extend -ix 4 recovery
+	tpm extend -ix 4 -ic recovery
 	exec /bin/ash
+fi
+
+if [ "$boot_option" = "t" ]; then
+	tpm extend -ix 4 -ic tails
+	exec /bin/tails-init
 fi
 
 echo '***** Normal boot'
@@ -58,5 +63,5 @@ exec "$CONFIG_BOOTSCRIPT"
 # We should never reach here, but just in case...
 recovery 'Boot script failure?  Entering recovery shell'
 # belts and suspenders, just in case...
-tpm extend -ix 4 recovery
+tpm extend -ix 4 -ic recovery
 exec /bin/ash


### PR DESCRIPTION
Took a quick pass at adding an option to boot Tails in Heads.  It follows the same pattern as the Qubes boot for signing and checking the hashes of the relevant boot files.

Not sure I did this all correctly, but it seems to works locally.  Would appreciate any feedback.