### PR TITLE
Skip boot choice confirmation in "force" mode

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -246,7 +246,12 @@ user_select() {
 	while [ "$option_confirm" != "y" -a "$option_confirm" != "d" ]
 	do
 		get_menu_option
-		confirm_menu_option
+    # In force boot mode, no need offer the option to set a default, just boot
+		if [ "$force_boot" = "y" ]; then
+			do_boot
+		else
+			confirm_menu_option
+		fi
 
 		if [ "$option_confirm" = 'd' ]; then
 			save_default_option


### PR DESCRIPTION
When a user gets confirmation of their boot menu choice, that's largely
to give them the option of making their boot choice the default. In the
case of "force mode" there's no reason for the user to be presented with
that dialog so this change skips right ahead to the boot once they have