### PR TITLE
Add option to choose GnuPG userinfo during OEM reset

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -20,6 +20,10 @@ ADMIN_PIN_DEF=12345678
 TPM_PASS_DEF=12345678
 CUSTOM_PASS=""
 
+GPG_USER_NAME="OEM Key"
+GPG_KEY_NAME=`date +%Y%m%d%H%M%S`
+GPG_USER_MAIL="oem-${GPG_KEY_NAME}@example.com"
+GPG_USER_COMMENT="OEM-generated key"
 ## External files sourced
 
 . /etc/functions
@@ -54,7 +58,6 @@ whiptail_error_die()
 
 gpg_key_reset()
 {
-    GPG_KEY_NAME=`date +%Y%m%d%H%M%S`
     # Factory reset GPG card
     {
         echo admin
@@ -76,9 +79,9 @@ gpg_key_reset()
         echo ${USER_PIN_DEF}
         echo 0
         echo y
-        echo "OEM Key"
-        echo "oem-${GPG_KEY_NAME}@example.com"
-        echo "OEM-generated key"
+        echo ${GPG_USER_NAME} 
+        echo ${GPG_USER_MAIL}
+        echo ${GPG_USER_COMMENT}
     } | gpg --command-fd=0 --status-fd=2 --pinentry-mode=loopback --card-edit \
         > /tmp/gpg_card_edit_output 2>/dev/null 
     if [ $? -ne 0 ]; then
@@ -259,6 +262,24 @@ It must be at least 8 characters in length.\n"
   done
   echo
   TPM_PASS_DEF=$CUSTOM_PASS
+fi
+
+# Prompt to change default GnuPG key information
+echo -e -n "Would you like to set custom user information for the GnuPG key? [y/N]: "
+read -n 1 prompt_output
+echo
+if [ "$prompt_output" == "y" \
+  -o "$prompt_output" == "Y" ] \
+; then
+  echo -e "\nPlease enter the following information...\n"
+  echo
+  echo -e -n "Real name: "
+  read GPG_USER_NAME
+  echo -e -n "Email address: "
+  read GPG_USER_MAIL
+  echo -e -n "Comment: "
+  read GPG_USER_COMMENT
+  echo
 fi
 
 ## sanity check the USB, GPG key, and boot device before proceeding further

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -89,6 +89,7 @@ gpg_key_reset()
         whiptail_error_die "GPG Key automatic keygen failed!\n\n$ERROR"
     fi
 }
+
 gpg_key_change_pin()
 {
     # 1 = user PIN, 3 = admin PIN
@@ -271,15 +272,33 @@ echo
 if [ "$prompt_output" == "y" \
   -o "$prompt_output" == "Y" ] \
 ; then
-  echo -e "\nPlease enter the following information...\n"
-  echo
-  echo -e -n "Real name: "
-  read GPG_USER_NAME
-  echo -e -n "Email address: "
-  read GPG_USER_MAIL
-  echo -e -n "Comment: "
-  read GPG_USER_COMMENT
-  echo
+	echo -e "\n\n"
+	echo -e "We will generate a GnuPG (PGP) keypair identifiable with the following text form:"
+	echo -e "Real Name (Comment) email@address.org"
+
+	echo -e "\nEnter your Real Name (At least 5 characters long):"
+	read -r GPG_USER_NAME
+	while [[ ${#GPG_USER_NAME} -lt 5 ]]; do
+	{
+		echo -e "\nEnter your Real Name (At least 5 characters long):"
+		read -r GPG_USER_NAME
+	};done
+
+	echo -e "\nEnter your email@adress.org:"
+	read -r GPG_USER_MAIL
+	while ! $(expr "$GPG_USER_MAIL" : '.*@' >/dev/null); do
+	{
+		echo -e "\nEnter your email@address.org:"
+		read -r GPG_USER_MAIL
+	};done
+
+	echo -e "\nEnter Comment (Optional, to distinguish this key from others with same previous attributes. Must be smaller then 60 characters):"
+	read -r GPG_USER_MAIL
+	while [[ ${#gpgcard_comment} -gt 60 ]]; do
+	{
+		echo -e "\nEnter Comment (Optional, to distinguish this key from others with same previous attributes. Must be smaller then 60 characters):"
+		read -r GPG_USER_MAIL
+	};done
 fi
 
 ## sanity check the USB, GPG key, and boot device before proceeding further


### PR DESCRIPTION
It is already possible to change the default user and admin/TPM PIN during OEM factory reset. It would be nice to also be able to choose a proper name, mail and comment field for the GnuPG keys.