### PR TITLE
Fedora 30 fix for pinentry: remove gtk and gnome3 support. 

### DIFF
--- a/modules/pinentry
+++ b/modules/pinentry
@@ -22,6 +22,8 @@ pinentry_configure := ./configure \
 	--disable-fallback-curses \
 	--disable-pinentry-curses \
 	--disable-pinentry-qt \
+  --disable-pinentry-gtk2 \
+  --disable-pinentry-gnome3 \
 	--disable-pinentry-fltk \
 	--disable-pinentry-emacs \
 	--disable-fallback-curses \

--- a/modules/pinentry
+++ b/modules/pinentry
@@ -22,8 +22,8 @@ pinentry_configure := ./configure \
 	--disable-fallback-curses \
 	--disable-pinentry-curses \
 	--disable-pinentry-qt \
-  --disable-pinentry-gtk2 \
-  --disable-pinentry-gnome3 \
+	--disable-pinentry-gtk2 \
+	--disable-pinentry-gnome3 \
 	--disable-pinentry-fltk \
 	--disable-pinentry-emacs \
 	--disable-fallback-curses \


### PR DESCRIPTION
TODO: remove all unneeded config options for ALL modules

Fixes #552 