### PR TITLE
Wrap whiptail text that's over 80 characters

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -26,7 +26,7 @@ verify_global_hashes()
     return 0
   elif [ ! -f $TMP_HASH_FILE ]; then
     if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Missing Hash File!' \
-      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time,\nselect Yes to update your list of checksums.\n\nOtherwise this could indicate a compromise\nand you should select No to return to the main menu.\n\nWould you like to update your checksums now?" 30 80) then
+      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time,\nselect Yes to update your list of checksums.\n\nOtherwise this could indicate a compromise\nand you should select No to return to the main menu.\n\nWould you like to update your checksums now?" 30 90) then
       update_checksums
     fi
     return 1
@@ -53,7 +53,7 @@ verify_global_hashes()
       TEXT="The following files failed the verification process:\n${CHANGED_FILES}\n\nThis could indicate a compromise!\n\nWould you like to update your checksums now?"
     fi
 
-    if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 30 80) then
+    if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 30 90) then
       update_checksums
     fi
     return 1
@@ -62,7 +62,7 @@ verify_global_hashes()
 update_checksums()
 {
   if (whiptail --title 'Update Checksums and sign all files in /boot' \
-      --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that the files in /boot have not been tampered with.\n\nYou will need your GPG key to continue and this change will modify your disk.\n\nDo you want to continue?" 16 80) then
+      --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that the files in /boot have not been tampered with.\n\nYou will need your GPG key to continue and this change will modify your disk.\n\nDo you want to continue?" 16 90) then
     mount_boot
     mount -o rw,remount /boot
 
@@ -105,7 +105,7 @@ while true; do
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS,\nyou will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
+        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS,\nyou will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 90 4 \
         'g' ' Generate new TOTP secret' \
         'i' ' Ignore error and continue to default boot menu' \
         'p' ' Reset the TPM' \
@@ -118,7 +118,7 @@ while true; do
 
   if [ "$totp_confirm" = "i" -o -z "$totp_confirm" ]; then 
     whiptail --clear --title "$CONFIG_BOOT_GUI_MENU_NAME" \
-      --menu "$date\nTOTP code: $TOTP" 20 80 10 \
+      --menu "$date\nTOTP code: $TOTP" 20 90 10 \
       'y' ' Default boot' \
       'r' ' TOTP does not match, refresh code' \
       'n' ' TOTP does not match after refresh, troubleshoot' \
@@ -132,7 +132,7 @@ while true; do
 
   if [ "$totp_confirm" = "o" ]; then
     whiptail --clear --title "Other Boot Options" \
-      --menu "Select A Boot Option" 20 80 10 \
+      --menu "Select A Boot Option" 20 90 10 \
       'm' ' Show OS boot menu' \
       'u' ' USB boot' \
       'i' ' Ignore tampering and force a boot (Unsafe!)' \
@@ -144,7 +144,7 @@ while true; do
 
   if [ "$totp_confirm" = "a" ]; then
     whiptail --clear --title "Advanced Settings" \
-      --menu "Configure Advanced Settings" 20 80 10 \
+      --menu "Configure Advanced Settings" 20 90 10 \
       'g' ' Generate new TOTP secret' \
       'p' ' Reset the TPM' \
       's' ' Update checksums and sign all files in /boot' \
@@ -164,7 +164,7 @@ while true; do
 
   if [ "$totp_confirm" = "n" ]; then
     if (whiptail $CONFIG_WARNING_BG_COLOR --title "TOTP code mismatched" \
-      --yesno "TOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s HH:MM:SS'\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 30 80) then
+      --yesno "TOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s HH:MM:SS'\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 30 90) then
       echo ""
       echo "To correct clock drift: 'date -s HH:MM:SS'"
       echo "and save it to the RTC: 'hwclock -w'"
@@ -183,7 +183,7 @@ while true; do
 
   if [ "$totp_confirm" = "g" ]; then
     if (whiptail --title 'Generate new TOTP secret' \
-        --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 16 80) then
+        --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 16 90) then
       echo "Scan the QR code to add the new TOTP secret"
       /bin/seal-totp
       echo "Once you have scanned the QR code, hit Enter to reboot"
@@ -197,7 +197,7 @@ while true; do
 
   if [ "$totp_confirm" = "p" ]; then
     if (whiptail --title 'Reset the TPM' \
-        --yesno "This will clear the TPM, erase the old TPM password and replace it with a new one!\n\nDo you want to proceed?" 16 80) then
+        --yesno "This will clear the TPM, erase the old TPM password and replace it with a new one!\n\nDo you want to proceed?" 16 90) then
       /bin/tpm-reset
 
       # now that the TPM is reset, remove invalid kexec_rollback.txt file
@@ -231,7 +231,7 @@ while true; do
   if [ "$totp_confirm" = "i" ]; then
     # Run the menu selection in "force" mode, bypassing hash checks
     if (whiptail $CONFIG_WARNING_BG_COLOR --title 'Unsafe Forced Boot Selected!' \
-        --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 16 80) then
+        --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 16 90) then
       mount_boot
       kexec-select-boot -m -b /boot -c "grub.cfg" -g -f
     else
