### PR TITLE
x230: remove 4M and 8M split-images from the build

### DIFF
--- a/boards/x230/x230.config
+++ b/boards/x230/x230.config
@@ -33,14 +33,6 @@ export CONFIG_USB_BOOT_DEV="/dev/sdb1"
 # the ME image and part of the coreboot image, and a 4 MB one that
 # has the rest of the coreboot and the reset vector.
 #
-# When flashing via an external programmer it is easiest to have
-# to separate files for these pieces.
-all: $(build)/$(BOARD)/$(BOARD)-8.rom
-$(build)/$(BOARD)/$(BOARD)-8.rom: $(build)/$(BOARD)/coreboot.rom
-	$(call do,DD 8MB,$@,dd of=$@ if=$< bs=65536 count=128 skip=0 status=none)
-	@sha256sum $@
-
-all: $(build)/$(BOARD)/$(BOARD)-4.rom
-$(build)/$(BOARD)/$(BOARD)-4.rom: $(build)/$(BOARD)/coreboot.rom
-	$(call do,DD 4MB,$@,dd of=$@ if=$< bs=65536 count=64 skip=128 status=none)
-	@sha256sum $@
+# Only flashing to the bios region is safe to do. The easiest is to
+# flash internally when the IFD is unlocked for writing, and x230-flash
+# is installed first.


### PR DESCRIPTION
The bios regions of the 12M coreboot image is 7M: 4M and 3 of the 8M split
image. The rest of the 8M image _generated_ with fake data and not usable
on real systems! It's dangerous to create them and suggest flashing them
externally.

That's exactly why the x230-flash build target is there: To
have a self-contained 4M image and enable easy unlocking of the 8M image
using the _original_ data.

the heads-wiki project is updated accordingly.

Closes #307
Closes #302