### PR TITLE
Automatically overwrite the crypttab in initramfs

### DIFF
--- a/initrd/bin/generate-crypttab
+++ b/initrd/bin/generate-crypttab
@@ -4,8 +4,9 @@
 # rd.luks.key=/secret.key should be sufficient.
 
 keyfile=/secret.key
+VOLUME_GROUP=$CONFIG_QUBES_VG
 
-for dev in /dev/sd*; do
+for dev in /dev/$VOLUME_GROUP/*; do
 	uuid=`cryptsetup luksUUID "$dev" 2>/dev/null` || continue
-	echo "luks-$uuid /dev/disk/by-uuid/$uuid $keyfile luks"
+	echo "luks-$uuid UUID=$uuid $keyfile" >> $1
 done

--- a/initrd/bin/qubes-init
+++ b/initrd/bin/qubes-init
@@ -75,8 +75,14 @@ tpm extend -ix 4 -ic qubes \
 	|| recovery 'Unable to scramble PCR'
 
 echo '+++ Building initrd'
-( cd "$INITRD_DIR" ; find . | cpio -H newc -o ) > "$SECRET_CPIO"
-cat "$INITRD" >> "$SECRET_CPIO"
+# pad the initramfs (dracut doesn't pad the last gz blob)
+# without this the kernel init/initramfs.c fails to read
+# the subsequent uncompressed/compressed cpio
+dd if="$INITRD" of="$SECRET_CPIO" bs=512 conv=sync
+
+# overwrite /etc/crypttab to mirror the behavior for in seal-key
+generate-crypttab "$INITRD_DIR/etc/crypttab"
+( cd "$INITRD_DIR" ; find . -type f | cpio -H newc -o ) >> "$SECRET_CPIO"
 
 /bin/qubes-boot "$XEN" "$KERNEL" "$SECRET_CPIO"
 

--- a/initrd/bin/seal-key
+++ b/initrd/bin/seal-key
@@ -13,7 +13,7 @@ RECOVERY_KEY="/tmp/secret/recovery.key"
 . /etc/config
 
 # Activate the LVM volume group
-VOLUME_GROUP=qubes_dom0
+VOLUME_GROUP=$CONFIG_QUBES_VG
 lvm vgchange -a y $VOLUME_GROUP \
 	|| die "$VOLUME_GROUP: unable to activate volume group"
 


### PR DESCRIPTION
Uses the same logic as seal-key to generate a crypttab file that
references the injected secret key.

This removes the need to alter dracut settings in Qubes or to manually fix up the generated initramfs (should address #203).