### PR TITLE
Makefile: add submodule checkout after git cloning coreboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,7 @@ define define_module =
     # this case, since we don't have a stable version to compare against.
     $(build)/$($1_base_dir)/.canary:
 	git clone $($1_repo) "$(build)/$($1_base_dir)"
+	cd $(build)/$($1_base_dir) && git submodule update --init --checkout
 	if [ -r patches/$1.patch ]; then \
 		( cd $(build)/$($1_base_dir) ; patch -p1 ) \
 			< patches/$1.patch \


### PR DESCRIPTION
Right now all git submodules are left behind on a git clone. Add
git submodule update --init --checkout according to the docs, see
https://www.coreboot.org/Build_HOWTO