### PR TITLE
CIs: Replace cache fingerprints so cache is reusable between builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: heads-{{ .Branch }}{{ .Environment.CACHE_VERSION }}
+          key: heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
       - run:
           name: git reset
@@ -154,7 +154,7 @@ jobs:
           path: build/qemu-coreboot
 
       - save_cache:
-          key: heads-{{ .Branch }}{{ .Environment.CACHE_VERSION }}
+          key: heads-{{ .CIRCLE_PROJECT_USERNAME }}{{ .Environment.CACHE_VERSION }}
           paths:
             - packages
             - crossgcc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ build:
       - packages
       - crossgcc
       - build
-    key: "$CI_COMMIT_REF_SLUG"
+    key: "heads-$GITLAB_USER_LOGIN"
   script:
     - dnf install -y @development-tools gcc-c++ gcc-gnat zlib-devel perl-Digest-MD5 perl-Digest-SHA uuid-devel pcsc-tools ncurses-devel lbzip2 libuuid-devel lzma elfutils-libelf-devel bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget libusb-devel cmake automake pv bsdiff autoconf libtool cpio texinfo
     - git fetch origin 


### PR DESCRIPTION
Both CircleCI and GitlabCI will now depend on `heads-username` tuple to build a reusable cache from the CI that launches the builds.

This will permit PRs to be built faster for an established CI.

Notes:
- GitlabCI permits to invalidate the cache from GUI directly from a failing pipeline.
- CircleCI requires to change a environment variable from the envirnment variable GUI. In case a build needs to have its cache flushed out, the project owner on a CI needs to change `CACHE_VERSION` to something new and restart the build.