### PR TITLE
Changed to coreboot patch not to call prog_segment_loaded in smm.

### DIFF
--- a/patches/coreboot-4.7.patch
+++ b/patches/coreboot-4.7.patch
@@ -113,14 +113,16 @@ diff --git ./src/lib/cbfs.c ./src/lib/cbfs.c
 index 596abc5..f1928ce 100644
 --- ./src/lib/cbfs.c
 +++ ./src/lib/cbfs.c
-@@ -69,7 +69,11 @@ void *cbfs_boot_map_with_leak(const char *name, uint32_t type, size_t *size)
+@@ -69,7 +69,13 @@ void *cbfs_boot_map_with_leak(const char *name, uint32_t type, size_t *size)
  	if (size != NULL)
  		*size = fsize;
  
 -	return rdev_mmap(&fh.data, 0, fsize);
 +	void * buffer = rdev_mmap(&fh.data, 0, fsize);
 +
++#ifndef __SMM__
 +	prog_segment_loaded((uintptr_t)buffer, fsize, 0);
++#endif
 +
 +	return buffer;
  }


### PR DESCRIPTION
If USE_OPTION_TABLE is not set when building coreboot, cbfs_boot_map_with_leak() within src/lib/cbfs.c is not called by smm codes, and will be stripped out at link time, otherwise, other modules may call cbfs_boot_map_with_leak() within smm codes, which breaks its build for prog_segment_loaded() is not built for smm codes (tested when building for Thinkpad x230 with USE_OPTION_TABLE enabled).
I believe that prog_segment_loaded() is not intended to be called within smm codes, so I create this patch, not to call prog_segment_loaded in smm, which enables us to set USE_OPTION_TABLE and STATIC_OPTION_TABLE to make tuning cmos options easier while keeping security.

More previous info could be found on #285, which is closed due to branch reform.