### PR TITLE
qemu-coreboot: finally a useable debug/test board

### DIFF
--- a/boards/qemu-coreboot/qemu-coreboot.config
+++ b/boards/qemu-coreboot/qemu-coreboot.config
@@ -50,10 +50,13 @@ export CONFIG_TPM=n
 
 export CONFIG_BOOT_DEV="/dev/sda1"
 
-#run: coreboot.intermediate
+#borrowed from https://github.com/orangecms/webboot/blob/boot-via-qemu/run-webboot.sh
 run:
 	qemu-system-x86_64 \
 		--machine q35 \
 		--serial /dev/tty \
 		--bios $(build)/$(BOARD)/coreboot.rom \
+		-object rng-random,filename=/dev/urandom,id=rng0 \
+		-device virtio-rng-pci,rng=rng0 \
+		-netdev user,id=u1 -device e1000,netdev=u1 \
 	; stty sane

--- a/config/coreboot-qemu.config
+++ b/config/coreboot-qemu.config
@@ -14,5 +14,6 @@ CONFIG_CPU_MICROCODE_CBFS_GENERATE=y
 # CONFIG_CONSOLE_SERIAL is not set
 CONFIG_DEFAULT_CONSOLE_LOGLEVEL_6=y
 CONFIG_PAYLOAD_LINUX=y
+CONFIG_LINUX_COMMAND_LINE="debug console=ttyS0 vga=786"
 CONFIG_PAYLOAD_FILE="../../build/qemu-coreboot/bzImage"
 CONFIG_LINUX_INITRD="../../build/qemu-coreboot/initrd.cpio.xz"


### PR DESCRIPTION
Now useful to debug something through make BOARD=qemu-coreboot.

TODO: [map a virtual TPM instance ](https://github.com/osresearch/heads/issues/516#issuecomment-538776741) and USB passthrough. 

Thanks to @orangecms for the tip. If you have others regarding https://github.com/osresearch/heads/issues/516#issuecomment-492695279, you are more then welcome.

Fixes #516 #701 and #158 

Based on top of #706 (should be merged first)

With testing happening on #700, another pull request will bonify he debugging output of this board too since debugfs will be useful through /etc/fstab presence.