### PR TITLE
Add a gui message when hash checks fail in kexec-select-boot

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -109,7 +109,7 @@ while true; do
     mount_boot
 	  DEFAULT_FILE=`find /boot/kexec_default.*.txt 2>/dev/null | head -1`
     if [ -r "$DEFAULT_FILE" ]; then
-      kexec-select-boot -b /boot -c "grub.cfg" \
+      kexec-select-boot -b /boot -c "grub.cfg" -g \
       || recovery "Failed default boot"
     else
       if (whiptail --title 'No Default Boot Option Configured' \

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -48,11 +48,16 @@ verify_global_hashes()
 {
 	echo "+++ Checking verified boot hash file "
 	# Check the hashes of all the files
-	if cd $bootdir && sha256sum -c "$TMP_HASH_FILE" ; then
+	if cd $bootdir && sha256sum -c "$TMP_HASH_FILE" > /tmp/hash_output ; then
 		echo "+++ Verified boot hashes "
 		valid_hash='y'
 		valid_global_hash='y'
 	else
+		if [ "$gui_menu" = "y" ]; then
+			CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
+			whiptail --title 'ERROR: Boot Hash Mismatch' \
+				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 60
+		fi
 		die "$TMP_HASH_FILE: boot hash mismatch"
 	fi
 }
@@ -210,10 +215,15 @@ default_select() {
 	# Enforce that default option hashes are valid
 	echo "+++ Checking verified default boot hash file "
 	# Check the hashes of all the files
-	if cd $bootdir && sha256sum -c "$TMP_DEFAULT_HASH_FILE" ; then
+	if cd $bootdir && sha256sum -c "$TMP_DEFAULT_HASH_FILE" > /tmp/hash_output ; then
 		echo "+++ Verified default boot hashes "
 		valid_hash='y'
 	else
+		if [ "$gui_menu" = "y" ]; then
+			CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
+			whiptail --title 'ERROR: Default Boot Hash Mismatch' \
+				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 60
+		fi
 		die "!!! $TMP_DEFAULT_HASH_FILE: default boot hash mismatch"
 	fi
 


### PR DESCRIPTION
When hashes mismatch in kexec-select-boot the user just gets dumped to a recovery console and often the suspect file has scrolled off of the screen. This change creates a GUI menu when in GUI mode that alerts the user to which file(s) failed before dumping them to a recovery menu.