### PR TITLE
Add a gui menu for changed boot entries

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -215,7 +215,7 @@ default_select() {
 				--msgbox "The list of boot entries has changed\n\nPlease set a new default" 16 60
 		fi
 		warn "!!! Boot entry has changed - please set a new default"
-    return
+		return
 	fi
 	parse_option
 

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -210,7 +210,12 @@ default_select() {
 	expectedoption=`cat $TMP_DEFAULT_FILE`
 	option=`head -n $default_index $TMP_MENU_FILE | tail -1`
 	if [ "$option" != "$expectedoption" ]; then
-		die "!!! Boot entry has changed - please set a new default"
+		if [ "$gui_menu" = "y" ]; then
+			whiptail --title 'ERROR: Boot Entry Has Changed' \
+				--msgbox "The list of boot entries has changed\n\nPlease set a new default" 16 60
+		fi
+		warn "!!! Boot entry has changed - please set a new default"
+    return
 	fi
 	parse_option
 


### PR DESCRIPTION
Currently when the boot entries change, kexec-select-boot dies. Given
the normal loop is set up to catch this event and display a regular boot
menu at the next iteration of the loop, instead of dying it would be
better to just warn and then return from that function back into the
main loop. In addition to that I added a GUI menu for the same warning
when in GUI mode.