### PR TITLE
Detect USB disk dynamically

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -55,7 +55,6 @@ while true; do
   whiptail --clear --title "Config Management Menu" \
     --menu "This menu lets you change settings for the current BIOS session.\n\nAll changes will revert after a reboot,\n\nunless you also save them to the running BIOS." 20 90 10 \
     'b' ' Change the /boot device' \
-    'u' ' Change the USB boot device' \
     's' ' Save the current configuration to the running BIOS' \
     'x' ' Exit' \
     2>/tmp/whiptail || recovery "GUI menu failed"
@@ -81,33 +80,6 @@ while true; do
 
       whiptail --title 'Config change successful' \
         --msgbox "The /boot device was successfully changed to $SELECTED_FILE" 16 60
-    ;;
-    "u" )
-      whiptail --title 'Insert a USB thumb drive' \
-        --msgbox "Insert a USB thumb drive so we can detect the device" 16 60
-
-      enable_usb
-
-      if ! lsmod | grep -q usb_storage; then
-        insmod /lib/modules/usb-storage.ko \
-        || die "usb_storage: module load failed"
-        sleep 5
-      fi
-
-      CURRENT_OPTION=`grep 'CONFIG_USB_BOOT_DEV=' /tmp/config | tail -n1 | cut -f2 -d '=' | tr -d '"'`
-      find /dev -name 'sd*' -o -name 'nvme*' > /tmp/filelist.txt
-      file_selector "/tmp/filelist.txt" "Choose the default USB boot device.\n\nCurrently set to $CURRENT_OPTION."
-      if [ "$FILE" == "" ]; then
-        return
-      else
-        SELECTED_FILE=$FILE
-      fi
-
-      replace_config /etc/config.user "CONFIG_USB_BOOT_DEV" "$SELECTED_FILE"
-      combine_configs
-
-      whiptail --title 'Config change successful' \
-        --msgbox "The USB boot device was successfully changed to $SELECTED_FILE" 16 60
     ;;
     "s" )
       /bin/flash.sh -r /tmp/config-gui.rom

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -5,17 +5,89 @@
 enable_usb
 
 if ! lsmod | grep -q usb_storage; then
-	insmod /lib/modules/usb-storage.ko \
-	|| die "usb_storage: module load failed"
-	sleep 5
+  insmod /lib/modules/usb-storage.ko \
+  || die "usb_storage: module load failed"
+  sleep 5
 fi
 
 if [ ! -d /media ]; then
-	mkdir /media
+  mkdir /media
 fi
 
-if [ -z "$1" ]; then
-	mount -o ro /media
+stat -c %N /sys/block/sd* | grep usb | cut -f1 -d ' ' | sed "s/[']//g;s|/sys/block|/dev|" > /tmp/usb_block_devices
+if [ -z `cat /tmp/usb_block_devices` ]; then
+  if [ -x /bin/whiptail ]; then
+    whiptail --title 'USB Drive Missing' \
+      --msgbox "Insert your USB drive and press Enter to continue." 16 60
+  else
+    echo "+++ USB Drive Missing! Insert your USB drive and press Enter to continue."
+    read
+  fi
+  sleep 1
+  stat -c %N /sys/block/sd* | grep usb | cut -f1 -d ' ' | sed "s/[']//g;s|/sys/block|/dev|" > /tmp/usb_block_devices
+  if [ -z `cat /tmp/usb_block_devices` ]; then
+    if [ -x /bin/whiptail ]; then
+      whiptail $CONFIG_ERROR_BG_COLOR --title 'ERROR: USB Drive Missing' \
+        --msgbox "USB Drive Missing! Aborting mount attempt.\n\nPress Enter to continue." 16 60
+    else
+      echo "!!! ERROR: USB Drive Missing! Aborting mount. Press Enter to continue."
+    fi
+    exit 1
+  fi
+fi
+
+# Check for the common case: a single USB disk with one partition
+if [ `cat /tmp/usb_block_devices | wc -l` -eq 1 ]; then
+  USB_MOUNT_DEVICE=`cat /tmp/usb_block_devices`
+  if [ `ls -1 ${USB_MOUNT_DEVICE}* | wc -l` -eq 2 ]; then
+    USB_MOUNT_DEVICE=`ls -1 ${USB_MOUNT_DEVICE}* | tail -n1`
+  fi
+# otherwise, let the user pick
 else
