### PR TITLE
libremkey-hotp-verification: toolchain adjustments

### DIFF
--- a/modules/libremkey-hotp-verification
+++ b/modules/libremkey-hotp-verification
@@ -16,4 +16,5 @@ libremkey-hotp-verification_output := \
 
 libremkey-hotp-verification_configure := \
   INSTALL="$(INSTALL)" \
+  CROSS="$(CROSS)" \
   cmake -DCMAKE_TOOLCHAIN_FILE=./Toolchain-heads.cmake -DCMAKE_AR="$(CROSS)ar" . 

--- a/patches/libremkey-hotp-verification.patch
+++ b/patches/libremkey-hotp-verification.patch
@@ -1,15 +1,24 @@
 --- nitrokey-hotp-verification-a/Toolchain-heads.cmake	2018-05-22 09:55:46.907209235 -0700
 +++ nitrokey-hotp-verification-b/Toolchain-heads.cmake	2018-05-22 09:55:26.659371966 -0700
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,27 @@
 +SET(CMAKE_SYSTEM_NAME Linux)
 +SET(CMAKE_SYSTEM_VERSION 1)
 +
 +# Specify the cross compiler
-+SET(CMAKE_C_COMPILER $ENV{INSTALL}/bin/musl-gcc)
-+SET(CMAKE_CXX_COMPILER $ENV{INSTALL}/bin/musl-gcc)
++SET(CMAKE_C_COMPILER $ENV{CROSS}gcc)
++SET(CMAKE_CXX_COMPILER $ENV{CROSS}gcc)
++
++#sysroot location
++set(MYSYSROOT $ENV{INSTALL})
++
++# compiler/linker flags
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --sysroot=${MYSYSROOT}" CACHE INTERNAL "" FORCE)
++set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} --sysroot=${MYSYSROOT}" CACHE INTERNAL "" FORCE)
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --sysroot=${MYSYSROOT}" CACHE INTERNAL "" FORCE)
++set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} --sysroot=${MYSYSROOT}" CACHE INTERNAL "" FORCE)
 +
 +# Where is the target environment
-+SET(CMAKE_FIND_ROOT_PATH $ENV{INSTALL})
++SET(CMAKE_FIND_ROOT_PATH "${MYSYSROOT}")
 +
 +# Search for programs only in the build host directories
 +SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Pass through new toolchain path via $(CROSS) so we can set the
c/c++ compiler paths correctly for CMake. Adjust patch to use
new paths, and fix compiler/linker paths to correct a libusb linking issue.

This fixes compilation of the libremkey-hotp-verification module, which was broken
when toolchain was changed to musl-cross-make in commit 791d064.

CMake isn't my forte, so open to "better" solutions.
Fix derived from: https://stackoverflow.com/questions/36195791/

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>