### PR TITLE
Set GPG_TTY before calling gpg in key-init

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -5,9 +5,6 @@ echo "hello world" > /dev/ttyprintk
 # Setup our path
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 
-#export GPG_TTY STATICALLY (NEED TO FIX)
-export GPG_TTY=/dev/console
-
 # This is the very first script invoked by the Linux kernel and is
 # running out of the ram disk.  There are no fileysstems mounted.
 # It is important to have a way to invoke a recovery shell in case
@@ -60,6 +57,10 @@ fi
 if [ "$CONFIG_LINUXBOOT" = "y" ]; then
 	/bin/uefi-init
 fi
+
+# Set GPG_TTY before calling gpg in key-init
+export GPG_TTY=$(tty)
+
 /bin/key-init
 
 # Setup recovery serial shell


### PR DESCRIPTION
Cherry-pick of @jandryuk to merge atop osresearch/gpg2 branch:

> 
> gpg2 needs GPG_TTY set to function properly.  We set it in /init so it
> is inherited by all children.  The call to $(tty) must be after /dev and
> (preferably) /dev/pts are mounted.
> 
> Signed-off-by: Jason Andryuk <jandryuk@gmail.com>