### PR TITLE
Add GUI to change /etc/config configuration options

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -67,7 +67,7 @@ while true; do
       exit 0
     ;;
     "b" )
-      CURRENT_OPTION=`grep 'CONFIG_BOOT_DEV=' /tmp/config | cut -f2 -d '=' | tr -d '"'`
+      CURRENT_OPTION=`grep 'CONFIG_BOOT_DEV=' /tmp/config | tail -n1 | cut -f2 -d '=' | tr -d '"'`
       find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose the default /boot device.\n\nCurrently set to $CURRENT_OPTION."
       if [ "$FILE" == "" ]; then
@@ -94,7 +94,7 @@ while true; do
         sleep 5
       fi
 
-      CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /tmp/config | cut -f2 -d '=' | tr -d '"'`
+      CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /tmp/config | tail -n1 | cut -f2 -d '=' | tr -d '"'`
       find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."
       if [ "$FILE" == "" ]; then

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -85,7 +85,15 @@ while true; do
     "u" )
       whiptail --title 'Insert a USB thumb drive' \
         --msgbox "Insert a USB thumb drive so we can detect the device" 16 60
-      mount-usb
+
+      enable_usb
+
+      if ! lsmod | grep -q usb_storage; then
+        insmod /lib/modules/usb-storage.ko \
+        || die "usb_storage: module load failed"
+        sleep 5
+      fi
+
       CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /tmp/config | cut -f2 -d '=' | tr -d '"'`
       find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -91,6 +91,9 @@ while true; do
         --msgbox "The /boot device was successfully changed to $SELECTED_FILE" 16 60
     ;;
     "u" )
+      whiptail --title 'Insert a USB thumb drive' \
+        --msgbox "Insert a USB thumb drive so we can detect the device" 16 60
+      enable_usb
       CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /etc/config | cut -f2 -d '=' | tr -d '"'`
       find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."
@@ -123,7 +126,6 @@ while true; do
         /bin/flash.sh /tmp/config-gui.rom
         whiptail --title 'BIOS Updated Successfully' \
           --msgbox "BIOS updated successfully.\n\nIf your keys have changed, be sure to re-sign all files in /boot\nafter you reboot.\n\nPress Enter to reboot" 16 60
-        umount /media
         /bin/reboot
       else
         exit 0

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -93,7 +93,7 @@ while true; do
     "u" )
       whiptail --title 'Insert a USB thumb drive' \
         --msgbox "Insert a USB thumb drive so we can detect the device" 16 60
