### PR TITLE
unseal-hotp: ensure /boot mounted before checking HOTP secret

### DIFF
--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -21,21 +21,6 @@ mount_boot_or_die()
 # get current value of HOTP counter in TPM, create if absent
 mount_boot_or_die
 
-tpm nv_readvalue \
-	-in 4d47 \
-	-sz 312 \
-	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
-
-tpm unsealfile  \
-	-hk 40000000 \
-	-if "$HOTP_SEALED" \
-	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
-
-shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
-
-
 #check_tpm_counter $HOTP_COUNTER hotp \
 #|| die "Unable to find/create TPM counter"
 #counter="$TPM_COUNTER"
@@ -50,6 +35,20 @@ if [ "$counter_value" == "" ]; then
 fi
 
 #counter_value=$(printf "%d" 0x${counter_value})
+
+tpm nv_readvalue \
+	-in 4d47 \
+	-sz 312 \
+	-of "$HOTP_SEALED" \
+|| die "Unable to retrieve sealed file from TPM NV"
+
+tpm unsealfile  \
+	-hk 40000000 \
+	-if "$HOTP_SEALED" \
+	-of "$HOTP_SECRET" \
+|| die "Unable to unseal HOTP secret"
+
+shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
 
 if ! hotp $counter_value < "$HOTP_SECRET"; then
 	shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null


### PR DESCRIPTION
If /boot isn't mounted, we can't read the HOTP counter, so no point in reading from the TPM.
This speeds up getting to the main menu in the case of an inaccessible or non-existent /boot.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>