### PR TITLE
gui-init: reorder, simplify main menu entries and add Power Off entry

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -176,7 +176,6 @@ while true; do
       'y' ' Default boot' \
       'a' ' Advanced Settings -->' \
       'P' ' Power Off' \
-      'x' ' Exit to recovery shell' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 
     totp_confirm=$(cat /tmp/whiptail)
@@ -191,6 +190,7 @@ while true; do
       'c' ' Change configuration settings -->' \
       'f' ' Flash/Update the BIOS -->' \
       'G' ' GPG Options -->' \
+      'x' ' Exit to recovery shell' \
       'r' ' <-- Return to main menu' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -174,6 +174,7 @@ while true; do
     whiptail $MAIN_MENU_BG_COLOR --clear --title "$CONFIG_BOOT_GUI_MENU_NAME" \
       --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 20 90 10 \
       'y' ' Default boot' \
+      'r' ' Refresh TOTP/HOTP' \
       'a' ' Settings -->' \
       'P' ' Power Off' \
       2>/tmp/whiptail || recovery "GUI menu failed"
@@ -214,7 +215,6 @@ while true; do
       --menu "Select An Option" 20 90 10 \
       'g' ' Generate new TOTP/HOTP secret' \
       'p' ' Reset the TPM' \
-      'r' ' TOTP/HOTP does not match, refresh code' \
       'n' ' TOTP/HOTP does not match after refresh, troubleshoot' \
       'r' ' <-- Return to main menu' \
       2>/tmp/whiptail || recovery "GUI menu failed"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -174,7 +174,7 @@ while true; do
     whiptail $MAIN_MENU_BG_COLOR --clear --title "$CONFIG_BOOT_GUI_MENU_NAME" \
       --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 20 90 10 \
       'y' ' Default boot' \
-      'a' ' Advanced Settings -->' \
+      'a' ' Settings -->' \
       'P' ' Power Off' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 
@@ -182,8 +182,8 @@ while true; do
   fi
 
   if [ "$totp_confirm" = "a" ]; then
-    whiptail --clear --title "Advanced Settings" \
-      --menu "Configure Advanced Settings" 20 90 10 \
+    whiptail --clear --title "Settings" \
+      --menu "Configure Settings" 20 90 10 \
       'o' ' Other Boot Options -->' \
       't' ' TPM/TOTP/HOTP Options -->' \
       's' ' Update checksums and sign all files in /boot' \

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -175,6 +175,7 @@ while true; do
       --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 20 90 10 \
       'y' ' Default boot' \
       'a' ' Advanced Settings -->' \
+      'P' ' Power Off' \
       'x' ' Exit to recovery shell' \
       2>/tmp/whiptail || recovery "GUI menu failed"
 
@@ -328,6 +329,10 @@ while true; do
   if [ "$totp_confirm" = "G" ]; then
     gpg-gui.sh
     continue
+  fi
+
+  if [ "$totp_confirm" = "P" ]; then
+    poweroff
   fi
 
   if [ "$totp_confirm" = "y" -o -n "$totp_confirm" ]; then


### PR DESCRIPTION
Clean up the main menu to only include menu entries that are expected
to be part of users' everyday routines. On the main menu itself, each option
should be almost trivially easy to understand.

* move "Exit to recovery shell" under Advanced Settings (quite obvious change IMO)
* add "Refresh TOTP/HOTP". Needed by anybody who verifies firmware integrity using TOTP
* keep "Advanced Settings" for the other stuff most people won't care too much about, but rename to "Settings" only. (we don't have "normal" ones, so why have "advanced" ones, right?)
* add "Power Off" at the bottom. IMO this is can be very useful to anybody: This enables users to
only verify the firmware integrity using OTP, and do nothing more. After having left the device out of sight, one might want to do a quick sanity check only.

That's the resulting menu after these changes:
* Default boot
* Refresh TOTP/HOTP
* Settings -->
* Power Off