### PR TITLE
Allow insecure boot mode to bypass kexec sig checks

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -294,7 +294,11 @@ do_boot()
 }
 
 while true; do
-	check_config $paramsdir
+	if [ "$force_boot" = "y" ]; then
+	  check_config $paramsdir force
+  else
+	  check_config $paramsdir
+  fi
 	TMP_DEFAULT_FILE=`find /tmp/kexec/kexec_default.*.txt 2>/dev/null | head -1` || true
 	TMP_MENU_FILE="/tmp/kexec/kexec_menu.txt"
 	TMP_HASH_FILE="/tmp/kexec/kexec_hashes.txt"

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -296,9 +296,9 @@ do_boot()
 while true; do
 	if [ "$force_boot" = "y" ]; then
 	  check_config $paramsdir force
-  else
+	else
 	  check_config $paramsdir
-  fi
+	fi
 	TMP_DEFAULT_FILE=`find /tmp/kexec/kexec_default.*.txt 2>/dev/null | head -1` || true
 	TMP_MENU_FILE="/tmp/kexec/kexec_menu.txt"
 	TMP_HASH_FILE="/tmp/kexec/kexec_hashes.txt"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -181,11 +181,11 @@ check_config() {
 		return
 	fi
 
-  if [ "$2" != "force" ]; then
-    if ! sha256sum `find $1/kexec*.txt` | gpgv $1/kexec.sig - ; then
-      die 'Invalid signature on kexec boot params'
-    fi
-  fi
+	if [ "$2" != "force" ]; then
+		if ! sha256sum `find $1/kexec*.txt` | gpgv $1/kexec.sig - ; then
+			die 'Invalid signature on kexec boot params'
+		fi
+	fi
 
 	echo "+++ Found verified kexec boot params"
 	cp $1/kexec*.txt /tmp/kexec \

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -181,9 +181,11 @@ check_config() {
 		return
 	fi
 
-	if ! sha256sum `find $1/kexec*.txt` | gpgv $1/kexec.sig - ; then
-		die 'Invalid signature on kexec boot params'
-	fi
+  if [ "$2" != "force" ]; then
+    if ! sha256sum `find $1/kexec*.txt` | gpgv $1/kexec.sig - ; then
+      die 'Invalid signature on kexec boot params'
+    fi
+  fi
 
 	echo "+++ Found verified kexec boot params"
 	cp $1/kexec*.txt /tmp/kexec \


### PR DESCRIPTION
There was a bug in the "force" boot mode where it would still fail if signatures didn't match. This was because the check_config function validates the signatures for kexec files. I've added a few conditionals
here so that in the case of a forced boot mode, we can bypass those signature checks that would prevent boot and error out to a recovery console.
