### PR TITLE
Adding cryptsetup-reencrypt support. First step into getting OEM predeployed QubesOS machines

### DIFF
--- a/modules/cryptsetup
+++ b/modules/cryptsetup
@@ -15,6 +15,7 @@ cryptsetup_configure := ./configure \
 	--host i386-elf-linux \
 	--prefix "/" \
 	--disable-gcrypt-pbkdf2 \
+	--enable-cryptsetup-reencrypt \
 	--with-crypto_backend=kernel \
 
 # but after building, replace prefix so that they will be installed
@@ -28,6 +29,7 @@ cryptsetup_target := \
 
 cryptsetup_output := \
 	src/.libs/cryptsetup \
+	src/.libs/cryptsetup-reencrypt \
 	src/.libs/veritysetup \
 
 cryptsetup_libraries := \


### PR DESCRIPTION
This addition permits deployment of customized OEM shipped QubesOS deployments.

The idea behind this is to be able to deploy preinstalled QubesOS trusthworthy machines and permit remote support over them on demand. This is an attempt to relaunch the idea behind [QubesOS librem OEM install disk](https://github.com/marmarek/qubes-installer-qubes-os/tree/r3.2-librem), but this time, including the deployment of a second AdminVM, permitting remote management, by a third party, on demand, through a tor hidden service. This onion hidden service is only available to remote management when both hidden hostname and attached public key are shared, and can be revoked at any time, while the AdminVM needs to be launched to permit remote management as a whole, leaving the user able to bypass and control that AdminVM deployments through dom0, on which the user controls everything. The Admin is an helper, not a complete machine owner: the user is the only one being truely in control of the system the whole time.

To do so, that second[ AdminVM, remotely SSH manageable through an hidden tor service](https://github.com/SkypLabs/my-qubes-os-formula/issues/6#issue-364582625) would permit [ additional persona deployments](https://github.com/QubesOS/qubes-issues/issues/1906#issuecomment-273124156) through customized salt recipes.

The actual unresolved problem with OEM deploying QubesOS offline and not before user's eyes is that [the user doesn't own his LUKS encrypted volume with](https://github.com/QubesOS/qubes-issues/issues/1906#issuecomment-422142622) delivered laptop. By using cryptsetup-reencrypt through Heads, the volume is reencrypted with user's keys upon reception and denies OEM responsibility of knowing LUKS original encryption key.

Even with [SSD deleted pool related risks](https://www.saout.de/pipermail/dm-crypt/2013-June/003390.html), the only data previously written to disk with precedent encryption key would be templates and base VMs deployements being deleted (deleted pools), so there is no real risks. **Reencrypting a 240GB SSD drive takes 25 minutes from the user to really own his laptop, which IMHO is not a real problem considering the gains.**

Heads' advanced menu could now include an option to reencrypt the LUKS encrypted volume. 


The use case this fits in is:
OEM preparation of laptop and LibremKey/Nitrokey Pro V2:
- Possibility to create a QubesOS OEM disk images that would deploy  remote-mgmt-AdminVM (basic idea [here](https://github.com/SkypLabs/my-qubes-os-formula/issues/6#issue-364582625)) which would replace  [QubesOS librem OEM install disk](https://github.com/marmarek/qubes-installer-qubes-os/tree/r3.2-librem)
- Possibility for the OEM to clone that resulting QubesOS disk to other machines disks without security risks.
- Flash Heads on hardware, including [GPG2 support](https://github.com/osresearch/heads/pull/454).
- LibremKey/Nitrokey Pro 2 is paired with laptop for measured boot firmware and boot integrity attestation.
- LibremKey/Nitrokey Pro 2 and laptops are shipped in different packages/different shippers to client

Client ownership:
- Client boots received hardware with received Librem/Nitrokey Pro 2 connected.
- Client validates attested integrity (green lights on the LibremKey/Nitrokey) and then owns his Librem/Nitrokey Pro 2 GPG smartcard from within Heads recovery. He generates/import his keys with the help of GPG2 from the Heads recovery, once.
- Client reencrypts his LUKS encrypted volume with his own passphrase, from Heads recovery, once.
- Client owns hardware TPM, signs his configs with his LibremKey/Nitrokey Pro v2, sets a default boot entry and defines a boot TPM bound decryption key into LUKS slot 1 through Heads enrollment ([when fixed and merged](https://github.com/osresearch/heads/pull/426#issuecomment-418136881))
- Client boots default config, changes his QubesOS user password from within QubesOS, once.

Client support:
- Client in need fires up remote-mgmt-AdminVM on demand/at boot and asks for support to his OEM through predefined support channels.

Client is happy with his trustworty hardware and is feeling supported if in need.