### PR TITLE
Add boot devices to qemu-coreboot

### DIFF
--- a/boards/qemu-coreboot/qemu-coreboot.config
+++ b/boards/qemu-coreboot/qemu-coreboot.config
@@ -32,6 +32,7 @@ export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_TPM=n
 
 export CONFIG_BOOT_DEV="/dev/sda1"
+export CONFIG_USB_BOOT_DEV="/dev/sdb1"
 
 #run: coreboot.intermediate
 run:

--- a/boards/qemu-coreboot/qemu-coreboot.config
+++ b/boards/qemu-coreboot/qemu-coreboot.config
@@ -31,6 +31,8 @@ CONFIG_LINUX_E1000=y
 export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_TPM=n
 
+export CONFIG_BOOT_DEV="/dev/sda1"
+
 #run: coreboot.intermediate
 run:
 	qemu-system-x86_64 \


### PR DESCRIPTION
Configure `/dev/sda1` and `/dev/sdb1` for QEMU with coreboot.