### PR TITLE
init: load usb modules for devices using USB keyboard

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -128,9 +128,6 @@ clean_boot_check()
     "Clean Boot Detected - Perform OEM Factory Reset?" "$CONFIG_WARNING_BG_COLOR"
 }
 
-# enable USB to load modules for external kb
-enable_usb
-
 if detect_boot_device ; then
   # /boot device with installed OS found
   clean_boot_check

--- a/initrd/init
+++ b/initrd/init
@@ -64,6 +64,11 @@ if [ ! -z "$CONFIG_BOOT_RECOVERY_SERIAL" ]; then
 		> "$CONFIG_BOOT_RECOVERY_SERIAL" 2>&1 &
 fi
 
+# load USB modules for boards using a USB keyboard
+if [ "$CONFIG_USB_KEYBOARD" = "y" ]; then
+	enable_usb
+fi
+
 # If the user has been holding down r, enter a recovery shell
 # otherwise immediately start the configured boot script.
 # We don't print a prompt, since this is a near instant timeout.


### PR DESCRIPTION
Some (out of tree) servers require use of a USB keyboard, and need
the USB kernel modules loaded prior to checking for keypress to enter
a recovery console. Since loading the modules affects the value in PRC5
and can cause issues putting a LUKS key in TPM, guard the loading of the
USB modules with CONFIG_USB_KEYBOARD and remove the unguarded call from
gui-init.

This should resolve issues #603 and #674.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>