### PR TITLE
fix install directory handling for git and builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ config/*.old
 *.log
 *~
 crossgcc
-install
 clean
 *.map
 *.sec

--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,7 @@ real.clean:
 			rm -rf "build/$$dir"; \
 		fi; \
 	done
-	rm -rf ./install
+	cd install && rm -rf -- *
 
 
 else


### PR DESCRIPTION
The install directly should basically behave like the "build" directory.
Since it's tracked by git, containing a gitignore file, we shouldn't
have it in the toplevel gitignore (just like the build directory).

But then, the toplevel Makefile's real.clean target removes the install
directory. This is changed so that only it's content is being removed.