### PR TITLE
Add option to build against coreboot 4.12

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -3,6 +3,9 @@ modules-$(CONFIG_COREBOOT) += coreboot
 ifeq "$(CONFIG_COREBOOT_VERSION)" "4.8.1"
 coreboot_version := 4.8.1
 coreboot_hash := f0ddf4db0628c1fe1e8348c40084d9cbeb5771400c963fd419cda3995b69ad23
+else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.12"
+coreboot_version := 4.12
+coreboot_hash := edcad000ee9b73183c396ea76155629b3d27c693e0f1ae83e3424c4d936e2be2
 else
 $(error "$(BOARD): does not specify coreboot version under CONFIG_COREBOOT_VERSION")
 endif 
@@ -55,7 +58,16 @@ coreboot_target := \
 coreboot_output := coreboot.rom
 coreboot_depend += linux initrd $(musl_dep)
 
-$(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL)
+ifeq "$(CONFIG_COREBOOT_VERSION)" "4.8.1"
+COREBOOT_TOOLCHAIN=""
+$(COREBOOT_TOOLCHAIN):
+else
+COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
+$(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
+	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=`nproc` crossgcc-i386
+endif
+
+$(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL) $(COREBOOT_TOOLCHAIN)
 $(COREBOOT_IASL): $(build)/$(coreboot_base_dir)/.canary
 	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=`nproc` iasl
 
@@ -98,10 +110,17 @@ modules-y += coreboot-blobs
 
 coreboot-blobs_version := $(coreboot_version)
 coreboot-blobs_tar := coreboot-blobs-$(coreboot-blobs_version).tar.xz
+coreboot-blobs_url := https://www.coreboot.org/releases/$(coreboot-blobs_tar)
+
+ifeq "$(CONFIG_COREBOOT_VERSION)" "4.8.1"
 coreboot-blobs_tar_opt := --strip 3
 coreboot-blobs_dir := coreboot-$(coreboot-blobs_version)/3rdparty/blobs
-coreboot-blobs_url := https://www.coreboot.org/releases/$(coreboot-blobs_tar)
 coreboot-blobs_hash := 18aa509ae3af005a05d7b1e0b0246dc640249c14fc828f5144b6fd20bb10e295
+else
+coreboot-blobs_tar_opt := --strip 2
+coreboot-blobs_dir := coreboot-$(coreboot-blobs_version)/3rdparty
+coreboot-blobs_hash := 4735ee6850d55d1e65dee8b08cc9b28b8af00b42acf31365f5d9545406579104
+endif
 
 ## there is nothing to build for the blobs, this should be
 ## made easier to make happen


### PR DESCRIPTION
Update Heads to allow building with coreboot 4.12:

* update version and hashes for coreboot and coreboot-blobs
* use coreboot's own toolchain (adapted from #709)

Build/boot tested on Librem 13v2/13v4/15v3/15v4, x230, qemu-coreboot-fbwhiptail 

Outstanding issues:
 * Qubes/Xen fails to boot on SKL/KBL Librems (fine on x230 and out of tree WHL-based Librem Mini)
 * Individual boards can be migrated to coreboot 4.12 in subsequent PRs
