### PR TITLE
Use shred instead of rm on secret related files.

### DIFF
--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -117,7 +117,7 @@ tpm sealfile2 \
 	-ix 7 X \
 || die "Unable to seal secret"
 
-rm -f "$KEY_FILE" \
+shred -n 10 -z -u "$KEY_FILE" 2> /dev/null \
 || die "Failed to delete key file"
 
 # try it without the owner password first

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -150,5 +150,5 @@ if ! tpm nv_writevalue \
 	|| die "Unable to write sealed secret to NVRAM"
 fi
 
-rm "$TPM_SEALED" \
+shred -n 10 -z -u "$TPM_SEALED" 2> /dev/null \
 || warn "Failed to delete the sealed secret - continuing"

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -38,7 +38,7 @@ for tries in 1 2 3; do
 		-hk 40000000 \
 	; then
 		# should be okay if this fails
-		rm -f /tmp/secret/sealed || true
+		shred -n 10 -z -u /tmp/secret/sealed || true
 		exit 0
 	fi
 

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -38,7 +38,7 @@ for tries in 1 2 3; do
 		-hk 40000000 \
 	; then
 		# should be okay if this fails
-		shred -n 10 -z -u /tmp/secret/sealed || true
+		shred -n 10 -z -u /tmp/secret/sealed 2> /dev/null || true
 		exit 0
 	fi
 

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -28,9 +28,9 @@ tpm unsealfile  \
 	-of "$HOTP_SECRET" \
 || die "Unable to unseal HOTP secret"
 
-rm -f "$HOTP_SEALED"
+shred -n 10 -z -u "$HOTP_SEALED"
 secret="`cat $HOTP_SECRET`"
-rm -f "$HOTP_SECRET"
+shred -n 10 -z -u "$HOTP_SECRET"
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -28,9 +28,9 @@ tpm unsealfile  \
 	-of "$HOTP_SECRET" \
 || die "Unable to unseal HOTP secret"
 
-shred -n 10 -z -u "$HOTP_SEALED"
+shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
 secret="`cat $HOTP_SECRET`"
-shred -n 10 -z -u "$HOTP_SECRET"
+shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -44,8 +44,10 @@ if ! tpm sealfile2 \
 	-ix 7 X \
 ; then
 	shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
-	 die "Unable to seal secret"
+	die "Unable to seal secret"
 fi
+
+shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
 
 
 # to create an nvram space we need the TPM owner password

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -43,7 +43,7 @@ if ! tpm sealfile2 \
 	-ix 4 0000000000000000000000000000000000000000 \
 	-ix 7 X \
 ; then
-	shred -n 10 -z -u "$TOTP_SECRET"
+	shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
 	 die "Unable to seal secret"
 fi
 
@@ -79,7 +79,7 @@ if ! tpm nv_writevalue \
 	|| die "Unable to write sealed secret to NVRAM"
 fi
 
-shred -n 10 -z -u "$TOTP_SEALED"
+shred -n 10 -z -u "$TOTP_SEALED" 2> /dev/null
 
 url="otpauth://totp/$HOST?secret=$secret"
 secret=""

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -43,7 +43,7 @@ if ! tpm sealfile2 \
 	-ix 4 0000000000000000000000000000000000000000 \
 	-ix 7 X \
 ; then
-	rm -f "$TOTP_SECRET"
+	shred -n 10 -z -u "$TOTP_SECRET"
 	 die "Unable to seal secret"
 fi
 
@@ -79,7 +79,7 @@ if ! tpm nv_writevalue \
 	|| die "Unable to write sealed secret to NVRAM"
 fi
 
-rm -f "$TOTP_SEALED"
+shred -n 10 -z -u "$TOTP_SEALED"
 
 url="otpauth://totp/$HOST?secret=$secret"
 secret=""

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -28,7 +28,7 @@ tpm unsealfile  \
 	-of "$HOTP_SECRET" \
 || die "Unable to unseal HOTP secret"
 
-shred -n 10 -z -u "$HOTP_SEALED"
+shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots
@@ -51,11 +51,11 @@ fi
 #counter_value=$(printf "%d" 0x${counter_value})
 
 if ! hotp $counter_value < "$HOTP_SECRET"; then
