### PR TITLE
TOTP Tweaks

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -90,11 +90,9 @@ prompt_update_checksums()
 }
 update_totp()
 {
-  echo "Scan the QR code to add the new TOTP secret"
+  echo -e "Scan the QR code to add the new TOTP secret...\n\n"
   /bin/seal-totp
   if [ -x /bin/libremkey_hotp_verification ]; then
-    echo "Once you have scanned the QR code, hit Enter to configure your Librem Key"
-    read
     /bin/seal-libremkey
   else
     echo "Once you have scanned the QR code, hit Enter to continue"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -169,8 +169,14 @@ while true; do
       TOTP=`unseal-totp`
       if [ $? -ne 0 ]; then
         whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-          --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf this is the first time the system has booted, you should reset the TPM\nand set your own password\n\nIf you just reflashed your BIOS, you'll need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 30 90 4 \
-          'g' ' Generate new TOTP/HOTP secret' \
+          --menu "    ERROR: Heads couldn't generate the TOTP code.\n
+    If you have just completed a Factory Reset, or just reflashed
+    your BIOS, you should generate a new HOTP/TOTP secret.\n
+    If this is the first time the system has booted, you should
+    reset the TPM and set your own password.\n
+    If you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n
+    How would you like to proceed?" 30 90 4 \
+          'g' ' Generate new HOTP/TOTP secret' \
           'i' ' Ignore error and continue to default boot menu' \
           'p' ' Reset the TPM' \
           'x' ' Exit to recovery shell' \

--- a/initrd/bin/seal-libremkey
+++ b/initrd/bin/seal-libremkey
@@ -16,17 +16,24 @@ mount_boot()
   fi
 }
 
+fatal_error()
+{
+  echo -e "\nERROR: ${1}; press Enter to continue."
+  read
+  die "$1"
+}
+
 tpm nv_readvalue \
 	-in 4d47 \
 	-sz 312 \
 	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
+|| fatal_error "Unable to retrieve sealed file from TPM NV"
 
 tpm unsealfile  \
 	-hk 40000000 \
 	-if "$HOTP_SEALED" \
 	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
+|| fatal_error "Unable to unseal HOTP secret"
 
 shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
 
@@ -50,29 +57,39 @@ counter_value=1
 
 enable_usb
 if ! libremkey_hotp_verification info ; then
-  echo "Insert your Librem Key and press Enter to configure it"
+  echo -e "\nInsert your Librem Key and press Enter to configure it"
   read
   if ! libremkey_hotp_verification info ; then
     # don't leak key on failure
     shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
-    die "Unable to find Librem Key"
+    fatal_error "Unable to find Librem Key"
   fi
 fi
 
-echo -e ""
-read -s -p "Enter your Librem Key Admin PIN: " admin_pin
-echo -e "\n"
+# try using factory default admin PIN
+admin_pin="12345678"
+libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value >/dev/null 2>1
 
-libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value 
 if [ $? -ne 0 ]; then
+  # prompt user for PIN and retry
+  echo ""
+  read -s -p "Enter your Librem Key Admin PIN: " admin_pin
   echo -e "\n"
-  read -s -p "Error setting HOTP secret, re-enter Admin PIN and try again: " admin_pin
-  echo -e "\n"
-  if ! libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value ; then
-    # don't leak key on failure
-    shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
-    die "Setting HOTP secret failed"
+  
+  libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value 
+  if [ $? -ne 0 ]; then
+    echo -e "\n"
+    read -s -p "Error setting HOTP secret, re-enter Admin PIN and try again: " admin_pin
+    echo -e "\n"
+    if ! libremkey_hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value ; then
+      # don't leak key on failure
+      shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
+      fatal_error "Setting HOTP secret failed"
+    fi
   fi
+else 
+  # remind user to change admin password
+  echo -e "\nWARNING: default GPG admin PIN detected: please change this as soon as possible."
 fi
 
 # HOTP key no longer needed
@@ -88,7 +105,7 @@ mount -o remount,rw /boot
 
 counter_value=`expr $counter_value + 1`
 echo $counter_value > $HOTP_COUNTER \
-|| die "Unable to create hotp counter file"
+|| fatal_error "Unable to create hotp counter file"
 
 #sha256sum /tmp/counter-$counter > $HOTP_COUNTER \
 #|| die "Unable to create hotp counter file"


### PR DESCRIPTION
Reduce friction when generating a new TOTP/HOTP secret by eliminating an unnecessary 'press enter to continue' prompt following QR code generation, and by attempting to use the default admin PIN set by the OEM factory reset function. Fall back to prompting the user if the default PIN fails.

Update text on TOTP error prompt to provide better guidance for users following the use of the OEM factory reset function

Also, ensure error messages are visible to users before being returned back to the GUI menu from which they came by wrapping existing calls to die()