### PR TITLE
Fixes for newt and slang modules

### DIFF
--- a/modules/newt
+++ b/modules/newt
@@ -22,3 +22,4 @@ newt_configure := ./autogen.sh; ./configure \
 	$(CROSS_TOOLS) \
 	--prefix "/" \
 	--host i386-elf-linux \
+	--without-tcl

--- a/modules/slang
+++ b/modules/slang
@@ -13,7 +13,7 @@ slang_configure := ./configure \
 	--with-png=no \
 	--with-pcre=no \
 	--with-onig=no \
-  && mkdir src/elfobjs
+  && mkdir -p src/elfobjs
 
 slang_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
If you have tcl-devel installed locally, newt will try to compile the Tcl extension, which will fail, and slang configure will complain about 'file already exists' when recompiling.