### PR TITLE
Use the Librem Key as a TPM work-alike in the absence of a TPM

### DIFF
--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -37,7 +37,7 @@ flash_rom() {
       die "$ROM: Read inconsistent"
     fi
   elif [ "$SHA" -eq 1 ]; then
-    flashrom $FLASHROM_OPTIONS -r "${ROM}" 2>/dev/null \
+    flashrom $FLASHROM_OPTIONS -r "${ROM}" 1&>2 >/dev/null \
     || die "$ROM: Read failed"
     sha256sum ${ROM} | cut -f1 -d ' '
   else
@@ -69,6 +69,7 @@ elif [ "$1" == "-s" ]; then
   READ=0
   SHA=1
   ROM="$2"
+  touch $ROM
 else
   CLEAN=0
   READ=0

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -36,6 +36,10 @@ flash_rom() {
     else
       die "$ROM: Read inconsistent"
     fi
+  elif [ "$SHA" -eq 1 ]; then
+    flashrom $FLASHROM_OPTIONS -r "${ROM}" 2>/dev/null \
+    || die "$ROM: Read failed"
+    sha256sum ${ROM} | cut -f1 -d ' '
   else
     cp "$ROM" /tmp/${CONFIG_BOARD}.rom
     sha256sum /tmp/${CONFIG_BOARD}.rom
@@ -52,20 +56,28 @@ flash_rom() {
 if [ "$1" == "-c" ]; then
   CLEAN=1
   READ=0
+  SHA=0
   ROM="$2"
 elif [ "$1" == "-r" ]; then
   CLEAN=0
   READ=1
+  SHA=0
   ROM="$2"
   touch $ROM
+elif [ "$1" == "-s" ]; then
+  CLEAN=0
+  READ=0
+  SHA=1
+  ROM="$2"
 else
   CLEAN=0
   READ=0
+  SHA=0
   ROM="$1"
 fi
 
 if [ ! -e "$ROM" ]; then
-	die "Usage: $0 [-c|-r] <path_to_image.rom>"
+	die "Usage: $0 [-c|-r|-s] <path_to_image.rom>"
 fi
 
 flash_rom $ROM

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -31,8 +31,9 @@ if [ "$CONFIG_TPM" = "y" ]; then
 
   rm -f "$HOTP_SEALED"
 else
-# without a TPM, use the first 19 characters of the ROM SHA256sum 
-  flash.sh -s /tmp/coreboot.rom | cut -c 1-19 > $HOTP_SECRET
+# without a TPM, use the first 20 characters of the ROM SHA256sum 
+  echo "TPM not configured, measuring ROM directly"
+  flash.sh -s /tmp/coreboot.rom | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
 fi
 
 secret="`cat $HOTP_SECRET`"

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -16,19 +16,25 @@ mount_boot()
   fi
 }
 
-tpm nv_readvalue \
-	-in 4d47 \
-	-sz 312 \
-	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
+if [ "$CONFIG_TPM" = "y" ]; then
+  tpm nv_readvalue \
+    -in 4d47 \
+    -sz 312 \
+    -of "$HOTP_SEALED" \
+  || die "Unable to retrieve sealed file from TPM NV"
 
-tpm unsealfile  \
-	-hk 40000000 \
-	-if "$HOTP_SEALED" \
-	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
+  tpm unsealfile  \
+    -hk 40000000 \
+    -if "$HOTP_SEALED" \
+    -of "$HOTP_SECRET" \
+  || die "Unable to unseal HOTP secret"
 
-rm -f "$HOTP_SEALED"
+  rm -f "$HOTP_SEALED"
+else
+# without a TPM, use the first 19 characters of the ROM SHA256sum 
+  flash.sh -s /tmp/coreboot.rom | cut -c 1-19 > $HOTP_SECRET
+fi
+
 secret="`cat $HOTP_SECRET`"
 rm -f "$HOTP_SECRET"
 

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -17,35 +17,36 @@ fi
 TOTP_SECRET="/tmp/secret/totp.key"
 TOTP_SEALED="/tmp/secret/totp.sealed"
 
-dd \
-	if=/dev/urandom \
-	of="$TOTP_SECRET" \
-	count=1 \
-	bs=20 \
-	2>/dev/null \
-|| die "Unable to generate 20 random bytes"
+if [ "$CONFIG_TPM" = "y" ]; then
+  dd \
+    if=/dev/urandom \
+    of="$TOTP_SECRET" \
+    count=1 \
+    bs=20 \
+    2>/dev/null \
+  || die "Unable to generate 20 random bytes"
 
-secret="`base32 < $TOTP_SECRET`"
+  secret="`base32 < $TOTP_SECRET`"
 
 # Use the current values of the PCRs, which will be read
 # from the TPM as part of the sealing ("X").
 # PCR4 == 0 means that we are still in the boot process and
 # not a recovery shell.
 # should this read the storage root key?
-if ! tpm sealfile2 \
-	-if "$TOTP_SECRET" \
-	-of "$TOTP_SEALED" \
-	-hk 40000000 \
-	-ix 0 X \
-	-ix 1 X \
-	-ix 2 X \
-	-ix 3 X \
-	-ix 4 0000000000000000000000000000000000000000 \
-	-ix 7 X \
-; then
-	rm -f "$TOTP_SECRET"
-	 die "Unable to seal secret"
-fi
+  if ! tpm sealfile2 \
+    -if "$TOTP_SECRET" \
+    -of "$TOTP_SEALED" \
+    -hk 40000000 \
+    -ix 0 X \
+    -ix 1 X \
+    -ix 2 X \
+    -ix 3 X \
+    -ix 4 0000000000000000000000000000000000000000 \
+    -ix 7 X \
+  ; then
+    rm -f "$TOTP_SECRET"
+     die "Unable to seal secret"
+  fi
 
 
 # to create an nvram space we need the TPM owner password
@@ -53,33 +54,40 @@ fi
 #
 # The permissions are 0 since there is nothing special
 # about the sealed file
-tpm physicalpresence -s \
-|| warn "Warning: Unable to assert physical presence"
+  tpm physicalpresence -s \
+  || warn "Warning: Unable to assert physical presence"
 
 # Try to write it without the password first, and then create
 # the NVRAM space using the owner password if it fails for some reason.
-if ! tpm nv_writevalue \
-	-in $TPM_NVRAM_SPACE \
-	-if "$TOTP_SEALED" \
-; then
-	warn 'NVRAM space does not exist? Owner password is required'
-	read -s -p "TPM Owner password: " tpm_password
-	echo
+  if ! tpm nv_writevalue \
+    -in $TPM_NVRAM_SPACE \
+    -if "$TOTP_SEALED" \
+  ; then
+    warn 'NVRAM space does not exist? Owner password is required'
+    read -s -p "TPM Owner password: " tpm_password
+    echo
 
-	tpm nv_definespace \
-		-in $TPM_NVRAM_SPACE \
-		-sz 312 \
-		-pwdo "$tpm_password" \
-		-per 0 \
-	|| die "Unable to define NVRAM space"
+    tpm nv_definespace \
+      -in $TPM_NVRAM_SPACE \
+      -sz 312 \
+      -pwdo "$tpm_password" \
+      -per 0 \
+    || die "Unable to define NVRAM space"
 
-	tpm nv_writevalue \
-		-in $TPM_NVRAM_SPACE \
-		-if "$TOTP_SEALED" \
-	|| die "Unable to write sealed secret to NVRAM"
+    tpm nv_writevalue \
+      -in $TPM_NVRAM_SPACE \
+      -if "$TOTP_SEALED" \
+    || die "Unable to write sealed secret to NVRAM"
+  fi
+
+  rm -f "$TOTP_SEALED"
+else
+# without a TPM, use the first 20 characters of the ROM SHA256sum 
+  echo "TPM not configured, measuring ROM directly"
+  flash.sh -s /tmp/coreboot.rom | cut -c 1-20 | tr -d '\n' > $TOTP_SECRET
+  secret="`base32 < $TOTP_SECRET`"
+  rm -f $TOTP_SECRET
 fi
-
-rm -f "$TOTP_SEALED"
 
 url="otpauth://totp/$HOST?secret=$secret"
 secret=""

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -32,7 +32,7 @@ if [ "$CONFIG_TPM" = "y" ]; then
   rm -f "$HOTP_SEALED"
 else
 # without a TPM, use the first 20 characters of the ROM SHA256sum 
-  echo "TPM not configured, measuring ROM directly"
+  echo "TPM not configured, measuring ROM directly" 1>&2
   flash.sh -s /tmp/coreboot.rom | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
 fi
 

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -6,6 +6,7 @@
 HOTP_SEALED="/tmp/secret/hotp.sealed"
 HOTP_SECRET="/tmp/secret/hotp.key"
 HOTP_COUNTER="/boot/kexec_hotp_counter"
+ROM_IMAGE="/tmp/coreboot-notpm.rom"
 
 mount_boot()
 {
@@ -33,7 +34,12 @@ if [ "$CONFIG_TPM" = "y" ]; then
 else
 # without a TPM, use the first 20 characters of the ROM SHA256sum 
   echo "TPM not configured, measuring ROM directly" 1>&2
-  flash.sh -s /tmp/coreboot.rom | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
+  # use a previously-copied image if it exists
+  if [ -f ${ROM_IMAGE} ]; then
+    sha256sum ${ROM_IMAGE} | cut -f1 -d ' ' | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
+  else
+    flash.sh -s ${ROM_IMAGE} | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
+  fi
 fi
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -31,8 +31,9 @@ if [ "$CONFIG_TPM" = "y" ]; then
 
   rm -f "$HOTP_SEALED"
 else
-# without a TPM, use the first 19 characters of the ROM SHA256sum 
-  flash.sh -s /tmp/coreboot.rom | cut -c 1-19 > $HOTP_SECRET
+# without a TPM, use the first 20 characters of the ROM SHA256sum 
+  echo "TPM not configured, measuring ROM directly"
+  flash.sh -s /tmp/coreboot.rom | cut -c 1-20 | tr -d '\n' > $HOTP_SECRET
 fi
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -16,19 +16,24 @@ mount_boot()
   fi
 }
 
-tpm nv_readvalue \
-	-in 4d47 \
-	-sz 312 \
-	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
+if [ "$CONFIG_TPM" = "y" ]; then
+  tpm nv_readvalue \
+    -in 4d47 \
+    -sz 312 \
+    -of "$HOTP_SEALED" \
+  || die "Unable to retrieve sealed file from TPM NV"
 
-tpm unsealfile  \
-	-hk 40000000 \
-	-if "$HOTP_SEALED" \
-	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
+  tpm unsealfile  \
+    -hk 40000000 \
+    -if "$HOTP_SEALED" \
+    -of "$HOTP_SECRET" \
+  || die "Unable to unseal HOTP secret"
 
-rm -f "$HOTP_SEALED"
+  rm -f "$HOTP_SEALED"
+else
+# without a TPM, use the first 19 characters of the ROM SHA256sum 
+  flash.sh -s /tmp/coreboot.rom | cut -c 1-19 > $HOTP_SECRET
+fi
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots


### PR DESCRIPTION
On machines without a TPM, we'd still like some way for the BIOS to attest that it has not been modified. With a Librem Key, we can have the BIOS use its own ROM measurement converted to a SHA256sum and truncated so it fits within an HOTP secret. Like with a TPM, a malicious BIOS with access to the correct measurements can send pre-known good measurements to the Librem Key.
    
This approach provides one big drawback in that we have to truncate the SHA256sum to 20 characters so that it fits within the limitations of HOTP secrets. This means the possibility of collisions is much higher but again, an attacker could also capture and spoof an existing ROM's measurements if they have prior access to it, either with this approach or with a TPM.
