### PR TITLE
Add red background to boot console for insecure "force" boot

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -312,6 +312,9 @@ while true; do
 # even if hashes don't match
 	if [ "$force_boot" = "y" ]; then
 		scan_options
+		# Remove boot splash and make background red in the event of a forced boot
+		add="$add vt.default_red=0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff"
+		remove="$remove splash quiet"
 		user_select
 	fi
 


### PR DESCRIPTION
In the event a user does pick the insecure "force" boot option that
bypasses checksum and signing checks in Heads, it would be nice to
provide a clear visual warning during the boot process that they are in
this state. This change will add a kernel argument that changes the boot
console background to be red and removes any boot splash that might
obscure it, in the event the user picks the insecure boot mode.

Since a user should only boot into this mode during emergencies, having
it be apparent that it's an unsafe mode helps ensure the user doesn't
pick this boot option needlessly.