### PR TITLE
Add a "force" option to kexec-select-boot to bypass hash checks

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -50,6 +50,7 @@ while true; do
       'm' ' Show OS boot menu' \
       'u' ' USB boot' \
       'g' ' Generate new TOTP secret' \
+      'i' ' Ignore tampering and force a boot (Unsafe!)' \
       'x' ' Exit to recovery shell' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 
@@ -101,6 +102,18 @@ while true; do
     # Try to select a kernel from the menu
     mount_boot
     kexec-select-boot -m -b /boot -c "grub.cfg" -g
+    continue
+  fi
+
+  if [ "$totp_confirm" = "i" ]; then
+    # Run the menu selection in "force" mode, bypassing hash checks
+    if (whiptail --title 'Unsafe Forced Boot Selected!' \
+        --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 16 60) then
+      mount_boot
+      kexec-select-boot -m -b /boot -c "grub.cfg" -g -f
+    else
+      echo "Returning to the main menu"
+    fi
     continue
   fi
 

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -13,7 +13,8 @@ valid_global_hash="n"
 valid_rollback="n"
 force_menu="n"
 gui_menu="n"
-while getopts "b:d:p:a:r:c:uimg" arg; do
+force_boot="n"
+while getopts "b:d:p:a:r:c:uimgf" arg; do
 	case $arg in
 		b) bootdir="$OPTARG" ;;
 		d) paramsdev="$OPTARG" ;;
@@ -25,6 +26,7 @@ while getopts "b:d:p:a:r:c:uimg" arg; do
 		m) force_menu="y" ;;
 		i) valid_hash="y"; valid_rollback="y" ;;
 		g) gui_menu="y" ;;
+		f) force_boot="y"; valid_hash="y"; valid_rollback="y" ;;
 	esac
 done
 
@@ -290,6 +292,13 @@ while true; do
 	TMP_ROLLBACK_FILE="/tmp/kexec/kexec_rollback.txt"
 	TMP_KEY_DEVICES="/tmp/kexec/kexec_key_devices.txt"
 	TMP_KEY_LVM="/tmp/kexec/kexec_key_lvm.txt"
+
+# Allow a way for users to ignore warnings and boot into their systems
+# even if hashes don't match
+	if [ "$force_boot" = "y" ]; then
+		scan_options
+		user_select
+	fi
 
 	if [ "$CONFIG_TPM" = "y" \
 		-a ! -r "$TMP_KEY_DEVICES" ]; then


### PR DESCRIPTION
The point of this change is to provide a failsafe (failunsafe?) mode for
less technically-savvy users who will ultimately be using Heads by
default on Librem laptops.

There are some scenarios where an end user might forget to update hashes
in /boot after an initrd change or might have some other hash mismatch.
Currently that user would then be stuck in a recovery console in Heads
not knowing what to do within that limited shell environment to fix the
situation.

This change adds a 'force' mode to kexec-select-boot that goes straight
into a boot menu and bypasses the hash checks so the user could more
easily get back into their system to attempt to repair it. It adds
appropriate warnings about why this is a risky option and moves it down
toward the bottom of the menu. The goal would be to just have this be an
emergency option our support could guide a user to if they ended up in
this situation.