### PR TITLE
Add ability to specify series of patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,14 @@ define define_module =
 		( cd $(build)/$($1_dir) ; patch -p1 ) \
 			< patches/$1.patch; \
 	fi
+	if [ -d patches/$1 ] && \
+	   [ -r patches/$1 ] ; then \
+		for patch in patches/$1/*.patch ; do \
+			echo "Applying patch file : $$$$patch " ;  \
+			( cd $(build)/$($1_dir) ; patch -p1 ) \
+				< $$$$patch ; \
+		done ; \
+	fi
 	@touch "$$@"
   else
     # Fetch and verify the source tar file
@@ -206,6 +214,14 @@ define define_module =
 	if [ -r patches/$1-$($1_version).patch ]; then \
 		( cd $(build)/$($1_dir) ; patch -p1 ) \
 			< patches/$1-$($1_version).patch; \
+	fi
+	if [ -d patches/$1-$($1_version) ] && \
+	   [ -r patches/$1-$($1_version) ] ; then \
+		for patch in patches/$1-$($1_version)/*.patch ; do \
+			echo "Applying patch file : $$$$patch " ;  \
+			( cd $(build)/$($1_dir) ; patch -p1 ) \
+				< $$$$patch ; \
+		done ; \
 	fi
 	@touch "$$@"
   endif

--- a/patches/coreboot-4.7/0001-intel-fsp-Fix-TPM-initialization-when-vboot-is-disab.patch
+++ b/patches/coreboot-4.7/0001-intel-fsp-Fix-TPM-initialization-when-vboot-is-disab.patch
@@ -1,0 +1,72 @@
+From feb246c6e8a87c1223c84b4b74f976d23506bb96 Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Wed, 7 Feb 2018 11:49:35 -0500
+Subject: [PATCH 1/9] intel/fsp: Fix TPM initialization when vboot is disabled
+
+A change introduced by commit fe4983e5 [1] in order to prevent
+re-initialization of the TPM if already setup in verstage
+had the wrong logic in the if statement, causing the TPM
+to never be initialized if vboot is disabled.
+
+The RESUME_PATH_SAME_AS_BOOT config is enabled by default for
+ARCH_X86 and therefore the if statement would be false. The
+behavior that was intended was probably meant to use an OR
+instead of an AND.
+
+This patch also enabled TPM initialization for FSP 2.0.
+
+[1] https://review.coreboot.org/#/c/coreboot/+/14106/
+
+Change-Id: Ic43d1aa31a296386c7eab6d997f9b701e9ea0fe5
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/drivers/intel/fsp1_1/romstage.c    |  4 ++--
+ src/drivers/intel/fsp2_0/memory_init.c | 10 ++++++++++
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/drivers/intel/fsp1_1/romstage.c b/src/drivers/intel/fsp1_1/romstage.c
+index 81939c4c33..76b4ad7c4d 100644
+--- a/src/drivers/intel/fsp1_1/romstage.c
++++ b/src/drivers/intel/fsp1_1/romstage.c
+@@ -172,8 +172,8 @@ void romstage_common(struct romstage_params *params)
+ 	 * in verstage and used to verify romstage.
+ 	 */
+ 	if (IS_ENABLED(CONFIG_LPC_TPM) &&
+-	    !IS_ENABLED(CONFIG_RESUME_PATH_SAME_AS_BOOT) &&
+-	    !IS_ENABLED(CONFIG_VBOOT_STARTS_IN_BOOTBLOCK))
++	    (!IS_ENABLED(CONFIG_RESUME_PATH_SAME_AS_BOOT) ||
++	     !IS_ENABLED(CONFIG_VBOOT_STARTS_IN_BOOTBLOCK)))
+ 		init_tpm(params->power_state->prev_sleep_state ==
+ 			 ACPI_S3);
+ }
+diff --git a/src/drivers/intel/fsp2_0/memory_init.c b/src/drivers/intel/fsp2_0/memory_init.c
+index 368fafa5d7..575f277466 100644
+--- a/src/drivers/intel/fsp2_0/memory_init.c
++++ b/src/drivers/intel/fsp2_0/memory_init.c
+@@ -28,6 +28,7 @@
+ #include <program_loading.h>
+ #include <reset.h>
+ #include <romstage_handoff.h>
++#include <tpm.h>
+ #include <string.h>
+ #include <symbols.h>
+ #include <timestamp.h>
+@@ -146,6 +147,15 @@ static void do_fsp_post_memory_init(bool s3wake, uint32_t fsp_version)
+ 
+ 	/* Create romstage handof information */
+ 	romstage_handoff_init(s3wake);
++
++	/*
++	 * Initialize the TPM, unless the TPM was already initialized
++	 * in verstage and used to verify romstage.
++	 */
++	if (IS_ENABLED(CONFIG_LPC_TPM) &&
++	    (!IS_ENABLED(CONFIG_RESUME_PATH_SAME_AS_BOOT) ||
++	     !IS_ENABLED(CONFIG_VBOOT_STARTS_IN_BOOTBLOCK)))
++		init_tpm(s3wake);
+ }
+ 
+ static int mrc_cache_verify_tpm_hash(const uint8_t *data, size_t size)
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0003-soc-intel-skylake-Enable-VT-d-and-X2APIC.patch
+++ b/patches/coreboot-4.7/0003-soc-intel-skylake-Enable-VT-d-and-X2APIC.patch
@@ -1,0 +1,173 @@
+From 403242fbaf2c3b8c12f4b1d55a581513aabf02a3 Mon Sep 17 00:00:00 2001
+From: Nico Huber <nico.h@gmx.de>
+Date: Tue, 19 Sep 2017 09:36:03 +0200
+Subject: [PATCH 3/9] soc/intel/skylake: Enable VT-d and X2APIC
+
+We use the usual static addresses 0xfed90000/0xfed91000 for the GFX
+IOMMU and the general IOMMU respectively. These addresses have to be
+configured in MCHBAR registers (maybe, who knows, the blob is undocu-
+mented), advertised to FSP and reserved from the OS.
+
+Change-Id: I77f87c385736615c127143760bbd144f97986b37
+Signed-off-by: Nico Huber <nico.h@gmx.de>
+---
+ src/soc/intel/skylake/chip_fsp20.c              | 10 ++++++++++
+ src/soc/intel/skylake/include/soc/iomap.h       |  6 ++++++
+ src/soc/intel/skylake/include/soc/systemagent.h | 11 +++++++++++
+ src/soc/intel/skylake/romstage/systemagent.c    |  8 ++++++++
+ src/soc/intel/skylake/systemagent.c             | 13 +++++++++++++
+ 5 files changed, 48 insertions(+)
+
+diff --git a/src/soc/intel/skylake/chip_fsp20.c b/src/soc/intel/skylake/chip_fsp20.c
+index ccda3032c5..875542c9c6 100644
+--- a/src/soc/intel/skylake/chip_fsp20.c
++++ b/src/soc/intel/skylake/chip_fsp20.c
+@@ -30,9 +30,11 @@
+ #include <soc/acpi.h>
+ #include <soc/intel/common/vbt.h>
+ #include <soc/interrupt.h>
++#include <soc/iomap.h>
+ #include <soc/irq.h>
+ #include <soc/pci_devs.h>
+ #include <soc/ramstage.h>
++#include <soc/systemagent.h>
+ #include <string.h>
+ 
+ void soc_init_pre_device(void *chip_info)
+@@ -313,6 +315,14 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
+ 	/* Set TccActivationOffset */
+ 	tconfig->TccActivationOffset = config->tcc_offset;
+ 
++	/* Enable VT-d and X2APIC */
++	if (soc_is_vtd_capable()) {
++		params->VtdBaseAddress[0] = GFXVT_BASE_ADDRESS;
++		params->VtdBaseAddress[1] = VTVC0_BASE_ADDRESS;
++		params->X2ApicOptOut = 0;
++		tconfig->VtdDisable = 0;
++	}
++
+ 	soc_irq_settings(params);
+ }
+ 
+diff --git a/src/soc/intel/skylake/include/soc/iomap.h b/src/soc/intel/skylake/include/soc/iomap.h
+index 0a573acb38..5f868061ec 100644
+--- a/src/soc/intel/skylake/include/soc/iomap.h
++++ b/src/soc/intel/skylake/include/soc/iomap.h
+@@ -52,6 +52,12 @@
+ #define GDXC_BASE_ADDRESS	0xfed84000
+ #define GDXC_BASE_SIZE		0x1000
+ 
++#define GFXVT_BASE_ADDRESS	0xfed90000
++#define GFXVT_BASE_SIZE		0x1000
++
++#define VTVC0_BASE_ADDRESS	0xfed91000
++#define VTVC0_BASE_SIZE		0x1000
++
+ #define HPET_BASE_ADDRESS	0xfed00000
+ 
+ #define PCH_PWRM_BASE_ADDRESS	0xfe000000
+diff --git a/src/soc/intel/skylake/include/soc/systemagent.h b/src/soc/intel/skylake/include/soc/systemagent.h
+index d8192a3e75..8e53f54b75 100644
+--- a/src/soc/intel/skylake/include/soc/systemagent.h
++++ b/src/soc/intel/skylake/include/soc/systemagent.h
+@@ -32,9 +32,13 @@
+ #define  D_LCK		(1 << 4)
+ #define  G_SMRAME	(1 << 3)
+ #define  C_BASE_SEG	((0 << 2) | (1 << 1) | (0 << 0))
++#define CAPID0_A	0xe4
++#define  VTD_DISABLE	(1 << 23)
+ 
+ #define BIOS_RESET_CPL		0x5da8
++#define GFXVTBAR		0x5400
+ #define EDRAMBAR		0x5408
++#define VTVC0BAR		0x5410
+ #define GDXCBAR			0x5420
+ 
+ #define MCH_PKG_POWER_LIMIT_LO	0x59a0
+@@ -42,4 +46,11 @@
+ #define MCH_DDR_POWER_LIMIT_LO	0x58e0
+ #define MCH_DDR_POWER_LIMIT_HI	0x58e4
+ 
++bool soc_is_vtd_capable(void);
++
++static const struct sa_mmio_descriptor soc_vtd_resources[] = {
++	{ GFXVTBAR, GFXVT_BASE_ADDRESS, GFXVT_BASE_SIZE, "GFXVTBAR" },
++	{ VTVC0BAR, VTVC0_BASE_ADDRESS, VTVC0_BASE_SIZE, "VTVC0BAR" },
++};
++
+ #endif
+diff --git a/src/soc/intel/skylake/romstage/systemagent.c b/src/soc/intel/skylake/romstage/systemagent.c
+index 8f2fb337ed..66676c1fbf 100644
+--- a/src/soc/intel/skylake/romstage/systemagent.c
++++ b/src/soc/intel/skylake/romstage/systemagent.c
+@@ -18,6 +18,7 @@
+ #include <device/device.h>
+ #include <intelblocks/systemagent.h>
+ #include <soc/iomap.h>
++#include <soc/pci_devs.h>
+ #include <soc/romstage.h>
+ #include <soc/systemagent.h>
+ 
+@@ -34,12 +35,19 @@ void systemagent_early_init(void)
+ 		{ EDRAMBAR, EDRAM_BASE_ADDRESS, EDRAM_BASE_SIZE, "EDRAMBAR" },
+ 	};
+ 
++	const bool vtd_capable =
++		!(pci_read_config32(SA_DEV_ROOT, CAPID0_A) & VTD_DISABLE);
++
+ 	/* Set Fixed MMIO addresss into PCI configuration space */
+ 	sa_set_pci_bar(soc_fixed_pci_resources,
+ 			ARRAY_SIZE(soc_fixed_pci_resources));
+ 	/* Set Fixed MMIO addresss into MCH base address */
+ 	sa_set_mch_bar(soc_fixed_mch_resources,
+ 			ARRAY_SIZE(soc_fixed_mch_resources));
++	if (vtd_capable)
++		sa_set_mch_bar(soc_vtd_resources,
++				ARRAY_SIZE(soc_vtd_resources));
++
+ 	/* Enable PAM regisers */
+ 	enable_pam_region();
+ }
+diff --git a/src/soc/intel/skylake/systemagent.c b/src/soc/intel/skylake/systemagent.c
+index 8af995d133..796e7ae131 100644
+--- a/src/soc/intel/skylake/systemagent.c
++++ b/src/soc/intel/skylake/systemagent.c
+@@ -15,6 +15,7 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include <arch/io.h>
+ #include <cpu/x86/msr.h>
+ #include <console/console.h>
+ #include <delay.h>
+@@ -23,8 +24,16 @@
+ #include <soc/cpu.h>
+ #include <soc/iomap.h>
+ #include <soc/msr.h>
++#include <soc/pci_devs.h>
+ #include <soc/systemagent.h>
+ 
++bool soc_is_vtd_capable(void)
++{
++	struct device *const root_dev = SA_DEV_ROOT;
++	return root_dev &&
++		!(pci_read_config32(root_dev, CAPID0_A) & VTD_DISABLE);
++}
++
+ /*
+  * SoC implementation
+  *
+@@ -45,6 +54,10 @@ void soc_add_fixed_mmio_resources(struct device *dev, int *index)
+ 
+ 	sa_add_fixed_mmio_resources(dev, index, soc_fixed_resources,
+ 			ARRAY_SIZE(soc_fixed_resources));
++
++	if (soc_is_vtd_capable())
++		sa_add_fixed_mmio_resources(dev, index, soc_vtd_resources,
++				ARRAY_SIZE(soc_vtd_resources));
+ }
+ 
+ /*
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0004-soc-intel-skylake-Generate-ACPI-DMAR-table.patch
+++ b/patches/coreboot-4.7/0004-soc-intel-skylake-Generate-ACPI-DMAR-table.patch
@@ -1,0 +1,154 @@
+From 65b3bf5a7d211f7e1e37d73d0b59ed053dff85a8 Mon Sep 17 00:00:00 2001
+From: Nico Huber <nico.h@gmx.de>
+Date: Mon, 18 Sep 2017 20:03:46 +0200
+Subject: [PATCH 4/9] soc/intel/skylake: Generate ACPI DMAR table
+
+If the SoC is VT-d capable, write an ACPI DMAR table. The entry for the
+GFXVTBAR is only generated if the IGD is enabled.
+
+Change-Id: I8176401dd19aee7ad09a8a145b7a3801fe5b2ae1
+Signed-off-by: Nico Huber <nico.h@gmx.de>
+---
+ src/soc/intel/skylake/acpi.c             | 68 ++++++++++++++++++++++++++++++++
+ src/soc/intel/skylake/chip_fsp20.c       |  3 +-
+ src/soc/intel/skylake/include/soc/acpi.h |  2 +
+ src/soc/intel/skylake/include/soc/p2sb.h |  3 ++
+ 4 files changed, 75 insertions(+), 1 deletion(-)
+
+diff --git a/src/soc/intel/skylake/acpi.c b/src/soc/intel/skylake/acpi.c
+index 61360dafae..45061aba6f 100644
+--- a/src/soc/intel/skylake/acpi.c
++++ b/src/soc/intel/skylake/acpi.c
+@@ -34,14 +34,17 @@
+ #include <intelblocks/lpc_lib.h>
+ #include <intelblocks/sgx.h>
+ #include <intelblocks/uart.h>
++#include <intelblocks/systemagent.h>
+ #include <soc/intel/common/acpi.h>
+ #include <soc/acpi.h>
+ #include <soc/cpu.h>
+ #include <soc/iomap.h>
+ #include <soc/msr.h>
++#include <soc/p2sb.h>
+ #include <soc/pci_devs.h>
+ #include <soc/pm.h>
+ #include <soc/ramstage.h>
++#include <soc/systemagent.h>
+ #include <string.h>
+ #include <types.h>
+ #include <vendorcode/google/chromeos/gnvs.h>
+@@ -539,6 +542,71 @@ void generate_cpu_entries(device_t device)
+ 	}
+ }
+ 
++static unsigned long acpi_fill_dmar(unsigned long current)
++{
++	struct device *const igfx_dev = dev_find_slot(0, SA_DEVFN_IGD);
++	const u32 gfx_vtbar = MCHBAR32(GFXVTBAR) & ~0xfff;
++
++	/* iGFX has to be enabled, GFXVTBAR set and in 32-bit space. */
++	if (igfx_dev && igfx_dev->enabled &&
++	    gfx_vtbar && !MCHBAR32(GFXVTBAR + 4)) {
++		const unsigned long tmp = current;
++
++		current += acpi_create_dmar_drhd(current, 0, 0, gfx_vtbar);
++		current += acpi_create_dmar_drhd_ds_pci(current, 0, 2, 0);
++
++		acpi_dmar_drhd_fixup(tmp, current);
++	}
++
++	struct device *const p2sb_dev = dev_find_slot(0, PCH_DEVFN_P2SB);
++	const u32 vtvc0bar = MCHBAR32(VTVC0BAR) & ~0xfff;
++
++	/* General VTBAR has to be set and in 32-bit space. */
++	if (p2sb_dev && vtvc0bar && !MCHBAR32(VTVC0BAR + 4)) {
++		const unsigned long tmp = current;
++
++		/* P2SB may already be hidden. There's no clear rule, when. */
++		const u8 p2sb_hidden =
++			pci_read_config8(p2sb_dev, PCH_P2SB_E0 + 1);
++		pci_write_config8(p2sb_dev, PCH_P2SB_E0 + 1, 0);
++
++		const u16 ibdf = pci_read_config16(p2sb_dev, PCH_P2SB_IBDF);
++		const u16 hbdf = pci_read_config16(p2sb_dev, PCH_P2SB_HBDF);
++
++		pci_write_config8(p2sb_dev, PCH_P2SB_E0 + 1, p2sb_hidden);
++
++		current += acpi_create_dmar_drhd(current,
++				DRHD_INCLUDE_PCI_ALL, 0, vtvc0bar);
++		current += acpi_create_dmar_drhd_ds_ioapic(current,
++				2, ibdf >> 8, PCI_SLOT(ibdf), PCI_FUNC(ibdf));
++		current += acpi_create_dmar_drhd_ds_msi_hpet(current,
++				0, hbdf >> 8, PCI_SLOT(hbdf), PCI_FUNC(hbdf));
++
++		acpi_dmar_drhd_fixup(tmp, current);
++	}
++
++	return current;
++}
++
++unsigned long northbridge_write_acpi_tables(struct device *const dev,
++					    unsigned long current,
++					    struct acpi_rsdp *const rsdp)
++{
++	acpi_dmar_t *const dmar = (acpi_dmar_t *)current;
++
++	/* Create DMAR table only if we have VT-d capability. */
++	if (!soc_is_vtd_capable())
++		return current;
++
++	printk(BIOS_DEBUG, "ACPI:    * DMAR\n");
++	acpi_create_dmar(dmar, DMAR_INTR_REMAP, acpi_fill_dmar);
++	current += dmar->header.length;
++	current = acpi_align_current(current);
++	acpi_add_table(rsdp, dmar);
++
++	return current;
++}
++
+ unsigned long acpi_madt_irq_overrides(unsigned long current)
+ {
+ 	int sci = acpi_sci_irq();
+diff --git a/src/soc/intel/skylake/chip_fsp20.c b/src/soc/intel/skylake/chip_fsp20.c
+index 875542c9c6..9fbc3da8dc 100644
+--- a/src/soc/intel/skylake/chip_fsp20.c
++++ b/src/soc/intel/skylake/chip_fsp20.c
+@@ -59,7 +59,8 @@ static struct device_operations pci_domain_ops = {
+ 	.scan_bus         = &pci_domain_scan_bus,
+ 	.ops_pci_bus      = &pci_bus_default_ops,
+ #if IS_ENABLED(CONFIG_HAVE_ACPI_TABLES)
+-	.acpi_name        = &soc_acpi_name,
++	.write_acpi_tables	= &northbridge_write_acpi_tables,
++	.acpi_name		= &soc_acpi_name,
+ #endif
+ };
+ 
+diff --git a/src/soc/intel/skylake/include/soc/acpi.h b/src/soc/intel/skylake/include/soc/acpi.h
+index b0d2194612..6d492acd67 100644
+--- a/src/soc/intel/skylake/include/soc/acpi.h
++++ b/src/soc/intel/skylake/include/soc/acpi.h
+@@ -32,5 +32,7 @@ void acpi_mainboard_gnvs(global_nvs_t *gnvs);
+ void southbridge_inject_dsdt(device_t device);
+ unsigned long southbridge_write_acpi_tables(device_t device,
+ 	unsigned long current, struct acpi_rsdp *rsdp);
++unsigned long northbridge_write_acpi_tables(struct device *,
++	unsigned long current, struct acpi_rsdp *);
+ 
+ #endif /* _SOC_ACPI_H_ */
+diff --git a/src/soc/intel/skylake/include/soc/p2sb.h b/src/soc/intel/skylake/include/soc/p2sb.h
+index d846dfc8f5..09e73fc254 100644
+--- a/src/soc/intel/skylake/include/soc/p2sb.h
++++ b/src/soc/intel/skylake/include/soc/p2sb.h
+@@ -19,6 +19,9 @@
+ #define HPTC_OFFSET		0x60
+ #define HPTC_ADDR_ENABLE_BIT	(1 << 7)
+ 
++#define PCH_P2SB_IBDF			0x6c
++#define PCH_P2SB_HBDF			0x70
++
+ #define PCH_P2SB_EPMASK0		0xB0
+ #define PCH_P2SB_EPMASK(mask_number)	(PCH_P2SB_EPMASK0 + ((mask_number) * 4))
+ 
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0005-purism-librem_skl-Enable-TPM-support.patch
+++ b/patches/coreboot-4.7/0005-purism-librem_skl-Enable-TPM-support.patch
@@ -1,0 +1,341 @@
+From c142a773852b8bbfddc3791248b8365242df4f4c Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 9 Feb 2018 18:42:49 -0500
+Subject: [PATCH 5/9] purism/librem_skl: Enable TPM support
+
+Change the GPIO to match the TPM-enabled motherboards, and add TPM
+support in devicetree and enable the config.
+After changing the GPIO table, the librem 13v2 and librem 15v3 now
+have the same GPIOs, so use a single gpio.h file instead of one
+file per variant.
+
+Change-Id: I425654c1c972118aa81c27961246238c2eef782d
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/mainboard/purism/librem_skl/Kconfig            |   1 +
+ src/mainboard/purism/librem_skl/Makefile.inc       |   1 -
+ .../librem13v2/include/variant => }/gpio.h         |  16 +-
+ src/mainboard/purism/librem_skl/ramstage.c         |   2 +-
+ .../librem_skl/variants/librem13v2/devicetree.cb   |   3 +
+ .../librem_skl/variants/librem15v3/devicetree.cb   |   3 +
+ .../variants/librem15v3/include/variant/gpio.h     | 201 ---------------------
+ 7 files changed, 16 insertions(+), 211 deletions(-)
+ rename src/mainboard/purism/librem_skl/{variants/librem13v2/include/variant => }/gpio.h (94%)
+ delete mode 100644 src/mainboard/purism/librem_skl/variants/librem15v3/include/variant/gpio.h
+
+diff --git a/src/mainboard/purism/librem_skl/Kconfig b/src/mainboard/purism/librem_skl/Kconfig
+index f68fd239f9..be4b7a37c7 100644
+--- a/src/mainboard/purism/librem_skl/Kconfig
++++ b/src/mainboard/purism/librem_skl/Kconfig
+@@ -9,6 +9,7 @@ config BOARD_PURISM_BASEBOARD_LIBREM_SKL
+ 	select SERIRQ_CONTINUOUS_MODE
+ 	select MAINBOARD_USES_FSP2_0
+ 	select SPD_READ_BY_WORD
++	select MAINBOARD_HAS_LPC_TPM
+ 
+ if BOARD_PURISM_BASEBOARD_LIBREM_SKL
+ 
+diff --git a/src/mainboard/purism/librem_skl/Makefile.inc b/src/mainboard/purism/librem_skl/Makefile.inc
+index 18c9ad6520..eb01360863 100644
+--- a/src/mainboard/purism/librem_skl/Makefile.inc
++++ b/src/mainboard/purism/librem_skl/Makefile.inc
+@@ -19,4 +19,3 @@ ramstage-y += pei_data.c
+ ramstage-y += ramstage.c
+ ramstage-y += hda_verb.c
+ 
+-CPPFLAGS_common += -I$(src)/mainboard/$(MAINBOARDDIR)/variants/$(VARIANT_DIR)/include
+diff --git a/src/mainboard/purism/librem_skl/variants/librem13v2/include/variant/gpio.h b/src/mainboard/purism/librem_skl/gpio.h
+similarity index 94%
+rename from src/mainboard/purism/librem_skl/variants/librem13v2/include/variant/gpio.h
+rename to src/mainboard/purism/librem_skl/gpio.h
+index 148e40b279..e3328a3336 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem13v2/include/variant/gpio.h
++++ b/src/mainboard/purism/librem_skl/gpio.h
+@@ -41,9 +41,9 @@ static const struct pad_config gpio_table[] = {
+ /* SUSACK# */		PAD_CFG_NF(GPP_A15, DN_20K, DEEP, NF1),
+ /* SD_1P8_SEL */	PAD_CFG_NC(GPP_A16),
+ /* SD_PWR_EN# */	PAD_CFG_NF(GPP_A17, NONE, DEEP, NF1),
+-/* ISH_GP0 */		PAD_CFG_NC(GPP_A18),
+-/* ISH_GP1 */		PAD_CFG_NC(GPP_A19),
+-/* ISH_GP2 */		PAD_CFG_NC(GPP_A20),
++/* ISH_GP0 */		PAD_CFG_GPI_GPIO_DRIVER(GPP_A18, NONE, DEEP),
++/* ISH_GP1 */		PAD_CFG_GPI_GPIO_DRIVER(GPP_A19, NONE, DEEP),
++/* ISH_GP2 */		PAD_CFG_GPI_GPIO_DRIVER(GPP_A20, NONE, DEEP),
+ /* ISH_GP3 */		PAD_CFG_NC(GPP_A21),
+ /* ISH_GP4 */		PAD_CFG_NC(GPP_A22),
+ /* ISH_GP5 */		PAD_CFG_NC(GPP_A23),
+@@ -108,18 +108,18 @@ static const struct pad_config gpio_table[] = {
+ /* ISH_I2C0_SCL */		PAD_CFG_NC(GPP_D6),
+ /* ISH_I2C1_SDA */		PAD_CFG_NC(GPP_D7),
+ /* ISH_I2C1_SCL */		PAD_CFG_NC(GPP_D8),
+-/* ISH_SPI_CS# */		PAD_CFG_NC(GPP_D9),
+-/* ISH_SPI_CLK */		PAD_CFG_NC(GPP_D10),
+-/* ISH_SPI_MISO */		PAD_CFG_NC(GPP_D11),
++/* ISH_SPI_CS# */		PAD_CFG_TERM_GPO(GPP_D9, 0, NONE, DEEP),
++/* ISH_SPI_CLK */		PAD_CFG_GPI_GPIO_DRIVER(GPP_D10, NONE, DEEP),
++/* ISH_SPI_MISO */		PAD_CFG_TERM_GPO(GPP_D11, 1, NONE, DEEP),
+ /* ISH_SPI_MOSI */		PAD_CFG_NC(GPP_D12),
+ /* ISH_UART0_RXD */		PAD_CFG_NC(GPP_D13),
+ /* ISH_UART0_TXD */		PAD_CFG_NC(GPP_D14),
+ /* ISH_UART0_RTS# */	PAD_CFG_NC(GPP_D15),
+ /* ISH_UART0_CTS# */	PAD_CFG_NC(GPP_D16),
+ /* DMIC_CLK1 */			PAD_CFG_NF(GPP_D17, NONE, DEEP, NF1),
+-/* DMIC_DATA1 */		PAD_CFG_NF(GPP_D18, NONE, DEEP, NF1),
++/* DMIC_DATA1 */		PAD_CFG_NF(GPP_D18, DN_20K, DEEP, NF1),
+ /* DMIC_CLK0 */			PAD_CFG_NF(GPP_D19, NONE, DEEP, NF1),
+-/* DMIC_DATA0 */		PAD_CFG_NF(GPP_D20, NONE, DEEP, NF1),
++/* DMIC_DATA0 */		PAD_CFG_NF(GPP_D20, DN_20K, DEEP, NF1),
+ /* SPI1_IO2 */			PAD_CFG_NC(GPP_D21),
+ /* SPI1_IO3 */			PAD_CFG_NC(GPP_D22),
+ /* I2S_MCLK */			PAD_CFG_NC(GPP_D23),
+diff --git a/src/mainboard/purism/librem_skl/ramstage.c b/src/mainboard/purism/librem_skl/ramstage.c
+index 15912cf862..94f8071340 100644
+--- a/src/mainboard/purism/librem_skl/ramstage.c
++++ b/src/mainboard/purism/librem_skl/ramstage.c
+@@ -15,7 +15,7 @@
+  */
+ 
+ #include <soc/ramstage.h>
+-#include <variant/gpio.h>
++#include "gpio.h"
+ 
+ void mainboard_silicon_init_params(FSP_SIL_UPD *params)
+ {
+diff --git a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+index 1fc19a5675..e2e2ac03da 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+@@ -195,6 +195,9 @@ chip soc/intel/skylake
+                         chip ec/purism/librem
+                                 device pnp 0c09.0 on end
+                         end
++                        chip drivers/pc80/tpm
++                                device pnp 0c31.0 on end
++                        end
+ 		end # LPC Interface
+ 		device pci 1f.1 on  end # P2SB
+ 		device pci 1f.2 on  end # Power Management Controller
+diff --git a/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb b/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
+index 647f054f74..6cf183a61f 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
+@@ -202,6 +202,9 @@ chip soc/intel/skylake
+                         chip ec/purism/librem
+                                 device pnp 0c09.0 on end
+                         end
++                        chip drivers/pc80/tpm
++                                device pnp 0c31.0 on end
++                        end
+ 		end # LPC Interface
+ 		device pci 1f.1 on  end # P2SB
+ 		device pci 1f.2 on  end # Power Management Controller
+diff --git a/src/mainboard/purism/librem_skl/variants/librem15v3/include/variant/gpio.h b/src/mainboard/purism/librem_skl/variants/librem15v3/include/variant/gpio.h
+deleted file mode 100644
+index 9c22f00f42..0000000000
+--- a/src/mainboard/purism/librem_skl/variants/librem15v3/include/variant/gpio.h
++++ /dev/null
+@@ -1,201 +0,0 @@
+-/*
+- * This file is part of the coreboot project.
+- *
+- * Copyright (C) 2015 Google Inc.
+- *
+- * This program is free software; you can redistribute it and/or modify
+- * it under the terms of the GNU General Public License as published by
+- * the Free Software Foundation; version 2 of the License.
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+- * GNU General Public License for more details.
+- */
+-
+-#ifndef MAINBOARD_GPIO_H
+-#define MAINBOARD_GPIO_H
+-
+-#include <soc/gpe.h>
+-#include <soc/gpio.h>
+-
+-#ifndef __ACPI__
+-
+-/* Pad configuration in ramstage. */
+-static const struct pad_config gpio_table[] = {
+-/* RCIN# */		PAD_CFG_NF(GPP_A0, NONE, DEEP, NF1),
+-/* LAD0 */		PAD_CFG_NF(GPP_A1, NONE, DEEP, NF1),
+-/* LAD1 */		PAD_CFG_NF(GPP_A2, NONE, DEEP, NF1),
+-/* LAD2 */		PAD_CFG_NF(GPP_A3, NONE, DEEP, NF1),
+-/* LAD3 */		PAD_CFG_NF(GPP_A4, NONE, DEEP, NF1),
+-/* LFRAME# */		PAD_CFG_NF(GPP_A5, NONE, DEEP, NF1),
+-/* SERIRQ */		PAD_CFG_NF(GPP_A6, NONE, DEEP, NF1),
+-/* PIRQA# */		PAD_CFG_NC(GPP_A7),
+-/* CLKRUN# */		PAD_CFG_NF(GPP_A8, NONE, DEEP, NF1),
+-/* CLKOUT_LPC0 */	PAD_CFG_NF(GPP_A9, NONE, DEEP, NF1),
+-/* CLKOUT_LPC1 */	PAD_CFG_NF(GPP_A10, NONE, DEEP, NF1),
+-/* PME# */		PAD_CFG_NC(GPP_A11),
+-/* BM_BUSY# */		PAD_CFG_NC(GPP_A12),
+-/* SUSWARN# */		PAD_CFG_NF(GPP_A13, NONE, DEEP, NF1),
+-/* SUS_STAT# */		PAD_CFG_NF(GPP_A14, NONE, DEEP, NF1),
+-/* SUSACK# */		PAD_CFG_NF(GPP_A15, DN_20K, DEEP, NF1),
+-/* SD_1P8_SEL */	PAD_CFG_NC(GPP_A16),
+-/* SD_PWR_EN# */	PAD_CFG_NF(GPP_A17, NONE, DEEP, NF1),
+-/* ISH_GP0 */		PAD_CFG_GPI(GPP_A18, NONE, DEEP),
+-/* ISH_GP1 */		PAD_CFG_GPI(GPP_A19, NONE, DEEP),
+-/* ISH_GP2 */		PAD_CFG_GPI(GPP_A20, NONE, DEEP),
+-/* ISH_GP3 */		PAD_CFG_NC(GPP_A21),
+-/* ISH_GP4 */		PAD_CFG_NC(GPP_A22),
+-/* ISH_GP5 */		PAD_CFG_NC(GPP_A23),
+-
+-/* CORE_VID0 */		PAD_CFG_NC(GPP_B0),
+-/* CORE_VID1 */		PAD_CFG_NC(GPP_B1),
+-/* VRALERT# */		PAD_CFG_NC(GPP_B2),
+-/* CPU_GP2 */		PAD_CFG_NC(GPP_B3),
+-/* CPU_GP3 */		PAD_CFG_NC(GPP_B4),
+-/* SRCCLKREQ0# */	PAD_CFG_NF(GPP_B5, NONE, DEEP, NF1),
+-/* SRCCLKREQ1# */	PAD_CFG_NF(GPP_B6, NONE, DEEP, NF1),
+-/* SRCCLKREQ2# */	PAD_CFG_NF(GPP_B7, NONE, DEEP, NF1),
+-/* SRCCLKREQ3# */	PAD_CFG_NF(GPP_B8, NONE, DEEP, NF1),
+-/* SRCCLKREQ4# */	PAD_CFG_NF(GPP_B9, NONE, DEEP, NF1),
+-/* SRCCLKREQ5# */	PAD_CFG_NF(GPP_B10, NONE, DEEP, NF1),
+-/* EXT_PWR_GATE# */	PAD_CFG_NC(GPP_B11),
+-/* SLP_S0# */		PAD_CFG_NF(GPP_B12, NONE, DEEP, NF1),
+-/* PLTRST# */		PAD_CFG_NF(GPP_B13, NONE, DEEP, NF1),
+-/* SPKR */		PAD_CFG_TERM_GPO(GPP_B14, 1, DN_20K, DEEP),
+-/* GSPI0_CS# */		PAD_CFG_NC(GPP_B15),
+-/* GSPI0_CLK */		PAD_CFG_NC(GPP_B16),
+-/* GSPI0_MISO */	PAD_CFG_NC(GPP_B17),
+-/* GSPI0_MOSI */	PAD_CFG_GPI_SCI(GPP_B18, UP_20K, PLTRST, LEVEL, INVERT),
+-/* GSPI1_CS# */		PAD_CFG_NC(GPP_B19),
+-/* GSPI1_CLK */		PAD_CFG_NC(GPP_B20),
+-/* GSPI1_MISO */	PAD_CFG_NC(GPP_B21),
+-/* GSPI1_MOSI */	PAD_CFG_NF(GPP_B22, DN_20K, DEEP, NF1),
+-/* SM1ALERT# */		PAD_CFG_TERM_GPO(GPP_B23, 1, DN_20K, DEEP),
+-
+-/* SMBCLK */		PAD_CFG_NF(GPP_C0, NONE, DEEP, NF1),
+-/* SMBDATA */		PAD_CFG_NF(GPP_C1, DN_20K, DEEP, NF1),
+-/* SMBALERT# */		PAD_CFG_TERM_GPO(GPP_C2, 1, DN_20K, DEEP),
+-/* SML0CLK */		PAD_CFG_NF(GPP_C3, NONE, DEEP, NF1),
+-/* SML0DATA */		PAD_CFG_NF(GPP_C4, NONE, DEEP, NF1),
+-/* SML0ALERT# */	PAD_CFG_GPI_APIC_INVERT(GPP_C5, DN_20K, DEEP),
+-/* SML1CLK */		PAD_CFG_NC(GPP_C6), /* RESERVED */
+-/* SML1DATA */		PAD_CFG_NC(GPP_C7), /* RESERVED */
+-/* UART0_RXD */		PAD_CFG_NF(GPP_C8, NONE, DEEP, NF1),
+-/* UART0_TXD */		PAD_CFG_NF(GPP_C9, NONE, DEEP, NF1),
+-/* UART0_RTS# */	PAD_CFG_NF(GPP_C10, NONE, DEEP, NF1),
+-/* UART0_CTS# */	PAD_CFG_NF(GPP_C11, NONE, DEEP, NF1),
+-/* UART1_RXD */		PAD_CFG_NC(GPP_C12),
+-/* UART1_TXD */		PAD_CFG_NC(GPP_C13),
+-/* UART1_RTS# */	PAD_CFG_NC(GPP_C14),
+-/* UART1_CTS# */	PAD_CFG_NC(GPP_C15),
+-/* I2C0_SDA */		PAD_CFG_GPI(GPP_C16, NONE, DEEP),
+-/* I2C0_SCL */		PAD_CFG_GPI(GPP_C17, NONE, DEEP),
+-/* I2C1_SDA */		PAD_CFG_GPI(GPP_C18, NONE, DEEP),
+-/* I2C1_SCL */		PAD_CFG_NC(GPP_C19),
+-/* UART2_RXD */		PAD_CFG_NC(GPP_C20),
+-/* UART2_TXD */		PAD_CFG_NC(GPP_C21),
+-/* UART2_RTS# */	PAD_CFG_NC(GPP_C22),
+-/* UART2_CTS# */	PAD_CFG_NC(GPP_C23),
+-
+-/* SPI1_CS# */		PAD_CFG_NC(GPP_D0),
+-/* SPI1_CLK */		PAD_CFG_NC(GPP_D1),
+-/* SPI1_MISO */		PAD_CFG_NC(GPP_D2),
+-/* SPI1_MOSI */		PAD_CFG_NC(GPP_D3),
+-/* FASHTRIG */		PAD_CFG_NC(GPP_D4),
+-/* ISH_I2C0_SDA */	PAD_CFG_NC(GPP_D5),
+-/* ISH_I2C0_SCL */	PAD_CFG_NC(GPP_D6),
+-/* ISH_I2C1_SDA */	PAD_CFG_NC(GPP_D7),
+-/* ISH_I2C1_SCL */	PAD_CFG_NC(GPP_D8),
+-/* ISH_SPI_CS# */	PAD_CFG_TERM_GPO(GPP_D9, 0, NONE, DEEP),
+-/* ISH_SPI_CLK */	PAD_CFG_GPI(GPP_D10, NONE, DEEP),
+-/* ISH_SPI_MISO */	PAD_CFG_TERM_GPO(GPP_D11, 1, NONE, DEEP),
+-/* ISH_SPI_MOSI */	PAD_CFG_NC(GPP_D12),
+-/* ISH_UART0_RXD */	PAD_CFG_NC(GPP_D13),
+-/* ISH_UART0_TXD */	PAD_CFG_NC(GPP_D14),
+-/* ISH_UART0_RTS# */	PAD_CFG_NC(GPP_D15),
+-/* ISH_UART0_CTS# */	PAD_CFG_NC(GPP_D16),
+-/* DMIC_CLK1 */		PAD_CFG_NF(GPP_D17, NONE, DEEP, NF1),
+-/* DMIC_DATA1 */	PAD_CFG_NF(GPP_D18, NONE, DEEP, NF1),
+-/* DMIC_CLK0 */		PAD_CFG_NF(GPP_D19, NONE, DEEP, NF1),
+-/* DMIC_DATA0 */	PAD_CFG_NF(GPP_D20, NONE, DEEP, NF1),
+-/* SPI1_IO2 */		PAD_CFG_NC(GPP_D21),
+-/* SPI1_IO3 */		PAD_CFG_NC(GPP_D22),
+-/* I2S_MCLK */		PAD_CFG_NC(GPP_D23),
+-
+-/* SATAXPCI0 */		PAD_CFG_NC(GPP_E0),
+-/* SATAXPCIE1 */	PAD_CFG_NC(GPP_E1),
+-/* SATAXPCIE2 */	PAD_CFG_NF(GPP_E2, UP_20K, DEEP, NF1),
+-/* CPU_GP0 */		PAD_CFG_NC(GPP_E3),
+-/* SATA_DEVSLP0 */	PAD_CFG_NC(GPP_E4),
+-/* SATA_DEVSLP1 */	PAD_CFG_NC(GPP_E5),
+-/* SATA_DEVSLP2 */	PAD_CFG_NC(GPP_E6),
+-/* CPU_GP1 */		PAD_CFG_NC(GPP_E7),
+-/* SATALED# */		PAD_CFG_NC(GPP_E8),
+-/* USB2_OCO# */		PAD_CFG_NF(GPP_E9, NONE, DEEP, NF1),
+-/* USB2_OC1# */		PAD_CFG_NF(GPP_E10, NONE, DEEP, NF1),
+-/* USB2_OC2# */		PAD_CFG_NF(GPP_E11, NONE, DEEP, NF1),
+-/* USB2_OC3# */		PAD_CFG_NC(GPP_E12),
+-/* DDPB_HPD0 */		PAD_CFG_NF(GPP_E13, NONE, DEEP, NF1),
+-/* DDPC_HPD1 */		PAD_CFG_NF(GPP_E14, NONE, DEEP, NF1),
+-/* DDPD_HPD2 */		PAD_CFG_NC(GPP_E15),
+-/* DDPE_HPD3 */		PAD_CFG_GPI_ACPI_SCI(GPP_E16, NONE, PLTRST, NONE),
+-/* EDP_HPD */		PAD_CFG_NF(GPP_E17, NONE, DEEP, NF1),
+-/* DDPB_CTRLCLK */	PAD_CFG_NF(GPP_E18, NONE, DEEP, NF1),
+-/* DDPB_CTRLDATA */	PAD_CFG_NF(GPP_E19, DN_20K, DEEP, NF1),
+-/* DDPC_CTRLCLK */	PAD_CFG_NF(GPP_E20, NONE, DEEP, NF1),
+-/* DDPC_CTRLDATA */	PAD_CFG_NF(GPP_E21, DN_20K, DEEP, NF1),
+-/* DDPD_CTRLCLK */	PAD_CFG_GPI_APIC(GPP_E22, NONE, DEEP),
+-/* DDPD_CTRLDATA */	PAD_CFG_TERM_GPO(GPP_E23, 1, DN_20K, DEEP),
+-
+-/* I2S2_SCLK */		PAD_CFG_NC(GPP_F0),
+-/* I2S2_SFRM */		PAD_CFG_NC(GPP_F1),
+-/* I2S2_TXD */		PAD_CFG_NC(GPP_F2),
+-/* I2S2_RXD */		PAD_CFG_NC(GPP_F3),
+-/* I2C2_SDA */		PAD_CFG_NC(GPP_F4),
+-/* I2C2_SCL */		PAD_CFG_NC(GPP_F5),
+-/* I2C3_SDA */		PAD_CFG_NC(GPP_F6),
+-/* I2C3_SCL */		PAD_CFG_NC(GPP_F7),
+-/* I2C4_SDA */		PAD_CFG_NF_1V8(GPP_F8, NONE, DEEP, NF1),
+-/* I2C4_SCL */		PAD_CFG_NF_1V8(GPP_F9, NONE, DEEP, NF1),
+-/* I2C5_SDA */		PAD_CFG_NC(GPP_F10),
+-/* I2C5_SCL */		PAD_CFG_NC(GPP_F11),
+-/* EMMC_CMD */		PAD_CFG_NC(GPP_F12),
+-/* EMMC_DATA0 */	PAD_CFG_NC(GPP_F13),
+-/* EMMC_DATA1 */	PAD_CFG_NC(GPP_F14),
+-/* EMMC_DATA2 */	PAD_CFG_NC(GPP_F15),
+-/* EMMC_DATA3 */	PAD_CFG_NC(GPP_F16),
+-/* EMMC_DATA4 */	PAD_CFG_NC(GPP_F17),
+-/* EMMC_DATA5 */	PAD_CFG_NC(GPP_F18),
+-/* EMMC_DATA6 */	PAD_CFG_NC(GPP_F19),
+-/* EMMC_DATA7 */	PAD_CFG_NC(GPP_F20),
+-/* EMMC_RCLK */		PAD_CFG_NC(GPP_F21),
+-/* EMMC_CLK */		PAD_CFG_NC(GPP_F22),
+-/* RSVD */		PAD_CFG_NC(GPP_F23),
+-
+-/* SD_CMD */		PAD_CFG_NF(GPP_G0, NONE, DEEP, NF1),
+-/* SD_DATA0 */		PAD_CFG_NF(GPP_G1, NONE, DEEP, NF1),
+-/* SD_DATA1 */		PAD_CFG_NF(GPP_G2, NONE, DEEP, NF1),
+-/* SD_DATA2 */		PAD_CFG_NF(GPP_G3, NONE, DEEP, NF1),
+-/* SD_DATA3 */		PAD_CFG_NF(GPP_G4, NONE, DEEP, NF1),
+-/* SD_CD# */		PAD_CFG_NF(GPP_G5, NONE, DEEP, NF1),
+-/* SD_CLK */		PAD_CFG_NF(GPP_G6, NONE, DEEP, NF1),
+-/* SD_WP */		PAD_CFG_NF(GPP_G7, UP_20K, DEEP, NF1),
+-
+-/* BATLOW# */		PAD_CFG_NC(GPD0),
+-/* ACPRESENT */		PAD_CFG_NF(GPD1, NONE, PWROK, NF1),
+-/* LAN_WAKE# */		PAD_CFG_NC(GPD2),
+-/* PWRBTN# */		PAD_CFG_NF(GPD3, UP_20K, PWROK, NF1),
+-/* SLP_S3# */		PAD_CFG_NF(GPD4, NONE, PWROK, NF1),
+-/* SLP_S4# */		PAD_CFG_NF(GPD5, NONE, PWROK, NF1),
+-/* SLP_A# */		PAD_CFG_NF(GPD6, NONE, PWROK, NF1),
+-/* RSVD */		PAD_CFG_NC(GPD7),
+-/* SUSCLK */		PAD_CFG_NF(GPD8, NONE, PWROK, NF1),
+-/* SLP_WLAN# */		PAD_CFG_NF(GPD9, NONE, PWROK, NF1),
+-/* SLP_S5# */		PAD_CFG_NF(GPD10, NONE, PWROK, NF1),
+-/* LANPHYC */		PAD_CFG_NF(GPD11, NONE, DEEP, NF1),
+-};
+-
+-#endif
+-
+-#endif
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0006-purism-librem_skl-Explicitely-enable-VMX-and-Intel-S.patch
+++ b/patches/coreboot-4.7/0006-purism-librem_skl-Explicitely-enable-VMX-and-Intel-S.patch
@@ -1,0 +1,40 @@
+From e6998f87d8d4c389d86586ea66f0ff20cd7751d2 Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 9 Feb 2018 18:44:45 -0500
+Subject: [PATCH 6/9] purism/librem_skl: Explicitely enable VMX and Intel
+ SpeedStep
+
+The VMX feature was enabled by default by the FSP but a different
+FSP might have it disabled, so this ensures that VMX is explicitely
+enabled for the Librem machines. This option however doesn't seem
+to work in the FSP since VMX doesn't actually get enabled but as
+long as the features MSR remains unlocked, it's not critical.
+
+Enabling Intel SpeedStep Technology ensures the ACPI tables contain
+the C-states/P-states which are required for the xen-acpi-processor
+module to be loaded. Without it, the Qubes 4.0-rc4 installer will
+complain at boot about modules that could not be loaded.
+
+Change-Id: I968ef36ec9382a10db13d96fd3a5c0fc904db387
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+index e2e2ac03da..9ce1d91549 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+@@ -7,6 +7,9 @@ chip soc/intel/skylake
+ 	register "deep_s5_enable_dc" = "0"
+ 	register "deep_sx_config" = "DSX_EN_LAN_WAKE_PIN"
+ 
++	register "eist_enable" = "1"
++	register "VmxEnable" = "1"
++
+ 	# GPE configuration
+ 	# Note that GPE events called out in ASL code rely on this
+ 	# route. i.e. If this route changes then the affected GPE
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0007-intel-fsp-fsp2_0-Fix-FSP-2.0-headers-to-match-github.patch
+++ b/patches/coreboot-4.7/0007-intel-fsp-fsp2_0-Fix-FSP-2.0-headers-to-match-github.patch
@@ -1,0 +1,43 @@
+From 8e7e0e390fcfda226f0d78bfa883ffee12f751a8 Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 9 Feb 2018 18:32:51 -0500
+Subject: [PATCH 7/9] intel/fsp/fsp2_0: Fix FSP 2.0 headers to match github
+ version
+
+The current FSP 2.0 headers do not match the headers from the official
+FSP 2.0 image that was released on github [1].
+
+[1] https://github.com/IntelFsp/FSP/tree/Kabylake/KabylakeFspBinPkg
+
+Change-Id: I233bf7cf6f62e9e1b389d42a09461717a3285f0f
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/vendorcode/intel/fsp/fsp2_0/skykabylake/MemInfoHob.h | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/vendorcode/intel/fsp/fsp2_0/skykabylake/MemInfoHob.h b/src/vendorcode/intel/fsp/fsp2_0/skykabylake/MemInfoHob.h
+index 248b4d5ef1..3abc877a19 100644
+--- a/src/vendorcode/intel/fsp/fsp2_0/skykabylake/MemInfoHob.h
++++ b/src/vendorcode/intel/fsp/fsp2_0/skykabylake/MemInfoHob.h
+@@ -207,10 +207,6 @@ typedef struct {
+   UINT8             RevisionId;              ///< The PCI revision id of this memory controller.
+   UINT8             ChannelCount;            ///< Number of valid channels that exist on the controller.
+   CHANNEL_INFO      ChannelInfo[MAX_CH];     ///< The following are channel level definitions.
+-  MRC_TA_TIMING     tRd2Rd;                  ///< Read-to-Read   Turn Around Timings
+-  MRC_TA_TIMING     tRd2Wr;                  ///< Read-to-Write  Turn Around Timings
+-  MRC_TA_TIMING     tWr2Rd;                  ///< Write-to-Read  Turn Around Timings
+-  MRC_TA_TIMING     tWr2Wr;                  ///< Write-to-Write Turn Around Timings
+ } CONTROLLER_INFO;
+ 
+ typedef struct {
+@@ -228,6 +224,7 @@ typedef struct {
+   UINT8             ErrorCorrectionType;
+ 
+   SiMrcVersion      Version;
++  UINT32            FreqMax;
+   BOOLEAN           EccSupport;
+   UINT8             MemoryProfile;
+   UINT32            TotalPhysicalMemorySize;
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0009-Add-heads-TPM-measurements-to-Skylake-Kabylake.patch
+++ b/patches/coreboot-4.7/0009-Add-heads-TPM-measurements-to-Skylake-Kabylake.patch
@@ -1,0 +1,60 @@
+From 8c6528caa1a2abcd30bbb0c4fdb4663dc70cb7d4 Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Thu, 22 Feb 2018 20:56:04 -0500
+Subject: [PATCH 9/9] Add heads TPM measurements to Skylake/Kabylake
+
+---
+ src/drivers/intel/fsp2_0/memory_init.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/src/drivers/intel/fsp2_0/memory_init.c b/src/drivers/intel/fsp2_0/memory_init.c
+index 575f277466..4160b997a4 100644
+--- a/src/drivers/intel/fsp2_0/memory_init.c
++++ b/src/drivers/intel/fsp2_0/memory_init.c
+@@ -33,6 +33,7 @@
+ #include <symbols.h>
+ #include <timestamp.h>
+ #include <tpm_lite/tlcl.h>
++#include <program_loading.h>
+ #include <security/vboot/vboot_common.h>
+ #include <vb2_api.h>
+ 
+@@ -150,12 +151,14 @@ static void do_fsp_post_memory_init(bool s3wake, uint32_t fsp_version)
+ 
+ 	/*
+ 	 * Initialize the TPM, unless the TPM was already initialized
+-	 * in verstage and used to verify romstage.
++	 * in verstage and used to verify romstage, or for measured boot.
+ 	 */
+ 	if (IS_ENABLED(CONFIG_LPC_TPM) &&
+-	    (!IS_ENABLED(CONFIG_RESUME_PATH_SAME_AS_BOOT) ||
+-	     !IS_ENABLED(CONFIG_VBOOT_STARTS_IN_BOOTBLOCK)))
++            (!IS_ENABLED(CONFIG_RESUME_PATH_SAME_AS_BOOT) ||
++                !IS_ENABLED(CONFIG_VBOOT_STARTS_IN_BOOTBLOCK)) &&
++            !IS_ENABLED(CONFIG_MEASURED_BOOT))
+ 		init_tpm(s3wake);
++	printk(BIOS_DEBUG, "%s: romstage complete\n", __FILE__);
+ }
+ 
+ static int mrc_cache_verify_tpm_hash(const uint8_t *data, size_t size)
+@@ -484,6 +487,17 @@ void fsp_memory_init(bool s3wake)
+ 	if (status != CB_SUCCESS)
+ 		die("Loading FSPM failed!\n");
+ 
++	if (IS_ENABLED(CONFIG_MEASURED_BOOT) && IS_ENABLED(CONFIG_LPC_TPM)) {
++		// we don't know if we are coming out of a resume
++		// at this point, but want to setup the tpm ASAP
++		init_tpm(0);
++		tlcl_lib_init();
++		const void * const bootblock = (const void*) 0xFFFFF800;
++		const unsigned bootblock_size = 0x800;
++		tlcl_measure(0, bootblock, bootblock_size);
++
++		tlcl_measure(1, _romstage, _eromstage - _romstage);
++	}
+ 	/* Signal that FSP component has been loaded. */
+ 	prog_segment_loaded(hdr.image_base, hdr.image_size, SEG_FINAL);
+ 
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0013-intel-cpu-Fix-SpeedStep-enabling.patch
+++ b/patches/coreboot-4.7/0013-intel-cpu-Fix-SpeedStep-enabling.patch
@@ -1,0 +1,37 @@
+From 73c4fda90fdc4bd0bc6b383995d15b2c803cc274 Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 2 Mar 2018 14:22:14 -0500
+Subject: [PATCH 13/15] intel/cpu: Fix SpeedStep enabling
+
+The IA32_MISC_ENABLE MSR was being overwritten by its old value
+right after enabling SpeedStep (eist) which caused it to revert
+the call to cpu_enable_eist().
+
+Fixes bug introduced in 6b45ee44.
+
+Change-Id: Id2ac660bf8ea56d45e8c3f631a586b74106a6cc9
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/soc/intel/skylake/cpu.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/soc/intel/skylake/cpu.c b/src/soc/intel/skylake/cpu.c
+index 291a40da3e..d09a05667e 100644
+--- a/src/soc/intel/skylake/cpu.c
++++ b/src/soc/intel/skylake/cpu.c
+@@ -260,11 +260,11 @@ static void configure_misc(void)
+ 	msr = rdmsr(IA32_MISC_ENABLE);
+ 	msr.lo |= (1 << 0);	/* Fast String enable */
+ 	msr.lo |= (1 << 3);	/* TM1/TM2/EMTTM enable */
++	wrmsr(IA32_MISC_ENABLE, msr);
+ 	if (conf->eist_enable)
+ 		cpu_enable_eist();
+ 	else
+ 		cpu_disable_eist();
+-	wrmsr(IA32_MISC_ENABLE, msr);
+ 
+ 	/* Disable Thermal interrupts */
+ 	msr.lo = 0;
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0014-purism-librem_skl-Set-TCC-Activation-at-95C.patch
+++ b/patches/coreboot-4.7/0014-purism-librem_skl-Set-TCC-Activation-at-95C.patch
@@ -1,0 +1,52 @@
+From f93f9ac4d9da20749197abc5f272839da5519e1d Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 2 Mar 2018 16:12:04 -0500
+Subject: [PATCH 14/15] purism/librem_skl: Set TCC Activation at 95C
+
+Set the Thermal Control Circuit (TCC) activaction value to 95C
+even though FSP integration guide says to set it to 100C for SKL-U
+(offset at 0), because when the TCC activates at 100C, the CPU
+will have already shut itself down from overheating protection.
+
+This was tested on Purism Librem 13 v2. A bisect showed that the
+immediate shutdowns happened after commit [1] was merged which led
+to this solution.
+
+There is still a temperature ramping problem where a 'stress -c 4'
+command will bring the temperature up from 50 to 100C (95C after
+this patch) within a few milliseconds, instead of it taking many
+dozens of seconds to reach ~80C. A bisect shows this regression
+was introduced in commit [2] and still needs to be investigated.
+This change may not be necessary anymore once the temperature
+ramping problem is fixed, but it is still wise to keep it for
+preventing shutdowns in corner cases.
+
+[1] ec5a947b (soc/intel/skylake: make tcc_offset take effect)
+[2] fb1cd095 (purism/librem13v2: migrate from FSP 1.1 to 2.0)
+
+Change-Id: Idfc001c8e46ed3b07b24150c961c4b9bc9b71a62
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+index 9ce1d91549..159d921046 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/variants/librem13v2/devicetree.cb
+@@ -10,6 +10,12 @@ chip soc/intel/skylake
+ 	register "eist_enable" = "1"
+ 	register "VmxEnable" = "1"
+ 
++	# Set the Thermal Control Circuit (TCC) activaction value to 95C
++	# even though FSP integration guide says to set it to 100C for SKL-U
++	# (offset at 0), because when the TCC activates at 100C, the CPU
++	# will have already shut itself down from overheating protection.
++	register "tcc_offset" = "5" # TCC of 95C
++
+ 	# GPE configuration
+ 	# Note that GPE events called out in ASL code rely on this
+ 	# route. i.e. If this route changes then the affected GPE
+-- 
+2.14.3
+

--- a/patches/coreboot-4.7/0015-purism-librem_skl-Fix-Librem-15-v3-devicetree-config.patch
+++ b/patches/coreboot-4.7/0015-purism-librem_skl-Fix-Librem-15-v3-devicetree-config.patch
@@ -1,0 +1,39 @@
+From bdaef1d8aa7cdfb27122665f951932e6e53d6a3d Mon Sep 17 00:00:00 2001
+From: Youness Alaoui <youness.alaoui@puri.sm>
+Date: Fri, 2 Mar 2018 17:03:11 -0500
+Subject: [PATCH 15/15] purism/librem_skl: Fix Librem 15 v3 devicetree
+ configuration
+
+Recent changes to devicetree for librem_skl were only applied
+to the librem13v2 variant (Enable SpeedStep, VMX, TCC at 95C),
+this fixes it by applying the same fixes for the Librem 15 v3.
+
+Change-Id: I1d5c3ba844c942bd94311f4639612228ff8e07f8
+Signed-off-by: Youness Alaoui <youness.alaoui@puri.sm>
+---
+ .../purism/librem_skl/variants/librem15v3/devicetree.cb          | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb b/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
+index 6cf183a61f..035db18eff 100644
+--- a/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/variants/librem15v3/devicetree.cb
+@@ -7,6 +7,15 @@ chip soc/intel/skylake
+ 	register "deep_s5_enable_dc" = "0"
+ 	register "deep_sx_config" = "DSX_EN_LAN_WAKE_PIN"
+ 
++	register "eist_enable" = "1"
++	register "VmxEnable" = "1"
++
++	# Set the Thermal Control Circuit (TCC) activaction value to 95C
++	# even though FSP integration guide says to set it to 100C for SKL-U
++	# (offset at 0), because when the TCC activates at 100C, the CPU
++	# will have already shut itself down from overheating protection.
++	register "tcc_offset" = "5" # TCC of 95C
++
+ 	# GPE configuration
+ 	# Note that GPE events called out in ASL code rely on this
+ 	# route. i.e. If this route changes then the affected GPE
+-- 
+2.14.3
+


### PR DESCRIPTION
Coreboot patches are becoming hard to maintain, and resolving conflicts in the patch if two people decide to update the patch file makes it even harder. 
This adds the ability to use a .series file which contains filenames for patches to apply. 
Also add various patches to coreboot 4.7 to add measured boot support to skylake devices, as well as IOMMU, and TPM support to librem 13v2.