### PR TITLE
Typo correction in .ash_history

### DIFF
--- a/initrd/.ash_history
+++ b/initrd/.ash_history
@@ -1,8 +1,7 @@
 mount /dev/sda1 /boot
 mount -o remount,rw /boot
 rm /boot/kexec_*
-usb-scan
-mount -o rw $CONFIG_USB_BOOT_DEV /media
+mount-usb
 mkdir -p /media/gpg_keys
 gpg --home=/media/gpg_keys --card-edit
 gpg --home=/media/gpg_keys --export --armor e@mail.address > /media/gpg_keys/public.key

--- a/initrd/.ash_history
+++ b/initrd/.ash_history
@@ -3,8 +3,8 @@ mount -o remount,rw /boot
 rm /boot/kexec_*
 usb-scan
 mount -o rw $CONFIG_USB_BOOT_DEV /media
-mkdir /media/gpg_keys
-gpg --home=/media/gpg_keys --edit-card
+mkdir -p /media/gpg_keys
+gpg --home=/media/gpg_keys --card-edit
 gpg --home=/media/gpg_keys --export --armor e@mail.address > /media/gpg_keys/public.key
 gpg --home=/media/gpg_keys --export-secret-keys --armor e@mail.address > /media/gpg_keys/private.key
 cbfs -o /media/coreboot.rom -a "heads/initrd/.gnupg/keys/public.key" -f /media/gpg_keys/public.key


### PR DESCRIPTION
Corrected gpg command needed to generate keys inside of smartcard, fix creation of directory only if not already existing.

An [alternative](https://sorenpoulsen.com/securing-gnupg-keys-on-a-nitrokey-pro) would be to generate keys offline and move the private keys, or only subkeys, to the smartcard, as per user's workflow and smartcard other usages.