-	mount -o ro $1 /media
+  > /tmp/usb_disk_list
+  for i in `cat /tmp/usb_block_devices`; do
+    ls $i* >> /tmp/usb_disk_list
+  done
+
+  if [ -x /bin/whiptail ]; then
+    MENU_OPTIONS=""
+    n=0
+    while read option
+    do
+      n=`expr $n + 1`
+      option=$(echo $option | tr " " "_")
+      MENU_OPTIONS="$MENU_OPTIONS $n ${option}"
+    done < /tmp/usb_disk_list
+
+    MENU_OPTIONS="$MENU_OPTIONS a Abort"
+    whiptail --clear --title "Select your USB disk" \
+      --menu "Choose your USB disk [1-$n, a to abort]:" 20 120 8 \
+      -- $MENU_OPTIONS \
+      2>/tmp/whiptail
+
+    option_index=$(cat /tmp/whiptail)
+  else
+    echo "+++ Select your USB disk:"
+    n=0
+    while read option
+    do
+      n=`expr $n + 1`
+      echo "$n. $option"
+    done < /tmp/usb_disk_list
+
+    read \
+      -p "Choose your USB disk [1-$n, a to abort]: " \
+      option_index
+  fi
+
+  if [ "$option_index" = "a" ]; then
+    exit 1
+  fi
+  USB_MOUNT_DEVICE=`head -n $option_index /tmp/usb_disk_list | tail -1`
+fi
+
+if [ "$1" = "rw" ]; then
+  mount -o rw $USB_MOUNT_DEVICE /media
+else
+  mount -o ro $USB_MOUNT_DEVICE /media
 fi

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -36,17 +36,29 @@ if [ -z `cat /tmp/usb_block_devices` ]; then
   fi
 fi
 
+USB_MOUNT_DEVICE=""
 # Check for the common case: a single USB disk with one partition
 if [ `cat /tmp/usb_block_devices | wc -l` -eq 1 ]; then
-  USB_MOUNT_DEVICE=`cat /tmp/usb_block_devices`
-  if [ `ls -1 ${USB_MOUNT_DEVICE}* | wc -l` -eq 2 ]; then
-    USB_MOUNT_DEVICE=`ls -1 ${USB_MOUNT_DEVICE}* | tail -n1`
+  USB_BLOCK_DEVICE=`cat /tmp/usb_block_devices`
+  # Subtract out block device
+  let USB_NUM_PARTITIONS=`ls -1 ${USB_BLOCK_DEVICE}* | wc -l`-1
+  if [ ${USB_NUM_PARTITIONS} -eq 0 ]; then
+    USB_MOUNT_DEVICE=${USB_BLOCK_DEVICE}
+  elif [ ${USB_NUM_PARTITIONS} -eq 1 ]; then
+    USB_MOUNT_DEVICE=`ls -1 ${USB_BLOCK_DEVICE}* | tail -n1`
   fi
+fi
 # otherwise, let the user pick
-else
+if [ -z ${USB_MOUNT_DEVICE} ]; then
   > /tmp/usb_disk_list
   for i in `cat /tmp/usb_block_devices`; do
-    ls $i* >> /tmp/usb_disk_list
+    # remove block device from list if numeric partitions exist, since not bootable
+    let USB_NUM_PARTITIONS=`ls -1 $i* | wc -l`-1
+    if [ ${USB_NUM_PARTITIONS} -eq 0 ]; then
+      echo $i >> /tmp/usb_disk_list
+    else
+      ls $i* | tail -${USB_NUM_PARTITIONS} >> /tmp/usb_disk_list
+    fi
   done
 
   if [ -x /bin/whiptail ]; then


### PR DESCRIPTION
Currently Heads relies on a hard-coded config value to determine which
USB disk to mount. This can be problematic when trying to distribute a
pre-built version of Heads that can work on multiple disk
configurations. I've modified the USB mounting script so that it
attempts to detect all USB boot disks present on the system, pick sane
defaults, and prompt the user when there are multiple choices.

I've also removed the USB configuration option from config-gui.sh as
this config option is no longer used.