### PR TITLE
Add a menu option to reset TPM for bootstrapping. Widen menus.

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -31,9 +31,10 @@ while true; do
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       whiptail --clear --title "ERROR: TOTP Generation Failed!" \
-        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS, you will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 20 60 4 \
+        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS, you will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted, you should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
         'g' ' Generate new TOTP secret' \
         'i' ' Ignore error and continue to default boot menu' \
+        'p' ' Reset the TPM' \
         'x' ' Exit to recovery shell' \
         2>/tmp/whiptail || recovery "GUI menu failed"
 
@@ -43,7 +44,7 @@ while true; do
 
   if [ "$totp_confirm" = "i" -o -z "$totp_confirm" ]; then 
     whiptail --clear --title "$CONFIG_BOOT_GUI_MENU_NAME" \
-      --menu "$date\nTOTP code: $TOTP" 20 60 8 \
+      --menu "$date\nTOTP code: $TOTP" 20 80 10 \
       'y' ' Default boot' \
       'r' ' TOTP does not match, refresh code' \
       'n' ' TOTP does not match after refresh, troubleshoot' \
@@ -51,6 +52,7 @@ while true; do
       'u' ' USB boot' \
       'g' ' Generate new TOTP secret' \
       'i' ' Ignore tampering and force a boot (Unsafe!)' \
+      'p' ' Reset the TPM' \
       'x' ' Exit to recovery shell' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 
@@ -67,7 +69,7 @@ while true; do
 
   if [ "$totp_confirm" = "n" ]; then
     if (whiptail --title "TOTP code mismatched" \
-      --yesno "TOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s HH:MM:SS'\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 30 60) then
+      --yesno "TOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s HH:MM:SS'\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 30 80) then
       echo ""
       echo "To correct clock drift: 'date -s HH:MM:SS'"
       echo "and save it to the RTC: 'hwclock -w'"
@@ -86,7 +88,22 @@ while true; do
 
   if [ "$totp_confirm" = "g" ]; then
     if (whiptail --title 'Generate new TOTP secret' \
-        --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 16 60) then
+        --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 16 80) then
+      echo "Scan the QR code to add the new TOTP secret"
+      /bin/seal-totp
+      echo "Once you have scanned the QR code, hit Enter to reboot"
+      read
+      /bin/reboot
+    else
+      echo "Returning to the main menu"
+    fi
+    continue
+  fi
+
+  if [ "$totp_confirm" = "p" ]; then
+    if (whiptail --title 'Reset the TPM' \
+        --yesno "This will clear the TPM, erase the old TPM password and replace it with a new one!\n\nDo you want to proceed?" 16 80) then
+      /bin/tpm-reset
       echo "Scan the QR code to add the new TOTP secret"
       /bin/seal-totp
       echo "Once you have scanned the QR code, hit Enter to reboot"
@@ -108,7 +125,7 @@ while true; do
   if [ "$totp_confirm" = "i" ]; then
     # Run the menu selection in "force" mode, bypassing hash checks
     if (whiptail --title 'Unsafe Forced Boot Selected!' \
-        --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 16 60) then
+        --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 16 80) then
       mount_boot
       kexec-select-boot -m -b /boot -c "grub.cfg" -g -f
     else
@@ -126,7 +143,7 @@ while true; do
       || recovery "Failed default boot"
     else
       if (whiptail --title 'No Default Boot Option Configured' \
-          --yesno "There is no default boot option configured yet. Would you like to load a menu of boot options? Otherwise you will return to the main menu." 16 60) then
+          --yesno "There is no default boot option configured yet. Would you like to load a menu of boot options? Otherwise you will return to the main menu." 16 80) then
         kexec-select-boot -m -b /boot -c "grub.cfg" -g
       else
         echo "Returning to the main menu"


### PR DESCRIPTION
One of the other core functions a user needs when bootstrapping is
taking over the TPM. I've added a new option in the menu for this and it
revealed that some of the menus needed more space so I've widened all
the menus and also made the main menu longer so the options don't
scroll.