### PR TITLE
Rollback musl-cross to last known working commit

### DIFF
--- a/modules/msrtools
+++ b/modules/msrtools
@@ -5,7 +5,7 @@ msrtools_depends := $(musl_dep)
 #msrtools_version := git
 #msrtools_repo := https://github.com/osresearch/msr-tools
 
-msrtools_version := 572ef8a
+msrtools_version := 572ef8a2b873eda15a322daa48861140a078b92c
 msrtools_dir := msrtools-$(msrtools_version)
 msrtools_tar := msr-tools-$(msrtools_version).tar.gz
 #msrtools_url := https://github.com/intel/msr-tools/archive/msr-tools-$(msrtools_version).tar.gz

--- a/modules/musl-cross
+++ b/modules/musl-cross
@@ -23,11 +23,11 @@ else
 # Force a full build of the cross compiler
 
 modules-y += musl-cross
-musl-cross_version := 1952975
+musl-cross_version := 3b5b118f1cdddecda3f04b5005f69f962278fc1e
 musl-cross_dir := musl-cross
 musl-cross_url := https://github.com/GregorR/musl-cross/archive/$(musl-cross_version).tar.gz
 musl-cross_tar := musl-cross-$(musl-cross_version).tar.gz
-musl-cross_hash := dea10cfe4bfe5f5b131d8f98e65127cf5093477af56054d15563e858dc3b25cb
+musl-cross_hash := 050c41b7c724fd1b007bc06680274e6c8f203436a9ab727f7bdc227d7c40f079
 
 CROSS_TOP := crossgcc/x86_64-linux-musl/bin/x86_64-linux-musl-
 CROSS := $(build)/../$(CROSS_TOP)

--- a/modules/tpmtotp
+++ b/modules/tpmtotp
@@ -5,7 +5,7 @@ tpmtotp_depends := mbedtls qrencode $(musl_dep)
 #tpmtotp_version := git
 #tpmtotp_repo := https://github.com/osresearch/tpmtotp
 
-tpmtotp_version := 18b860f
+tpmtotp_version := 18b860fdcf5a55537c8395b891f2b2a5c24fc00a
 tpmtotp_dir := tpmtotp-$(tpmtotp_version)
 tpmtotp_tar := tpmtotp-$(tpmtotp_version).tar.gz
 tpmtotp_url := https://github.com/osresearch/tpmtotp/archive/$(tpmtotp_version).tar.gz

--- a/patches/musl-cross-3b5b118f1cdddecda3f04b5005f69f962278fc1e.patch
+++ b/patches/musl-cross-3b5b118f1cdddecda3f04b5005f69f962278fc1e.patch
@@ -1,5 +1,5 @@
 diff --git a/config.sh b/config.sh
-index ec3c1ce..844fb3d 100644
+index 4e321c9..6d9ea32 100644
 --- a/config.sh
 +++ b/config.sh
 @@ -1,13 +1,15 @@
@@ -20,7 +20,7 @@ index ec3c1ce..844fb3d 100644
  
  # If you use arm, you may need more fine-tuning:
  # arm hardfloat v7
-@@ -20,11 +22,14 @@ CC_BASE_PREFIX=/opt/cross
+@@ -20,7 +22,10 @@ CC_BASE_PREFIX=/opt/cross
  #GCC_BOOTSTRAP_CONFFLAGS="--with-arch=armv7-a --with-float=softfp"
  #GCC_CONFFLAGS="--with-arch=armv7-a --with-float=softfp"
  
@@ -29,10 +29,6 @@ index ec3c1ce..844fb3d 100644
  
  # Enable this to build the bootstrap gcc (thrown away) without optimization, to reduce build time
  GCC_STAGE1_NOOPT=1
- 
++
 +# Build GMP, MPFR and MPC
 +GCC_BUILTIN_PREREQS=yes
-+
- # uncomment these to get smaller/stripped binaries
- #export CFLAGS="-Os -g0 -s"
- #export CXXFLAGS="-Os -g0"


### PR DESCRIPTION
Builds working along with lvm.  Reproducibility checked using clean builds on Ubuntu 16.04, Ubuntu 18.04, Fedora 29, Fedora 30, Debian 10 and `make BOARD=qemu-coreboot`:

```
f63f560bda044eb5a540b20687613ef6bd07c290904a8acf86bec3365dad1fb5  build/qemu-coreboot/coreboot.rom
```

Make sure to remove `crossgcc/*` and `build/*` if using an existing tree to ensure everything is rebuilt.
