### PR TITLE
GPG trustdb export from .ash_history and import in key-init

### DIFF
--- a/initrd/.ash_history
+++ b/initrd/.ash_history
@@ -1,14 +1,17 @@
-mount /dev/sda1 /boot
-mount -o remount,rw /boot
-rm /boot/kexec_*
-mount-usb
-mkdir -p /media/gpg_keys
-gpg --home=/media/gpg_keys --card-edit
-gpg --home=/media/gpg_keys --export --armor e@mail.address > /media/gpg_keys/public.key
-gpg --home=/media/gpg_keys --export-secret-keys --armor e@mail.address > /media/gpg_keys/private.key
-cbfs -o /media/coreboot.rom -a "heads/initrd/.gnupg/keys/public.key" -f /media/gpg_keys/public.key
-cbfs -o /media/coreboot.rom -a "heads/initrd/.gnupg/keys/private.key" -f /media/gpg_keys/private.key
-mount -o remount,ro /media
-flash.sh /media/coreboot.com
+#remove invalid kexec_* signed files
+mount /dev/sda1 /boot && mount -o remount,rw /boot && rm /boot/kexec* && mount -o remount,ro /boot
+#Generate keys from GPG smartcard: 
+mount-usb && gpg --home=/.gnupg/ --card-edit
+#Copy generated public key, private_subkey, trustdb and artifacts to external media for backup: 
+mount -o remount,rw /media && mkdir -p /media/gpg_keys; gpg --export-secret-keys --armor email@address.com > /media/gpg_keys/private.key && gpg --export --armor email@address.com  > /media/gpg_keys/public.key && gpg --export-ownertrust > /media/gpg_keys/otrust.txt && cp -r ./.gnupg/* /media/gpg_keys/ 2> /dev/null
+#Insert public key and trustdb export into reproducible rom:
+cbfs -o /media/coreboot.rom -a "heads/initrd/.gnupg/keys/public.key" -f /media/gpg_keys/public.key && cbfs -o /media/coreboot.rom -a "heads/initrd/.gnupg/keys/otrust.txt" -f /media/gpg_keys/otrust.txt
+#Flush changes to external media: 
+mount -o,remount ro /media
+#Flash modified reproducible rom with inserted public key and trustdb export from precedent step. Flushes actual rom's keys (-c: clean):
+flash.sh -c /media/coreboot.rom
+#Attest integrity of firmware as it is
+seal-totp
+#Verify Intel ME state:
 cbmem --console | grep '^ME'
 cbmem --console | less

--- a/initrd/bin/key-init
+++ b/initrd/bin/key-init
@@ -5,7 +5,12 @@ set -e -o pipefail
 # Post processing of keys
 
 # Import user's keys
-gpg --import /.gnupg/keys/* 2>/dev/null || true
+gpg --import /.gnupg/keys/*.key 2>/dev/null || true
+
+#Import trustdb if it exists
+if [ -s /.gnupg/keys/otrust.txt ]; then
+  gpg --import-ownertrust /.gnupg/keys/otrust.txt
+fi
 
 # Import trusted distro keys allowed for ISO signing
 gpg --homedir=/etc/distro/ --import /etc/distro/keys/* 2>/dev/null || true


### PR DESCRIPTION
Add support for trustdb after upgraded command history to export it at key generation, so that the signing key is trusted and heads doesn't complain about it.
