### PR TITLE
Pin tag of musl-cross, tpmtotp and msrtools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,10 @@ define define_module =
     # Unpack the tar file and touch the canary so that we know
     # that the files are all present
     $(build)/$($1_base_dir)/.canary: $(packages)/.$1-$($1_version)_verify
-	tar -xf "$(packages)/$($1_tar)" -C "$(build)"
+	mkdir -p "$$(dir $$@)"
+	tar -xf "$(packages)/$($1_tar)" --strip 1 -C "$$(dir $$@)"
 	if [ -r patches/$1-$($1_version).patch ]; then \
-		( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+		( cd $$(dir $$@) ; patch -p1 ) \
 			< patches/$1-$($1_version).patch \
 			|| exit 1 ; \
 	fi
@@ -274,7 +275,7 @@ define define_module =
 	   [ -r patches/$1-$($1_version) ] ; then \
 		for patch in patches/$1-$($1_version)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+			( cd $$(dir $$@) ; patch -p1 ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ define define_module =
     # that the files are all present
     $(build)/$($1_base_dir)/.canary: $(packages)/.$1-$($1_version)_verify
 	mkdir -p "$$(dir $$@)"
-	tar -xf "$(packages)/$($1_tar)" --strip 1 -C "$$(dir $$@)"
+	tar -xf "$(packages)/$($1_tar)" $(or $($1_tar_opt),--strip 1) -C "$$(dir $$@)"
 	if [ -r patches/$1-$($1_version).patch ]; then \
 		( cd $$(dir $$@) ; patch -p1 ) \
 			< patches/$1-$($1_version).patch \

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -108,6 +108,7 @@ modules-y += coreboot-blobs
 
 coreboot-blobs_version := $(coreboot_version)
 coreboot-blobs_tar := coreboot-blobs-$(coreboot-blobs_version).tar.xz
+coreboot-blobs_tar_opt := --strip 3
 coreboot-blobs_dir := coreboot-$(coreboot-blobs_version)/3rdparty/blobs
 coreboot-blobs_url := https://www.coreboot.org/releases/$(coreboot-blobs_tar)
 coreboot-blobs_hash := 18aa509ae3af005a05d7b1e0b0246dc640249c14fc828f5144b6fd20bb10e295

--- a/modules/msrtools
+++ b/modules/msrtools
@@ -2,14 +2,15 @@ modules-$(CONFIG_MSRTOOLS) += msrtools
 
 msrtools_depends := $(musl_dep)
 
-msrtools_version := git
-msrtools_repo := https://github.com/osresearch/msr-tools
+#msrtools_version := git
+#msrtools_repo := https://github.com/osresearch/msr-tools
 
-#msrtools_version := 1.3
+msrtools_version := 572ef8a
 msrtools_dir := msrtools-$(msrtools_version)
 msrtools_tar := msr-tools-$(msrtools_version).tar.gz
-msrtools_url := https://github.com/intel/msr-tools/archive/msr-tools-$(msrtools_version).tar.gz
-msrtools_hash := e8205aa3d19e536080f5974ed06ab9a88c4c3f37870c2f6a3a08a2f39302c22c
+#msrtools_url := https://github.com/intel/msr-tools/archive/msr-tools-$(msrtools_version).tar.gz
+msrtools_url := https://github.com/osresearch/msr-tools/archive/$(msrtools_version).tar.gz
+msrtools_hash := 80554790d0a404205fe215c9ae8d2de159e980ec23821d636f201f12550e6ac0
 
 msrtools_target := \
 	$(CROSS_TOOLS) \

--- a/modules/musl-cross
+++ b/modules/musl-cross
@@ -23,9 +23,11 @@ else
 # Force a full build of the cross compiler
 
 modules-y += musl-cross
-musl-cross_version := git
-musl-cross_dir := musl-cross-$(musl-cross_version)
-musl-cross_repo := https://github.com/GregorR/musl-cross
+musl-cross_version := 81d563e
+musl-cross_dir := musl-cross
+musl-cross_url := https://github.com/GregorR/musl-cross/archive/$(musl-cross_version).tar.gz
+musl-cross_tar := musl-cross-$(musl-cross_version).tar.gz
+musl-cross_hash := 6362751b2442dc273c0889e5ef3ce6306a38b9c415cbe8cb4cfe3b8c6d776e96
 
 CROSS_TOP := crossgcc/x86_64-linux-musl/bin/x86_64-musl-linux-
 CROSS := $(build)/../$(CROSS_TOP)

--- a/modules/musl-cross
+++ b/modules/musl-cross
@@ -29,7 +29,7 @@ musl-cross_url := https://github.com/GregorR/musl-cross/archive/$(musl-cross_ver
 musl-cross_tar := musl-cross-$(musl-cross_version).tar.gz
 musl-cross_hash := 6362751b2442dc273c0889e5ef3ce6306a38b9c415cbe8cb4cfe3b8c6d776e96
 
-CROSS_TOP := crossgcc/x86_64-linux-musl/bin/x86_64-musl-linux-
+CROSS_TOP := crossgcc/x86_64-linux-musl/bin/x86_64-linux-musl-
 CROSS := $(build)/../$(CROSS_TOP)
 musl-cross_output := ../../$(CROSS_TOP)gcc
 

--- a/modules/tpmtotp
+++ b/modules/tpmtotp
@@ -2,14 +2,14 @@ modules-$(CONFIG_TPMTOTP) += tpmtotp
 
 tpmtotp_depends := mbedtls qrencode $(musl_dep)
 
-tpmtotp_version := git
-tpmtotp_repo := https://github.com/osresearch/tpmtotp
+#tpmtotp_version := git
+#tpmtotp_repo := https://github.com/osresearch/tpmtotp
 
-#tpmtotp_version := 0.3.0
+tpmtotp_version := 18b860f
 tpmtotp_dir := tpmtotp-$(tpmtotp_version)
 tpmtotp_tar := tpmtotp-$(tpmtotp_version).tar.gz
-tpmtotp_url := https://github.com/osresearch/tpmtotp/archive/v$(tpmtotp_version).tar.gz
-tpmtotp_hash := e8205aa3d19e536080f5974ed06ab9a88c4c3f37870c2f6a3a08a2f39302c22c
+tpmtotp_url := https://github.com/osresearch/tpmtotp/archive/$(tpmtotp_version).tar.gz
+tpmtotp_hash := 1082f2b0e4af833e04220dddedcc21a39eb39ee4dc5668bb010e7bcc795c606c
 
 tpmtotp_target := \
 	$(CROSS_TOOLS) \

--- a/patches/musl-cross-81d563e.patch
+++ b/patches/musl-cross-81d563e.patch
@@ -36,3 +36,15 @@ index ec3c1ce..844fb3d 100644
  # uncomment these to get smaller/stripped binaries
  #export CFLAGS="-Os -g0 -s"
  #export CXXFLAGS="-Os -g0"
+--- /dev/null	2019-10-28 16:42:28.211999999 +0100
++++ musl-cross/hashes/gmp-6.1.0.tar.bz2.sha256	2019-10-29 13:08:53.288687684 +0100
+@@ -0,0 +1 @@
++498449a994efeba527885c10405993427995d3f86b8768d8cdf8d9dd7c6b73e8  gmp-6.1.0.tar.bz2
+--- /dev/null	2019-10-28 16:42:28.211999999 +0100
++++ musl-cross/hashes/mpfr-3.1.4.tar.bz2.sha256	2019-10-29 13:08:53.292687684 +0100
+@@ -0,0 +1 @@
++d3103a80cdad2407ed581f3618c4bed04e0c92d1cf771a65ead662cc397f7775  mpfr-3.1.4.tar.bz2
+--- /dev/null	2019-10-28 16:42:28.211999999 +0100
++++ musl-cross/hashes/mpc-1.0.3.tar.gz.sha256	2019-10-29 13:08:53.296687684 +0100
+@@ -0,0 +1 @@
++617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3  mpc-1.0.3.tar.gz


### PR DESCRIPTION
These were the only three that were being pulled from git heads rather than specific tags or releases.

Also changes the top level `Makefile` extraction of tarballs to use `--strip 1`, which ensures that the extracted directory matches the name in `$($(MODULE)-dir)`.