### PR TITLE
Walkaround envvars passed through make(1) when generating etc/config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,8 @@ $(build)/$(BOARD)/tools.cpio: \
 		mkdir -p "$(initrd_dir)/etc" ; \
 		export \
 			| grep ' CONFIG_' \
-			| sed 's/^declare -x /export /' \
+			| sed -e 's/^declare -x /export /' \
+			-e 's/\\\"//g' \
 			> "$(initrd_dir)/etc/config" \
 	)
 	$(call do-cpio,$@,$(initrd_dir))


### PR DESCRIPTION
"export" statements included or declared in a Makefile proves literally
(with no escape) passed to the shell, which may result in shell envvars
containing literal double quote if SHELL is set as bash, and they further
becomes statements containing `\"` when printed with command export.

This behavior could be observed by the makefile inlined at the end.

This commit adds a regexp to sed to remove those `\"`.

export QUOTE="QUOTE"
SHELL := /bin/bash
.SHELLFLAGS := -o pipefail -c
export-quote:
        export|grep QUOTE