### PR TITLE
flash-gui: set unset variable USB_FAILED

### DIFF
--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -7,7 +7,7 @@ set -e -o pipefail
 mount_usb(){
 # Mount the USB boot device
   if ! grep -q /media /proc/mounts ; then
-    mount-usb "$CONFIG_USB_BOOT_DEV" || USB_FAILED=1
+    mount-usb "$CONFIG_USB_BOOT_DEV" && USB_FAILED=0 || USB_FAILED=1
     if [ $USB_FAILED -ne 0 ]; then
       if [ ! -e "$CONFIG_USB_BOOT_DEV" ]; then
         whiptail --title 'USB Drive Missing' \


### PR DESCRIPTION
Not setting USB_FAILED when call to mount-usb succeeds results
in a spurious 'sh: 0 unknown operand' error printed to console.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>