### PR TITLE
UX Tweaks [2/2]

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -8,6 +8,7 @@ file_selector() {
   FILE=""
   FILE_LIST=$1
   MENU_MSG=${2:-"Choose the file"}
+  MENU_TITLE=${3:-"Select your File"}
 # create file menu options
   if [ `cat "$FILE_LIST" | wc -l` -gt 0 ]; then
     option=""
@@ -23,7 +24,7 @@ file_selector() {
       done < $FILE_LIST
 
       MENU_OPTIONS="$MENU_OPTIONS a Abort"
-      whiptail --clear --title "Select your File" \
+      whiptail --clear --title "${MENU_TITLE}" \
         --menu "${MENU_MSG} [1-$n, a to abort]:" 20 120 8 \
         -- $MENU_OPTIONS \
         2>/tmp/whiptail || die "Aborting"

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -51,16 +51,24 @@ file_selector() {
   fi
 }
 
+param=$1
+
 while true; do
+  if [ ! -z "$param" ]; then
+    # use first char from parameter
+    menu_choice=${param::1}
+    unset param
+  else
   unset menu_choice
   whiptail --clear --title "Config Management Menu" \
     --menu "This menu lets you change settings for the current BIOS session.\n\nAll changes will revert after a reboot,\n\nunless you also save them to the running BIOS." 20 90 10 \
     'b' ' Change the /boot device' \
     's' ' Save the current configuration to the running BIOS' \
-    'x' ' Exit' \
+    'x' ' Return to Main Menu' \
     2>/tmp/whiptail || recovery "GUI menu failed"
 
   menu_choice=$(cat /tmp/whiptail)
+  fi
 
   case "$menu_choice" in
     "x" )

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -43,6 +43,12 @@ flash_rom() {
       preserve_rom /tmp/${CONFIG_BOARD}.rom \
       || die "$ROM: Config preservation failed"
     fi
+    # persist serial number from CBFS
+    if cbfs -r serial_number > /tmp/serial 2>/dev/null; then
+      echo "Persisting system serial"
+      cbfs -o /tmp/${CONFIG_BOARD}.rom -d serial_number 2>/dev/null || true
+      cbfs -o /tmp/${CONFIG_BOARD}.rom -a serial_number -f /tmp/serial
+    fi
 
     flashrom $FLASHROM_OPTIONS -w /tmp/${CONFIG_BOARD}.rom \
     || die "$ROM: Flash failed"

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -105,7 +105,9 @@ gpg_flash_rom() {
   if (cbfs -o /tmp/gpg-gui.rom -l | grep -q "heads/initrd/.gnupg/trustdb.gpg") then
     cbfs -o /tmp/gpg-gui.rom -d "heads/initrd/.gnupg/trustdb.gpg"
   fi
-  cbfs -o /tmp/gpg-gui.rom -a "heads/initrd/.gnupg/trustdb.gpg" -f /.gnupg/trustdb.gpg
+  if [ -e /.gnupg/trustdb.gpg ]; then
+    cbfs -o /tmp/gpg-gui.rom -a "heads/initrd/.gnupg/trustdb.gpg" -f /.gnupg/trustdb.gpg
+  fi
 
   #Remove old method owner trust exported file
   if (cbfs -o /tmp/gpg-gui.rom -l | grep -q "heads/initrd/.gnupg/otrust.txt") then
@@ -116,8 +118,9 @@ gpg_flash_rom() {
   if (cbfs -o /tmp/gpg-gui.rom -l | grep -q "heads/initrd/etc/config.user") then
     cbfs -o /tmp/gpg-gui.rom -d "heads/initrd/etc/config.user"
   fi
-  cbfs -o /tmp/gpg-gui.rom -a "heads/initrd/etc/config.user" -f /etc/config.user
-
+  if [ -e /etc/config.user ]; then
+    cbfs -o /tmp/gpg-gui.rom -a "heads/initrd/etc/config.user" -f /etc/config.user
+  fi
   /bin/flash.sh /tmp/gpg-gui.rom
 
   if (whiptail --title 'BIOS Flashed Successfully' \

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -196,7 +196,12 @@ gpg_add_key_reflash() {
       find /media -name '*.key' > /tmp/filelist.txt
       find /media -name '*.asc' >> /tmp/filelist.txt
       file_selector "/tmp/filelist.txt" "Choose your GPG public key"
-      PUBKEY=$FILE
+      # bail if user didn't select a file
+      if [ "$FILE" = "" ]; then
+        return
+      else
+        PUBKEY=$FILE
+      fi
 
       /bin/flash.sh -r /tmp/gpg-gui.rom
       if [ ! -s /tmp/gpg-gui.rom ]; then

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -97,10 +97,9 @@ update_totp()
     read
     /bin/seal-libremkey
   else
-    echo "Once you have scanned the QR code, hit Enter to reboot"
+    echo "Once you have scanned the QR code, hit Enter to continue"
     read
   fi
-  /bin/reboot
 }
 
 # enable USB to load modules for external kb

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -15,7 +15,7 @@ mount_boot()
     if [ ! -e "$CONFIG_BOOT_DEV" ]; then
       if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: $CONFIG_BOOT_DEV missing!" \
           --yesno "The /boot device $CONFIG_BOOT_DEV could not be found!\n\nYou will need to configure the correct device for /boot.\n\nWould you like to configure the /boot device now?" 30 90) then
-        config-gui.sh
+        config-gui.sh boot_device_select
       else
         # exit to main menu
         break
@@ -27,7 +27,7 @@ mount_boot()
     if [ $? -ne 0 ]; then
       if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Cannot mount /boot' \
       --yesno "The /boot partition at $CONFIG_BOOT_DEV could not be mounted!\n\nWould you like to configure the /boot device now?" 30 90) then
-        config-gui.sh
+        config-gui.sh boot_device_select
       else
         recovery "Unable to mount /boot"
       fi

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -186,11 +186,12 @@ scan_options() {
 save_default_option() {
 	read \
 		-n 1 \
-		-p "Saving a default will modify the disk. Proceed? (y/n): " \
+		-p "Saving a default will modify the disk. Proceed? (Y/n): " \
 		default_confirm
 	echo
 
-	if [ "$default_confirm" = "y" ]; then
+	[ "$default_confirm" = "" ] && default_confirm="y"
+	if [[ "$default_confirm" = "y" || "$default_confirm" = "Y" ]]; then
 		if kexec-save-default \
 			-b "$bootdir" \
 			-d "$paramsdev" \

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -136,8 +136,28 @@ confirm_gpg_card()
 	# setup the USB so we can reach the GPG card
 	enable_usb
 
-	gpg --card-status \
-	|| die "gpg card read failed"
+	echo -e "\nVerifying presence of GPG card...\n"
+	# ensure we don't exit without retrying
+	errexit=$(set -o | grep errexit | awk '{print $2}')
+	set +e
+	gpg --card-status > /dev/null
+	if [ $? -ne 0 ]; then
+	  # prompt for reinsertion and try a second time
+	  read -n1 -r -p \
+	      "Can't access GPG key; remove and reinsert, then press Enter to retry. " \
+	      ignored
+	  # restore prev errexit state
+	  if [ "$errexit" = "on" ]; then
+	    set -e
+	  fi
+	  # retry card status
+	  gpg --card-status > /dev/null \
+	  	|| die "gpg card read failed"
+	fi
+	# restore prev errexit state
+	if [ "$errexit" = "on" ]; then
+	  set -e
+	fi
 }
 
 


### PR DESCRIPTION
series of small tweaks to the HEADS UI which improve user experience:

* add ability to directly access menu options in config-gui via function parameter
* filter out invalid boot devices from options menu
* don't reboot after creating new HOTP/TOTP
* jump directly to boot device selection when existing is invalid
* add Full Reset config option to reset TPM, GPG, boot signatures
* check for file existence when persisting between flashes
* default to Y when selecting a new boot device
* prompt for retry when GPG card detection fails
* better handle user cancellation when adding a new key to ROM
* persist device serial in CBFS between flashes