### PR TITLE
init: fix invalid GPG_TTY variable

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -52,7 +52,7 @@ if [ "$CONFIG_LINUXBOOT" = "y" ]; then
 fi
 
 # Set GPG_TTY before calling gpg in key-init
-export GPG_TTY=$(tty)
+export GPG_TTY=/dev/console
 
 /bin/key-init
 


### PR DESCRIPTION
busyboy tty isn't working after the musl-cross-make change so
revert to known good value.