### PR TITLE
kexec-boot patch so that xen can be booted from bootdir and referred …

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -68,7 +68,7 @@ do
 	if [ "$key" = "kernel" ]; then
 		if [ "$kexectype" = "xen" ]; then
 			# always overload xen and with custom arguments
-			kexeccmd="$kexeccmd -l /bin/xen.gz"
+			kexeccmd="$kexeccmd -l $bootdir$firstval"
 			kexeccmd="$kexeccmd --command-line \"no-real-mode reboot=no vga=current\""
 		elif [ "$kexectype" = "multiboot" ]; then
 			fix_file_path


### PR DESCRIPTION
…xen.gz and not internal flash xen.gz