### PR TITLE
Improve mirror URLs

### DIFF
--- a/modules/dropbear
+++ b/modules/dropbear
@@ -4,7 +4,7 @@ modules-$(CONFIG_DROPBEAR) += dropbear
 dropbear_version := 2016.74
 dropbear_dir := dropbear-$(dropbear_version)
 dropbear_tar := dropbear-$(dropbear_version).tar.bz2
-dropbear_url := http://matt.ucc.asn.au/dropbear/releases/$(dropbear_tar)
+dropbear_url := https://matt.ucc.asn.au/dropbear/releases/$(dropbear_tar)
 dropbear_hash := 2720ea54ed009af812701bcc290a2a601d5c107d12993e5d92c0f5f81f718891
 
 dropbear_configure := ./configure \

--- a/modules/make
+++ b/modules/make
@@ -6,7 +6,7 @@
 make_version := 4.2
 make_dir := make-$(make_version)
 make_tar := make-$(make_version).tar.bz2
-make_url := http://gnu.mirror.constant.com/make/$(make_tar)
+make_url := https://ftpmirror.gnu.org/make/$(make_tar)
 make_hash := 4e5ce3b62fe5d75ff8db92b7f6df91e476d10c3aceebf1639796dc5bfece655f
 
 # This is built for the local machine, not the target, so it doesn't have any

--- a/modules/popt
+++ b/modules/popt
@@ -3,7 +3,7 @@ modules-$(CONFIG_POPT) += popt
 popt_version := 1.16
 popt_dir := popt-$(popt_version)
 popt_tar := popt-$(popt_version).tar.gz
-popt_url := http://anduin.linuxfromscratch.org/BLFS/popt/$(popt_tar)
+popt_url := https://anduin.linuxfromscratch.org/BLFS/popt/$(popt_tar)
 popt_hash := e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
 
 popt_configure := ./configure \

--- a/modules/popt
+++ b/modules/popt
@@ -3,7 +3,7 @@ modules-$(CONFIG_POPT) += popt
 popt_version := 1.16
 popt_dir := popt-$(popt_version)
 popt_tar := popt-$(popt_version).tar.gz
-popt_url := https://anduin.linuxfromscratch.org/BLFS/popt/$(popt_tar)
+popt_url := https://launchpad.net/popt/head/$(popt_version)/+download/$(popt_tar)
 popt_hash := e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
 
 popt_configure := ./configure \

--- a/modules/zlib
+++ b/modules/zlib
@@ -4,7 +4,7 @@ modules-$(CONFIG_ZLIB) += zlib
 zlib_version := 1.2.11
 zlib_dir := zlib-$(zlib_version)
 zlib_tar := zlib-$(zlib_version).tar.gz
-zlib_url := http://www.zlib.net/$(zlib_tar)
+zlib_url := https://www.zlib.net/$(zlib_tar)
 zlib_hash := c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 zlib_configure := \


### PR DESCRIPTION
The new URL automatically redirects to a nearby, current GNU mirror.

Also, the fact that it's HTTPS helps with restrictive outbound firewall policies that disallow plaintext traffic (for example, using Qubes' firewall functionality).