### PR TITLE
modules/flashrom: update to v1.1 release

### DIFF
--- a/modules/flashrom
+++ b/modules/flashrom
@@ -5,11 +5,11 @@ flashrom_depends := pciutils $(musl_dep)
 #flashrom_version := git
 #flashrom_repo := https://github.com/osresearch/flashrom
 
-flashrom_version := 1.0
+flashrom_version := v1.1
 flashrom_dir := flashrom-$(flashrom_version)
 flashrom_tar := flashrom-$(flashrom_version).tar.bz2
 flashrom_url := https://download.flashrom.org/releases/$(flashrom_tar)
-flashrom_hash := 3702fa215ba5fb5af8e54c852d239899cfa1389194c1e51cb2a170c4dc9dee64
+flashrom_hash := aeada9c70c22421217c669356180c0deddd0b60876e63d2224e3260b90c14e19
 
 flashrom_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
TODO:
- migrate kgpe-d16 patch (still needed?)
- drop x220 patch (now supported)
- adjust FLASHROM_OPTIONS in board configs (:laptop=force... no longer needed)

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>