### PR TITLE
upgrade gpg toolstack to latest versions

### DIFF
--- a/modules/gpg2
+++ b/modules/gpg2
@@ -1,10 +1,10 @@
 modules-$(CONFIG_GPG2) += gpg2
 
-gpg2_version := 2.2.10
+gpg2_version := 2.2.20
 gpg2_dir := gnupg-$(gpg2_version)
 gpg2_tar := gnupg-$(gpg2_version).tar.bz2
 gpg2_url := https://www.gnupg.org/ftp/gcrypt/gnupg/$(gpg2_tar)
-gpg2_hash := 799dd37a86a1448732e339bd20440f4f5ee6e69755f6fd7a73ee8af30840c915
+gpg2_hash := 04a7c9d48b74c399168ee8270e548588ddbe52218c337703d7f06373d326ca30
 
 # For reproducibility reasons we have to override the exec_prefix
 # and datarootdir on the configure line so that the Makefiles will
@@ -16,7 +16,7 @@ gpg2_configure := ./configure \
 	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--host x86_64-linux-musl \
 	--with-libusb="$(INSTALL)" \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--with-libgcrypt-prefix="$(INSTALL)" \
 	--with-libassuan-prefix="$(INSTALL)" \
 	--with-ksba-prefix="$(INSTALL)" \
@@ -30,19 +30,12 @@ gpg2_configure := ./configure \
         --disable-regex \
         --disable-doc \
 	--disable-bzip2 \
-	--disable-asm \
 	--disable-exec \
 	--disable-photo-viewers \
-	--disable-keyserver-helpers \
 	--disable-ldap \
-	--disable-hkp \
-	--disable-finger \
-	--disable-dns-srv \
-	--disable-dns-cert \
 	--disable-regex \
 	--disable-nls \
 	--disable-all-tests \
-	--disable-wks-server \
 	--disable-wks-tools \
 	--disable-gnutls \
 	--disable-dirmngr \

--- a/modules/libassuan
+++ b/modules/libassuan
@@ -1,18 +1,16 @@
 modules-$(CONFIG_GPG2) += libassuan
-libassuan_version := 2.5.1
+libassuan_version := 2.5.3
 libassuan_dir := libassuan-$(libassuan_version)
 libassuan_tar := libassuan-$(libassuan_version).tar.bz2
 libassuan_url := https://gnupg.org/ftp/gcrypt/libassuan/$(libassuan_tar)
-libassuan_hash := 47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449
+libassuan_hash := 91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702
 
 libassuan_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 libassuan_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/libgcrypt
+++ b/modules/libgcrypt
@@ -1,16 +1,16 @@
 modules-$(CONFIG_GPG2) += libgcrypt
-libgcrypt_version := 1.8.3
+libgcrypt_version := 1.8.5
 libgcrypt_dir := libgcrypt-$(libgcrypt_version)
 libgcrypt_tar := libgcrypt-$(libgcrypt_version).tar.bz2
 libgcrypt_url := https://gnupg.org/ftp/gcrypt/libgcrypt/$(libgcrypt_tar)
-libgcrypt_hash := 66ec90be036747602f2b48f98312361a9180c97c68a690a5f376fa0f67d0af7c
+libgcrypt_hash := 3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
 
 libgcrypt_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--host=x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--disable-asm \
 
 libgcrypt_target := $(MAKE_JOBS) \

--- a/modules/libgpg-error
+++ b/modules/libgpg-error
@@ -1,9 +1,9 @@
 modules-$(CONFIG_GPG2) += libgpg-error
-libgpg-error_version := 1.32
+libgpg-error_version := 1.37
 libgpg-error_dir := libgpg-error-$(libgpg-error_version)
 libgpg-error_tar := libgpg-error-$(libgpg-error_version).tar.bz2
 libgpg-error_url := https://gnupg.org/ftp/gcrypt/libgpg-error/$(libgpg-error_tar)
-libgpg-error_hash := c345c5e73cc2332f8d50db84a2280abfb1d8f6d4f1858b9daa30404db44540ca
+libgpg-error_hash := b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763
 
 libgpg-error_configure := ./configure \
 	$(CROSS_TOOLS) \
@@ -14,7 +14,6 @@ libgpg-error_configure := ./configure \
 	--disable-languages \
 	--disable-doc \
 	--disable-tests \
-	--disable-asm \
 
 libgpg-error_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/libksba
+++ b/modules/libksba
@@ -10,9 +10,7 @@ libksba_configure := ./configure \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 libksba_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/npth
+++ b/modules/npth
@@ -10,9 +10,7 @@ npth_configure := ./configure \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 npth_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/pinentry
+++ b/modules/pinentry
@@ -27,7 +27,8 @@ pinentry_configure := ./configure \
 	--disable-pinentry-fltk \
 	--disable-pinentry-emacs \
 	--disable-fallback-curses \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--disable-pinentry-qt5   \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--with-libassuan-prefix="$(INSTALL)" \
 
 # Run one build to generate the executables with the pre-defined


### PR DESCRIPTION
- Remove unrecognized configure options
- fixes gawk issue #668 by upgrading to libgpg-error 1.37 instead of patching 1.32 for regex change (fixed upstream)
- move patches so they match new versions for libassuan, gpg and libgcrypt (no change)

Version change:
- gpg 2.2.10 -> 2.2.20
- libassuan 2.5.1 -> 2.5.3
- libgcrypt 1.8.3 -> 1.8.5
- libgpg-error 1.32 -> 1.37

Size changes:
- gpg                   886.5 -> 911.3 kB
- gpg-agent:            371.9 -> 376.0 kB
- scdaemon:             399.5 -> 407.8 kB
- libgpg-error.so.0     125.9 -> 130.0 kB

Unrecognized options on gpg2 toolstack:
- disable-nls and disable-asm disable-keyserver-helpers disable-hkp disable-finger disable-dns-srv disable-dns-cert and disable-wks-server

(Sorry. This is a exact redo of https://github.com/osresearch/heads/pull/714 without CI changes that got merged and reverted upstream. Sorry, commit history.)