### PR TITLE
flash.sh: Add progress bar

### DIFF
--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -15,6 +15,89 @@ case "$CONFIG_FLASHROM_OPTIONS" in
   ;;
 esac
 
+flashrom_progress() {
+    local current=0
+    local total_bytes=0
+    local percent=0
+    local IN=''
+    local spin='-\|/'
+    local spin_idx=0
+    local progressbar=''
+    local progressbar2=''
+    local status='init'
+    local prev_word=''
+    local prev_prev_word=''
+
+    progressbar2=$(for i in `seq 48` ; do echo -ne ' ' ; done)
+    echo -e "\nInitializing internal Flash Programmer"
+    while true ; do
+        prev_prev_word=$prev_word
+        prev_word=$IN
+        read -r -d' ' IN || break
+        if [ "$total_bytes" != "0" ]; then
+            current=$(echo "$IN" | grep -E -o '0x[0-9a-f]+-0x[0-9a-f]+:.*' | grep -E -o "0x[0-9a-f]+" | tail -n 1)
+            if [ "${current}" != "" ]; then
+                percent=$((100 * (current + 1) / total_bytes))
+                pct1=$((percent / 2))
+                pct2=$((49 - percent / 2))
+                progressbar=$(for i in `seq $pct1 2>/dev/null` ; do echo -ne '#' ; done)
+                progressbar2=$(for i in `seq $pct2 2>/dev/null` ; do echo -ne ' ' ; done)
+            fi
+        else
+            if [ "$prev_prev_word"  == "Reading" ] && [ "$IN" == "bytes" ]; then
+                # flashrom may read the descriptor first, so ensure total_bytes is at least 4MB
+                if [[ $prev_word -gt  4194303 ]]; then
+                    total_bytes=$prev_word
+                    echo "Total flash size : $total_bytes bytes"
+                fi
+            fi
+        fi
+        if [ "$percent" -gt 99 ]; then
+            spin_idx=4
+        else
+            spin_idx=$(( (spin_idx+1) %4 ))
+        fi
+        if [ "$status" == "init" ]; then
+            if [ "$IN" == "contents..." ]; then
+                status="reading"
+                echo "Reading old flash contents. Please wait..."
+            fi
+        fi
+        if [ "$status" == "reading" ]; then
+            if echo "${IN}" | grep "done." > /dev/null ; then
+                status="writing"
+            fi
+        fi
+        if [ "$status" == "writing" ]; then
+            echo -ne "Flashing: [${progressbar}${spin:$spin_idx:1}${progressbar2}] (${percent}%)\\r"
+            if echo "$IN" | grep "Verifying" > /dev/null ; then
+                status="verifying"
+                echo ""
+                echo "Verifying flash contents. Please wait..."
+            fi
+            if echo "$IN" | grep "identical" > /dev/null ; then
+                status="done"
+		        echo ""
+                echo "The flash contents are identical to the image being flashed."
+            fi
+        fi
+        if [ "$status" == "verifying" ]; then
+            if echo "${IN}" | grep "VERIFIED." > /dev/null ; then
+                status="done"
+                echo "The flash contents were verified and the image was flashed correctly."
+            fi
+        fi
+    done
+    echo ""
+    if [ "$status" == "done" ]; then
+        return 0
+    else
+        echo 'Error flashing coreboot -- see timestampped flashrom log in /tmp for more info'
+        echo ""
+        return 1
+    fi
+}
+
 flash_rom() {
   ROM=$1
   if [ "$READ" -eq 1 ]; then
@@ -45,7 +128,8 @@ flash_rom() {
     fi
 
     flashrom $CONFIG_FLASHROM_OPTIONS -w /tmp/${CONFIG_BOARD}.rom \
-    || die "$ROM: Flash failed"
+      -V -o "/tmp/flashrom-$(date '+%Y%m%d-%H%M%S').log" 2>&1 | flashrom_progress \
+      || die "$ROM: Flash failed"
   fi
 }
 


### PR DESCRIPTION
Show progress of flashrom reads/writes when flashing by means
of a progress bar, adapted from the Librem coreboot flashing script.

Also provides a time-stamped flashrom log in /tmp to aid diagnosis in the
event that a firmware update fails.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>