### PR TITLE
Add whiptail binary, new libraries, and slang dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,7 @@ bin_modules-$(CONFIG_GPG) += gpg
 bin_modules-$(CONFIG_LVM2) += lvm2
 bin_modules-$(CONFIG_XEN) += xen
 bin_modules-$(CONFIG_DROPBEAR) += dropbear
+bin_modules-$(CONFIG_NEWT) += newt
 
 $(foreach m, $(bin_modules-y), \
 	$(call map,initrd_bin_add,$(call bins,$m)) \
@@ -456,6 +457,8 @@ module_dirs := \
 		$(util-linux_dir) \
 		$(zlib_dir) \
 		$(kernel-headers_dir) \
+		$(slang_dir) \
+		$(newt_dir) \
 
 modules.clean:
 	for dir in $(module_dirs) \

--- a/modules/newt
+++ b/modules/newt
@@ -1,0 +1,24 @@
+modules-$(CONFIG_TPMTOTP) += newt
+
+newt_depends := popt slang $(musl_dep)
+
+newt_version := 0.52.20
+newt_dir := newt-$(newt_version)
+newt_tar := newt-$(newt_version).tar.gz
+newt_url := https://releases.pagure.org/newt/$(newt_tar)
+newt_hash := 8d66ba6beffc3f786d4ccfee9d2b43d93484680ef8db9397a4fb70b5adbb6dbc
+
+newt_target := \
+	$(MAKE_JOBS) \
+	$(CROSS_TOOLS) \
+
+newt_output := \
+	whiptail \
+
+newt_libraries := \
+	libnewt.so.0.52 \
+
+newt_configure := ./autogen.sh; ./configure \
+	$(CROSS_TOOLS) \
+	--prefix "/" \
+	--host i386-elf-linux \

--- a/modules/newt
+++ b/modules/newt
@@ -1,4 +1,4 @@
-modules-$(CONFIG_TPMTOTP) += newt
+modules-$(CONFIG_NEWT) += newt
 
 newt_depends := popt slang $(musl_dep)
 

--- a/modules/slang
+++ b/modules/slang
@@ -11,6 +11,9 @@ slang_configure := ./configure \
 	--prefix "/" \
 	--host i386-elf-linux \
 	--with-png=no \
+	--with-pcre=no \
+	--with-onig=no \
+  && mkdir src/elfobjs
 
 slang_target := \
 	$(MAKE_JOBS) \

--- a/modules/slang
+++ b/modules/slang
@@ -1,0 +1,26 @@
+modules-$(CONFIG_SLANG) += slang
+
+slang_version := 2.3.1a
+slang_dir := slang-$(slang_version)
+slang_tar := slang-$(slang_version).tar.bz2
+slang_url := https://www.jedsoft.org/releases/slang/$(slang_tar)
+slang_hash := 54f0c3007fde918039c058965dffdfd6c5aec0bad0f4227192cc486021f08c36
+
+slang_configure := ./configure \
+	$(CROSS_TOOLS) \
+	--prefix "/" \
+	--host i386-elf-linux \
+  --with-png=no \
+
+slang_target := \
+	$(MAKE_JOBS) \
+	$(CROSS_TOOLS) \
+	&& $(MAKE) \
+		-C "$(build)/$(slang_dir)" \
+		$(CROSS_TOOLS) \
+		DESTDIR="$(INSTALL)" \
+		install
+
+slang_libraries := src/elfobjs/libslang.so.2
+
+slang_depends := $(musl_dep)

--- a/modules/slang
+++ b/modules/slang
@@ -10,7 +10,7 @@ slang_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--prefix "/" \
 	--host i386-elf-linux \
-  --with-png=no \
+	--with-png=no \
 
 slang_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
The whiptail binary will allow us to create GUI menus from bash scripts.
It is included in the newt library, which depends on slang. To enable,
the board configuration file should add CONFIG_SLANG=y and CONFIG_NEWT=y