-      enable_usb
+      mount-usb
       CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /etc/config | cut -f2 -d '=' | tr -d '"'`
       find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -62,7 +62,7 @@ replace_config() {
 while true; do
   unset menu_choice
   whiptail --clear --title "Config Management Menu" \
-    --menu "This menu lets you change existing configuration options for the existing BIOS session.\n\nIf you want those changes to persist after reboot\n\nyou must also save them to the running BIOS." 20 90 10 \
+    --menu "This menu lets you change settings for the current BIOS session.\n\nAll changes will revert after a reboot,\n\nunless you also save them to the running BIOS." 20 90 10 \
     'b' ' Change the /boot device' \
     'u' ' Change the USB boot device' \
     's' ' Save the current configuration to the running BIOS' \

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+set -e -o pipefail
+. /etc/functions
+. /etc/config
+
+file_selector() {
+  FILE=""
+  FILE_LIST=$1
+  MENU_MSG=${2:-"Choose the file"}
+# create file menu options
+  if [ `cat "$FILE_LIST" | wc -l` -gt 0 ]; then
+    option=""
+    while [ -z "$option" ]
+    do
+      MENU_OPTIONS=""
+      n=0
+      while read option
+      do
+        n=`expr $n + 1`
+        option=$(echo $option | tr " " "_")
+        MENU_OPTIONS="$MENU_OPTIONS $n ${option}"
+      done < $FILE_LIST
+
+      MENU_OPTIONS="$MENU_OPTIONS a Abort"
+      whiptail --clear --title "Select your File" \
+        --menu "${MENU_MSG} [1-$n, a to abort]:" 20 120 8 \
+        -- $MENU_OPTIONS \
+        2>/tmp/whiptail || die "Aborting"
+
+      option_index=$(cat /tmp/whiptail)
+
+      if [ "$option_index" = "a" ]; then
+        option="a"
+        return
+      fi
+
+      option=`head -n $option_index $FILE_LIST | tail -1`
+      if [ "$option" == "a" ]; then
+        return
+      fi
+    done
+    if [ -n "$option" ]; then
+      FILE=$option
+    fi
+  else
+    whiptail $CONFIG_ERROR_BG_COLOR --title 'ERROR: No Files Found' \
+      --msgbox "No Files found matching the pattern. Aborting." 16 60
+    exit 1
+  fi
+}
+replace_config() {
+  CONFIG_OPTION=$1
+  NEW_SETTING=$2
+
+  awk "gsub(\"^export ${CONFIG_OPTION}=.*\",\"export ${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /etc/config > /tmp/config
+  awk "gsub(\"^${CONFIG_OPTION}=.*\",\"${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /etc/config >> /tmp/config
+  grep -v "^export ${CONFIG_OPTION}=" /etc/config | grep -v "^${CONFIG_OPTION}=" >> /tmp/config
+  mv /tmp/config /etc/config
+}
+
+while true; do
+  unset menu_choice
+  whiptail --clear --title "Config Management Menu" \
+    --menu "This menu lets you change existing configuration options for the existing BIOS session.\n\nIf you want those changes to persist after reboot\n\nyou must also save them to the running BIOS." 20 90 10 \
+    'b' ' Change the /boot device' \
+    'u' ' Change the USB boot device' \
+    's' ' Save the current configuration to the running BIOS' \
+    'x' ' Exit' \
+    2>/tmp/whiptail || recovery "GUI menu failed"
+
+  menu_choice=$(cat /tmp/whiptail)
+
+  case "$menu_choice" in
+    "x" )
+      exit 0
+    ;;
+    "b" )
+      CURRENT_OPTION=`grep 'CONFIG_BOOT_DEV=' /etc/config | cut -f2 -d '=' | tr -d '"'`
+      find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
+      file_selector "/tmp/filelist.txt" "Choose the default /boot device.\n\nCurrently set to $CURRENT_OPTION."
+      if [ "$FILE" == "" ]; then
+        return
+      else
+        SELECTED_FILE=$FILE
+      fi
+
+      replace_config "CONFIG_BOOT_DEV" "$SELECTED_FILE"
+
+      whiptail --title 'Config change successful' \
+        --msgbox "The /boot device was successfully changed to $SELECTED_FILE" 16 60
+    ;;
+    "u" )
+      CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /etc/config | cut -f2 -d '=' | tr -d '"'`
+      find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
+      file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."
+      if [ "$FILE" == "" ]; then
+        return
+      else
+        SELECTED_FILE=$FILE
+      fi
+
+      replace_config "CONFIG_USB_BOOT_DEV" "$SELECTED_FILE"
+
+      whiptail --title 'Config change successful' \
+        --msgbox "The USB boot device was successfully changed to $SELECTED_FILE" 16 60
+    ;;
+    "s" )
+      /bin/flash.sh -r /tmp/config-gui.rom
+      if [ ! -s /tmp/config-gui.rom ]; then
+        whiptail $CONFIG_ERROR_BG_COLOR --title 'ERROR: BIOS Read Failed!' \
+          --msgbox "Unable to read BIOS" 16 60
+        exit 1
+      fi
+
+      if (cbfs -o /tmp/config-gui.rom -l | grep -q "heads/initrd/etc/config") then
+        cbfs -o /tmp/config-gui.rom -d "heads/initrd/etc/config"
+      fi
+      cbfs -o /tmp/config-gui.rom -a "heads/initrd/etc/config" -f /etc/config
+
+      if (whiptail --title 'Update ROM?' \
+          --yesno "This will reflash your BIOS with the updated version\n\nDo you want to proceed?" 16 90) then
+        /bin/flash.sh /tmp/config-gui.rom
+        whiptail --title 'BIOS Updated Successfully' \
+          --msgbox "BIOS updated successfully.\n\nIf your keys have changed, be sure to re-sign all files in /boot\nafter you reboot.\n\nPress Enter to reboot" 16 60
+        umount /media
+        /bin/reboot
+      else
+        exit 0
+      fi
+    ;;
+  esac
+
+done
+exit 0

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -2,7 +2,7 @@
 #
 set -e -o pipefail
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 mount_usb(){
 # Mount the USB boot device

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -4,7 +4,7 @@
 #
 set -e -o pipefail
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 case "$CONFIG_BOARD" in
   librem* )