@@ -258,7 +258,7 @@ while true; do
       || recovery "Failed default boot"
     else
       if (whiptail --title 'No Default Boot Option Configured' \
-          --yesno "There is no default boot option configured yet.\nWould you like to load a menu of boot options?\nOtherwise you will return to the main menu." 16 80) then
+          --yesno "There is no default boot option configured yet.\nWould you like to load a menu of boot options?\nOtherwise you will return to the main menu." 16 90) then
         kexec-select-boot -m -b /boot -c "grub.cfg" -g
       else
         echo "Returning to the main menu"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -26,7 +26,7 @@ verify_global_hashes()
     return 0
   elif [ ! -f $TMP_HASH_FILE ]; then
     if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Missing Hash File!' \
-      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time, select Yes to update your list of checksums.\n\nOtherwise this could indicate a compromise and you should select No to return to the main menu.\n\nWould you like to update your checksums now?" 30 80) then
+      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time,\nselect Yes to update your list of checksums.\n\nOtherwise this could indicate a compromise\nand you should select No to return to the main menu.\n\nWould you like to update your checksums now?" 30 80) then
       update_checksums
     fi
     return 1
@@ -36,7 +36,7 @@ verify_global_hashes()
     # if files changed before package manager started, show stern warning
     if [ -f "$TMP_PACKAGE_TRIGGER_PRE" ]; then 
       PRE_CHANGED_FILES=$(grep '^CHANGED_FILES' $TMP_PACKAGE_TRIGGER_POST | cut -f 2 -d '=' | tr -d '"')
-      TEXT="The OS logged that the following files failed the verification process BEFORE package updates ran:\n${PRE_CHANGED_FILES}\n\nCompare against the files Heads has detected have changed:\n${CHANGED_FILES}\n\nThis could indicate a compromise!\n\nWould you like to update your checksums anyway?"
+      TEXT="The following files failed the verification process BEFORE package updates ran:\n${PRE_CHANGED_FILES}\n\nCompare against the files Heads has detected have changed:\n${CHANGED_FILES}\n\nThis could indicate a compromise!\n\nWould you like to update your checksums anyway?"
 
     # if files changed after package manager started, probably caused by package manager
     elif [ -f "$TMP_PACKAGE_TRIGGER_POST" ]; then 
@@ -105,7 +105,7 @@ while true; do
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS, you will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted, you should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
+        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS, you will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
         'g' ' Generate new TOTP secret' \
         'i' ' Ignore error and continue to default boot menu' \
         'p' ' Reset the TPM' \
@@ -258,7 +258,7 @@ while true; do
       || recovery "Failed default boot"
     else
       if (whiptail --title 'No Default Boot Option Configured' \
-          --yesno "There is no default boot option configured yet. Would you like to load a menu of boot options? Otherwise you will return to the main menu." 16 80) then
+          --yesno "There is no default boot option configured yet.\nWould you like to load a menu of boot options?\nOtherwise you will return to the main menu." 16 80) then
         kexec-select-boot -m -b /boot -c "grub.cfg" -g
       else
         echo "Returning to the main menu"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -105,7 +105,7 @@ while true; do
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS, you will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
+        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS,\nyou will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 80 4 \
         'g' ' Generate new TOTP secret' \
         'i' ' Ignore error and continue to default boot menu' \
         'p' ' Reset the TPM' \

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -26,7 +26,7 @@ verify_global_hashes()
     return 0
   elif [ ! -f $TMP_HASH_FILE ]; then
     if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Missing Hash File!' \
-      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time,\nselect Yes to update your list of checksums.\n\nOtherwise this could indicate a compromise\nand you should select No to return to the main menu.\n\nWould you like to update your checksums now?" 30 90) then
+      --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time, select Yes to update\nyour list of checksums.\n\nOtherwise this could indicate a compromise and you should select No to\nreturn to the main menu.\n\nWould you like to update your checksums now?" 30 90) then
       update_checksums
     fi
     return 1
@@ -105,7 +105,7 @@ while true; do
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you have just reflashed your BIOS,\nyou will need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted,\nyou should reset the TPM and set your own password\n\nHow would you like to proceed?" 30 90 4 \
+        --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf you just reflashed your BIOS, you'll need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nIf this is the first time the system has booted, you should reset the TPM\nand set your own password\n\nHow would you like to proceed?" 30 90 4 \
         'g' ' Generate new TOTP secret' \
         'i' ' Ignore error and continue to default boot menu' \
         'p' ' Reset the TPM' \


### PR DESCRIPTION
While the whiptail program wraps text appropriately based on column
size, the fbwhiptail program doesn't, leading to text that scrolls off
the window where it can no longer be read. This change wraps the longer
text output so it all fits.