### PR TITLE
HOTP fixes

### DIFF
--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -62,10 +62,10 @@ fi
 read -s -p "Enter your Librem Key Admin PIN" admin_pin
 echo
 
-libremkey_hotp_initialize $admin_pin $HOTP_SECRET $counter_value 
+libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value 
 if [ $? -ne 0 ]; then
   read -s -p "Error setting HOTP secret, re-enter Admin PIN and try again:" admin_pin
-  if ! libremkey_hotp_initialize $admin_pin $HOTP_SECRET $counter_value ; then
+  if ! libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value ; then
     # don't leak key on failure
     shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
     die "Setting HOTP secret failed"

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -29,8 +29,6 @@ tpm unsealfile  \
 || die "Unable to unseal HOTP secret"
 
 shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
-secret="`cat $HOTP_SECRET`"
-shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots
@@ -54,21 +52,28 @@ enable_usb
 if ! libremkey_hotp_verification info ; then
   echo "Insert your Librem Key and press Enter to configure it"
   read
-  libremkey_hotp_verification info \
-  || die "Unable to find Librem Key"
+  if ! libremkey_hotp_verification info ; then
+    # don't leak key on failure
+    shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
+    die "Unable to find Librem Key"
+  fi
 fi
 
 read -s -p "Enter your Librem Key Admin PIN" admin_pin
 echo
 
-libremkey_hotp_initialize $admin_pin $secret $counter_value 
+libremkey_hotp_initialize $admin_pin $HOTP_SECRET $counter_value 
 if [ $? -ne 0 ]; then
   read -s -p "Error setting HOTP secret, re-enter Admin PIN and try again:" admin_pin
-  libremkey_hotp_initialize $admin_pin $secret $counter_value \
-  || die "Setting HOTP secret failed"
+  if ! libremkey_hotp_initialize $admin_pin $HOTP_SECRET $counter_value ; then
+    # don't leak key on failure
+    shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
+    die "Setting HOTP secret failed"
+  fi
 fi
 
-secret=""
+# HOTP key no longer needed
+shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
 
 # Make sure our counter is incremented ahead of the next check
 #increment_tpm_counter $counter > /dev/null \

--- a/patches/libremkey-hotp-verification.patch
+++ b/patches/libremkey-hotp-verification.patch
@@ -29,4 +29,33 @@
 +static const int CONNECTION_ATTEMPTS_COUNT = 2;
  
  static const int CONNECTION_ATTEMPT_DELAY_MICRO_SECONDS = 1000*1000/2;
+
+--- libremkey-hotp-verification/libremkey_hotp_initialize
++++ libremkey-hotp-verification-b/libremkey_hotp_initialize
+@@ -14,7 +14,7 @@ fi
+ PIN=$1
+ SECRET=$2
+ COUNTER=$3
+-SECRET_B32=$(echo -n $SECRET | base32)
++SECRET_B32=$(cat $SECRET | base32)
  
+ libremkey_hotp_verification set $SECRET_B32 $PIN 
+ if [ $? -ne 0 ]; then
+@@ -25,7 +25,7 @@ fi
+ i=9
+ while [ "$i" -lt "$COUNTER" ]; do
+   echo "Updating counter to $i"
+-  HOTP_CODE=$(echo $SECRET | hotp $i)
++  HOTP_CODE=$(hotp $i < $SECRET)
+   libremkey_hotp_verification check $HOTP_CODE > /dev/null
+   if [ $? -ne 0 ]; then
+     echo "HOTP check failed for counter=$i, code=$HOTP_CODE"
+@@ -34,7 +34,7 @@ while [ "$i" -lt "$COUNTER" ]; do
+   let "i += 10"
+ done
+ 
+-HOTP_CODE=$(echo $SECRET | hotp $COUNTER)
++HOTP_CODE=$(hotp $COUNTER < $SECRET)
+ libremkey_hotp_verification check $HOTP_CODE > /dev/null
+ if [ $? -ne 0 ]; then
+   echo "HOTP check failed for counter=$COUNTER, code=$HOTP_CODE"

--- a/patches/libremkey-hotp-verification.patch
+++ b/patches/libremkey-hotp-verification.patch
@@ -32,15 +32,18 @@
 
 --- libremkey-hotp-verification/libremkey_hotp_initialize
 +++ libremkey-hotp-verification-b/libremkey_hotp_initialize
-@@ -14,7 +14,7 @@ fi
+@@ -14,9 +14,9 @@ fi
  PIN=$1
  SECRET=$2
  COUNTER=$3
 -SECRET_B32=$(echo -n $SECRET | base32)
 +SECRET_B32=$(cat $SECRET | base32)
  
- libremkey_hotp_verification set $SECRET_B32 $PIN 
+-libremkey_hotp_verification set $SECRET_B32 $PIN 
++libremkey_hotp_verification set $SECRET_B32 "$PIN"
  if [ $? -ne 0 ]; then
+   echo "ERROR: Setting HOTP secret on Librem Key failed!"
+   exit 1
 @@ -25,7 +25,7 @@ fi
  i=9
  while [ "$i" -lt "$COUNTER" ]; do


### PR DESCRIPTION
Fix two issues with HOTP generation/validation:
- truncation of the HOTP secret when passing to libremkey-hotp-verification
- fix validation of Librem Key admin pin when passphrase with spaces is used