### PR TITLE
Parse grub config files for Fedora 29/30

### DIFF
--- a/initrd/bin/kexec-parse-bls
+++ b/initrd/bin/kexec-parse-bls
@@ -1,0 +1,99 @@
+#!/bin/sh
+set -e -o pipefail
+bootdir="$1"
+file="$2"
+blsdir="$3"
+kernelopts=""
+
+if [ -z "$bootdir" -o -z "$file" ]; then
+	die "Usage: $0 /boot /boot/grub/grub.cfg blsdir"
+fi
+
+reset_entry() {
+	name=""
+	kexectype="elf"
+	kernel=""
+	initrd=""
+	modules=""
+	append="$kernelopts"
+}
+
+filedir=`dirname $file`
+bootdir="${bootdir%%/}"
+bootlen="${#bootdir}"
+appenddir="${filedir:$bootlen}"
+# assumption. grubenv is in same location as config file
+# ignored if doesn't exist
+grubenv="$filedir/grubenv"
+
+fix_path() {
+	path="$@"
+	if [ "${path:0:1}" != "/" ]; then
+		path="$appenddir/$path"
+	fi
+}
+
+echo_entry() {
+	if [ "$kexectype" = "elf" ]; then
+		if [ -z "$kernel" ]; then return; fi
+
+		fix_path $kernel
+		entry="$name|$kexectype|kernel $path"
+		if [ -n "$initrd" ]; then
+			fix_path $initrd
+			entry="$entry|initrd $path"
+		fi
+		if [ -n "$append" ]; then
+			entry="$entry|append $append"
+		fi
+
+		echo $(eval "echo \"$entry\"")
+	fi
+	if [ "$kexectype" = "multiboot" -o "$kexectype" = "xen" ]; then
+		if [ -z "$kernel" ]; then return; fi
+
+		fix_path $kernel
+		echo $(eval "echo \"$name|$kexectype|kernel $path$modules\"")
+	fi
+}
+
+bls_entry() {
+	# add info to menuentry
+	trimcmd=`echo $line | tr '\t ' ' ' | tr -s ' '`
+	cmd=`echo $trimcmd | cut -d\  -f1`
+	val=`echo $trimcmd | cut -d\  -f2-`
+	case $cmd in
+		title)
+			name=$val
+			;;
+		linux*)
+			kernel=$val
+			;;
+		initrd*)
+			initrd=$val
+			;;
+		options)
+			# default is "options $kernelopts"
+			# need to substitute that variable if set in .cfg/grubenv
+			append=`echo "$val" | sed "s@\\$kernelopts@$kernelopts@"`
+			;;
+	esac
+}
+
+# This is the default append value if no options field in bls entry
+grep -q "set default_kernelopts" "$file" && 
+	kernelopts=`grep "set default_kernelopts" "$file" |
+		tr "'" "\"" | cut -d\" -f 2`
+[ -f "$grubenv" ] && grep -q "^kernelopts" "$grubenv" &&
+	kernelopts=`grep "^kernelopts" "$grubenv" | tr '@' '_' | cut -d= -f 2-`
+reset_entry
+find $blsdir -type f -name \*.conf |
+while read f
+do
+	while read line
+	do
+		bls_entry
+	done < "$f"
+	echo_entry
+	reset_entry
+done

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -163,6 +163,14 @@ scan_options() {
 	for i in `find $bootdir -name "$config"`; do
 		kexec-parse-boot "$bootdir" "$i" >> $option_file
 	done
+	# FC29/30+ may use BLS format grub config files
+	# https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault
+	# only parse these if $option_file is still empty
+	if [ ! -s $option_file ] && [ -d "$bootdir/loader/entries" ]; then
+		for i in `find $bootdir -name "$config"`; do
+			kexec-parse-bls "$bootdir" "$i" "$bootdir/loader/entries" >> $option_file
+		done
+	fi
 	if [ ! -r $option_file ]; then
 		die "Failed to parse any boot options"
 	fi


### PR DESCRIPTION
Have made this fix more conservative. If kexec-parse-boot provides any output at all, then the BLS parsing will not be performed. The /boot/loader/entries directory will only be parsed if there are no grub .cfg files with direct kernel parameters within them.

To proceed to execute kexec-parse-bls, there are two tests: 
```
[ ! -s $option_file ] - $option_file is zero size
[ -d "$bootdir/loader/entries" ] - /boot/loader/entries directory exists
```

I've tested this with Fedora 30, Qubes 4.0.1 (which seems to have a bizarre /boot/loader/entries directory...) and for good measure, Ubuntu 19.04