### PR TITLE
gui-init: update TOTP error prompt

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -169,8 +169,14 @@ while true; do
       TOTP=`unseal-totp`
       if [ $? -ne 0 ]; then
         whiptail $CONFIG_ERROR_BG_COLOR --clear --title "ERROR: TOTP Generation Failed!" \
-          --menu "ERROR: Heads couldn't generate the TOTP code.\n\nIf this is the first time the system has booted, you should reset the TPM\nand set your own password\n\nIf you just reflashed your BIOS, you'll need to generate a new TOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 30 90 4 \
-          'g' ' Generate new TOTP/HOTP secret' \
+          --menu "    ERROR: Heads couldn't generate the TOTP code.\n
+    If you have just completed a Factory Reset, or just reflashed
+    your BIOS, you should generate a new HOTP/TOTP secret.\n
+    If this is the first time the system has booted, you should
+    reset the TPM and set your own password.\n
+    If you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n
+    How would you like to proceed?" 30 90 4 \
+          'g' ' Generate new HOTP/TOTP secret' \
           'i' ' Ignore error and continue to default boot menu' \
           'p' ' Reset the TPM' \
           'x' ' Exit to recovery shell' \


### PR DESCRIPTION
Update text on TOTP error prompt to provide better guidance for users
following the use of the OEM factory reset function

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>