### PR TITLE
gui-init: fix checking librem key card-status

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -118,8 +118,11 @@ clean_boot_check()
   [ $GPG_KEY_COUNT -ne 0 ] && return
 
    # check for USB security token
-  if ! gpg --card-status > /dev/null ; then
-   return
+  if [ "$CONFIG_LIBREMKEY" = "y" ]; then
+    enable_usb
+    if ! gpg --card-status > /dev/null ; then
+      return
+    fi
   fi
 
   # OS is installed, no kexec files present, no GPG keys in keyring, security token present


### PR DESCRIPTION
Commit 6b5adcca moved the call to enable_usb from gui-init
to init and guarded it with CONFIG_USB_KEYBOARD, but it was
missed that this is needed for the clean boot check logic
when a librem key is used. Add the call back to gui-init
and guard it properly

Test: clean_boot_detect works properly on a librem 13v4

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>