-	shred -n 10 -z -u "$HOTP_SECRET"
+	shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
 	die 'Unable to compute HOTP hash?'
 fi
 
-shred -n 10 -z -u "$HOTP_SECRET"
+shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
 
 #increment_tpm_counter $counter > /dev/null \
 #|| die "Unable to increment tpm counter"

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -28,7 +28,7 @@ tpm unsealfile  \
 	-of "$HOTP_SECRET" \
 || die "Unable to unseal HOTP secret"
 
-rm -f "$HOTP_SEALED"
+shred -n 10 -z -u "$HOTP_SEALED"
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots
@@ -51,11 +51,11 @@ fi
 #counter_value=$(printf "%d" 0x${counter_value})
 
 if ! hotp $counter_value < "$HOTP_SECRET"; then
-	rm -f "$HOTP_SECRET"
+	shred -n 10 -z -u "$HOTP_SECRET"
 	die 'Unable to compute HOTP hash?'
 fi
 
-rm -f "$HOTP_SECRET"
+shred -n 10 -z -u "$HOTP_SECRET"
 
 #increment_tpm_counter $counter > /dev/null \
 #|| die "Unable to increment tpm counter"

--- a/initrd/bin/unseal-totp
+++ b/initrd/bin/unseal-totp
@@ -18,12 +18,12 @@ tpm unsealfile  \
 	-of "$TOTP_SECRET" \
 || die "Unable to unseal totp secret"
 
-shred -n 10 -z -u "$TOTP_SEALED"
+shred -n 10 -z -u "$TOTP_SEALED" 2> /dev/null
 
 if ! totp -q < "$TOTP_SECRET"; then
-	shred -n 10 -z -u "$TOTP_SECRET"
+	shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
 	die 'Unable to compute TOTP hash?'
 fi
 
-shred -n 10 -z -u "$TOTP_SECRET"
+shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
 exit 0

--- a/initrd/bin/unseal-totp
+++ b/initrd/bin/unseal-totp
@@ -18,12 +18,12 @@ tpm unsealfile  \
 	-of "$TOTP_SECRET" \
 || die "Unable to unseal totp secret"
 
-rm -f "$TOTP_SEALED"
+shred -n 10 -z -u "$TOTP_SEALED"
 
 if ! totp -q < "$TOTP_SECRET"; then
-	rm -f "$TOTP_SECRET"
+	shred -n 10 -z -u "$TOTP_SECRET"
 	die 'Unable to compute TOTP hash?'
 fi
 
-rm -f "$TOTP_SECRET"
+shred -n 10 -z -u "$TOTP_SECRET"
 exit 0

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -235,7 +235,7 @@ replace_config() {
 # then copy any remaining settings from the existing config file, minus the option you changed
 	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp || true
   sort ${CONFIG_FILE}.tmp | uniq > ${CONFIG_FILE}
-	shred -n 10 -z -u ${CONFIG_FILE}.tmp
+	rm -f ${CONFIG_FILE}.tmp
 }
 combine_configs() {
 	cat /etc/config* > /tmp/config

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -15,6 +15,7 @@ recovery() {
 
 	# Remove any temporary secret files that might be hanging around
 	# but recreate the directory so that new tools can use it.
+	shred -n 10 -z -u /tmp/secret/* 2> /dev/null
 	rm -rf /tmp/secret
 	mkdir -p /tmp/secret
 
@@ -234,7 +235,7 @@ replace_config() {
 # then copy any remaining settings from the existing config file, minus the option you changed
 	grep -v "^export ${CONFIG_OPTION}=" ${CONFIG_FILE} | grep -v "^${CONFIG_OPTION}=" >> ${CONFIG_FILE}.tmp || true
   sort ${CONFIG_FILE}.tmp | uniq > ${CONFIG_FILE}
-	rm -f ${CONFIG_FILE}.tmp
+	shred -n 10 -z -u ${CONFIG_FILE}.tmp
 }
 combine_configs() {
 	cat /etc/config* > /tmp/config


### PR DESCRIPTION
Replacing rm with shred for secrets that should not be present in ram when booting OS.
Address the following [concerns](https://github.com/osresearch/heads/pull/511#issuecomment-464363619)