### PR TITLE
fix the fbwhiptail source URL

### DIFF
--- a/modules/fbwhiptail
+++ b/modules/fbwhiptail
@@ -4,7 +4,7 @@ fbwhiptail_depends := cairo $(musl_dep)
 
 fbwhiptail_version := git
 fbwhiptail_dir := fbwhiptail
-fbwhiptail_repo := https://code.puri.sm/kakaroto/fbwhiptail.git
+fbwhiptail_repo := https://source.puri.sm/coreboot/fbwhiptail.git
 
 fbwhiptail_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
The current source URL is not available anymore.

kakaroto changed his copy of heads to point to his own github account's fbwhiptail:
https://github.com/kakaroto/heads/commit/b13cc5e68d9d77ef9bfd6623b812f4205698dafb

But it seems that source.puri.sm/coreboot is a more accessible home for the
project.