--- a/initrd/bin/generic-init
+++ b/initrd/bin/generic-init
@@ -2,7 +2,7 @@
 # Boot from a local disk installation
 
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 mount_boot()
 {

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -4,7 +4,7 @@
 CONFIG_BOOT_GUI_MENU_NAME='Heads Boot Menu'
 
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 mount_boot()
 {

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -183,6 +183,7 @@ while true; do
       --menu "Configure Advanced Settings" 20 90 10 \
       'g' ' Generate new TOTP/HOTP secret' \
       's' ' Update checksums and sign all files in /boot' \
+      'c' ' Change configuration settings -->' \
       'f' ' Flash/Update the BIOS -->' \
       'p' ' Reset the TPM' \
       'n' ' TOTP/HOTP does not match after refresh, troubleshoot' \
@@ -283,6 +284,11 @@ while true; do
 
   if [ "$totp_confirm" = "s" ]; then
     update_checksums
+    continue
+  fi
+
+  if [ "$totp_confirm" = "c" ]; then
+    config-gui.sh
     continue
   fi
 

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Launches kexec from saved configuration entries
 set -e -o pipefail
-. /etc/config
+. /tmp/config
 . /etc/functions
 
 dryrun="n"

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -2,7 +2,7 @@
 # Boot from signed ISO
 set -e -o pipefail
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 MOUNTED_ISO_PATH="$1"
 ISO_PATH="$2"

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Save these options to be the persistent default
 set -e -o pipefail
-. /etc/config
+. /tmp/config
 . /etc/functions
 
 while getopts "b:d:p:i:" arg; do

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -11,7 +11,7 @@ TPM_SEALED="/tmp/secret/secret.sealed"
 RECOVERY_KEY="/tmp/secret/recovery.key"
 
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 paramsdir=$1
 if [ -z "$paramsdir" ]; then

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Generic configurable boot script via kexec
 set -e -o pipefail
-. /etc/config
+. /tmp/config
 . /etc/functions
 
 add=""

--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Sign a valid directory of kexec params
 set -e -o pipefail
-. /etc/config
+. /tmp/config
 . /etc/functions
 
 rollback="n"

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -2,7 +2,7 @@
 # Boot a USB installation
 
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 if [ "$CONFIG_TPM" = "y" ]; then
 	# Extend PCR4 as soon as possible

--- a/initrd/bin/usb-scan
+++ b/initrd/bin/usb-scan
@@ -2,7 +2,7 @@
 # Scan for USB installation options
 set -e -o pipefail
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 # Unmount any previous boot device
 if grep -q /boot /proc/mounts ; then

--- a/initrd/bin/x230-flash.init
+++ b/initrd/bin/x230-flash.init
@@ -3,7 +3,7 @@
 # invoke a recovery shell and prompt the user for how to proceed
 
 . /etc/functions
-. /etc/config
+. /tmp/config
 
 insmod /lib/modules/ehci-hcd.ko
 insmod /lib/modules/ehci-pci.ko

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -233,5 +233,5 @@ replace_config() {
 	mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
 }
 combine_configs() {
-	sort /etc/config* | uniq > /tmp/config
+	cat /etc/config* > /tmp/config
 }

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -218,18 +218,19 @@ preserve_rom() {
 	done
 }
 replace_config() {
-  CONFIG_FILE=$1
-  CONFIG_OPTION=$2
-  NEW_SETTING=$3
+	CONFIG_FILE=$1
+	CONFIG_OPTION=$2
+	NEW_SETTING=$3
 
+	touch $CONFIG_FILE
 # first pull out the existing option from the global config and place in a tmp file
-  awk "gsub(\"^export ${CONFIG_OPTION}=.*\",\"export ${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config > ${CONFIG_FILE}.tmp
-  awk "gsub(\"^${CONFIG_OPTION}=.*\",\"${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config >> ${CONFIG_FILE}.tmp
+	awk "gsub(\"^export ${CONFIG_OPTION}=.*\",\"export ${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config > ${CONFIG_FILE}.tmp
+	awk "gsub(\"^${CONFIG_OPTION}=.*\",\"${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config >> ${CONFIG_FILE}.tmp
 
 # then copy any remaining settings from the existing config file, minus the option you changed
-  grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp
+	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp
 
-  mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
+	mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
 }
 combine_configs() {
 	sort /etc/config* | uniq > /tmp/config

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -17,6 +17,10 @@ recovery() {
 	# but recreate the directory so that new tools can use it.
 	rm -rf /tmp/secret
 	mkdir -p /tmp/secret
+
+	# ensure /tmp/config exists for recovery scripts that depend on it
+	touch /tmp/config
+
 	if [ "$CONFIG_TPM" = y ]; then
 		tpm extend -ix 4 -ic recovery
 	fi

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -229,8 +229,8 @@ replace_config() {
 
 # then copy any remaining settings from the existing config file, minus the option you changed
 	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp || true
-
-	mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
+  sort ${CONFIG_FILE}.tmp | uniq > ${CONFIG_FILE}
+	rm -f ${CONFIG_FILE}.tmp
 }
 combine_configs() {
 	cat /etc/config* > /tmp/config

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -217,3 +217,20 @@ preserve_rom() {
 		fi
 	done
 }
+replace_config() {
+  CONFIG_FILE=$1
+  CONFIG_OPTION=$2
+  NEW_SETTING=$3
+
+# first pull out the existing option from the global config and place in a tmp file
+  awk "gsub(\"^export ${CONFIG_OPTION}=.*\",\"export ${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config > ${CONFIG_FILE}.tmp
+  awk "gsub(\"^${CONFIG_OPTION}=.*\",\"${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config >> ${CONFIG_FILE}.tmp
+
+# then copy any remaining settings from the existing config file, minus the option you changed
+  grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp
+
+  mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
+}
+combine_configs() {
+	sort /etc/config* | uniq > /tmp/config
+}

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -228,7 +228,7 @@ replace_config() {
 	awk "gsub(\"^${CONFIG_OPTION}=.*\",\"${CONFIG_OPTION}=\\\"${NEW_SETTING}\\\"\")" /tmp/config >> ${CONFIG_FILE}.tmp
 
 # then copy any remaining settings from the existing config file, minus the option you changed
-	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp
+	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp || true
 
 	mv ${CONFIG_FILE}.tmp ${CONFIG_FILE}
 }

--- a/initrd/init
+++ b/initrd/init
@@ -49,18 +49,6 @@ if [ "$CONFIG_LINUXBOOT" = "y" ]; then
 	/bin/uefi-init
 fi
 
-combine_configs
-. /tmp/config
-
-# Add our boot devices into the /etc/fstab, if they are defined
-# in the configuration file.
-if [ ! -z "$CONFIG_BOOT_DEV" ]; then
-	echo >> /etc/fstab "$CONFIG_BOOT_DEV /boot auto defaults,ro 0 0"
-fi
-if [ ! -z "$CONFIG_USB_BOOT_DEV" ]; then
-	echo >> /etc/fstab "$CONFIG_USB_BOOT_DEV /media auto defaults,ro 0 0"
-fi
-
 /bin/key-init
 
 # Setup recovery serial shell
@@ -89,6 +77,18 @@ if [ "$boot_option" = "r" ]; then
 	fi
 	exec /bin/ash
 	exit
+fi
+
+combine_configs
+. /tmp/config
+
+# Add our boot devices into the /etc/fstab, if they are defined
+# in the configuration file.
+if [ ! -z "$CONFIG_BOOT_DEV" ]; then
+	echo >> /etc/fstab "$CONFIG_BOOT_DEV /boot auto defaults,ro 0 0"
+fi
+if [ ! -z "$CONFIG_USB_BOOT_DEV" ]; then
+	echo >> /etc/fstab "$CONFIG_USB_BOOT_DEV /media auto defaults,ro 0 0"
 fi
 
 if [ ! -x "$CONFIG_BOOTSCRIPT" -a ! -x "$CONFIG_BOOTSCRIPT_NETWORK" ]; then

--- a/initrd/init
+++ b/initrd/init
@@ -40,6 +40,15 @@ hwclock -l -s
 
 # Read the system configuration parameters
 . /etc/functions
+. /etc/config
+
+if [ "$CONFIG_COREBOOT" = "y" ]; then
+	/bin/cbfs-init
+fi
+if [ "$CONFIG_LINUXBOOT" = "y" ]; then
+	/bin/uefi-init
+fi
+
 combine_configs
 . /tmp/config
 
@@ -52,12 +61,6 @@ if [ ! -z "$CONFIG_USB_BOOT_DEV" ]; then
 	echo >> /etc/fstab "$CONFIG_USB_BOOT_DEV /media auto defaults,ro 0 0"
 fi
 
-if [ "$CONFIG_COREBOOT" = "y" ]; then
-	/bin/cbfs-init
-fi
-if [ "$CONFIG_LINUXBOOT" = "y" ]; then
-	/bin/uefi-init
-fi
 /bin/key-init
 
 # Setup recovery serial shell

--- a/initrd/init
+++ b/initrd/init
@@ -40,7 +40,8 @@ hwclock -l -s
 
 # Read the system configuration parameters
 . /etc/functions
-. /etc/config
+combine_configs
+. /tmp/config
 
 # Add our boot devices into the /etc/fstab, if they are defined
 # in the configuration file.


### PR DESCRIPTION
This change adds a config-gui.sh script that provides a GUI to change exported configuration options like you'd see in /etc/config. To protect against any future additions to /etc/config that this would otherwise overwrite, this change adds an additional /etc/config.user file that is intended to be stored in CBFS and at boot combines all /etc/config* files into /tmp/config. Existing scripts have been updated to source this new combined config file.

This script behaves much like on network hardware where the changes apply to the running instance only, and to make them persist you have to explicitly tell Heads to save them, whereby it uses cbfs to add /etc/config.user to the running BIOS and reflash.