### PR TITLE
Fix qemu-coreboot board to boot by default

### DIFF
--- a/boards/qemu-coreboot/qemu-coreboot.config
+++ b/boards/qemu-coreboot/qemu-coreboot.config
@@ -56,4 +56,5 @@ run:
 		--machine q35 \
 		--serial /dev/tty \
 		--bios $(build)/$(BOARD)/coreboot.rom \
+		-nic none \
 	; stty sane


### PR DESCRIPTION
add "-nic none" to fix https://github.com/osresearch/heads/issues/516#issuecomment-464000222 and boot heads in qemu