### PR TITLE
Add partition Label to list of mount-usb

### DIFF
--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -55,10 +55,10 @@ if [ -z ${USB_MOUNT_DEVICE} ]; then
     # remove block device from list if numeric partitions exist, since not bootable
     let USB_NUM_PARTITIONS=`ls -1 $i* | wc -l`-1
     if [ ${USB_NUM_PARTITIONS} -eq 0 ]; then
-      echo $i $(blkid | grep $i | grep -o 'LABEL=".*"' | sed 's/\ UUID.*$//') >> /tmp/usb_disk_list
+      echo $(blkid | grep $i | grep -o 'LABEL=".*"' | cut -f2 -d '"') $i >> /tmp/usb_disk_list
     else
       for j in $(ls $i* | tail -${USB_NUM_PARTITIONS}); do
-        echo $j $(blkid | grep $j | grep -o 'LABEL=".*"' | sed 's/\ UUID.*$//') >> /tmp/usb_disk_list
+        echo $(blkid | grep $j | grep -o 'LABEL=".*"' | cut -f2 -d '"') $j >> /tmp/usb_disk_list
       done
     fi
   done

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -55,9 +55,11 @@ if [ -z ${USB_MOUNT_DEVICE} ]; then
     # remove block device from list if numeric partitions exist, since not bootable
     let USB_NUM_PARTITIONS=`ls -1 $i* | wc -l`-1
     if [ ${USB_NUM_PARTITIONS} -eq 0 ]; then
-      echo $i >> /tmp/usb_disk_list
+      echo $i $(blkid | grep $i | grep -o 'LABEL=".*"' | sed 's/\ UUID.*$//') >> /tmp/usb_disk_list
     else
-      ls $i* | tail -${USB_NUM_PARTITIONS} >> /tmp/usb_disk_list
+      for j in $(ls $i* | tail -${USB_NUM_PARTITIONS}); do
+        echo $j $(blkid | grep $j | grep -o 'LABEL=".*"' | sed 's/\ UUID.*$//') >> /tmp/usb_disk_list
+      done
     fi
   done
 
@@ -95,7 +97,7 @@ if [ -z ${USB_MOUNT_DEVICE} ]; then
   if [ "$option_index" = "a" ]; then
     exit 1
   fi
-  USB_MOUNT_DEVICE=`head -n $option_index /tmp/usb_disk_list | tail -1`
+  USB_MOUNT_DEVICE=`head -n $option_index /tmp/usb_disk_list | tail -1 | sed 's/\ .*$//'`
 fi
 
 if [ "$1" = "rw" ]; then

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -55,10 +55,10 @@ if [ -z ${USB_MOUNT_DEVICE} ]; then
     # remove block device from list if numeric partitions exist, since not bootable
     let USB_NUM_PARTITIONS=`ls -1 $i* | wc -l`-1
     if [ ${USB_NUM_PARTITIONS} -eq 0 ]; then
-      echo $(blkid | grep $i | grep -o 'LABEL=".*"' | cut -f2 -d '"') $i >> /tmp/usb_disk_list
+      echo $i $(blkid | grep $i | grep -o 'LABEL=".*"' | cut -f2 -d '"') >> /tmp/usb_disk_list
     else
       for j in $(ls $i* | tail -${USB_NUM_PARTITIONS}); do
-        echo $(blkid | grep $j | grep -o 'LABEL=".*"' | cut -f2 -d '"') $j >> /tmp/usb_disk_list
+        echo $j $(blkid | grep $j | grep -o 'LABEL=".*"' | cut -f2 -d '"') >> /tmp/usb_disk_list
       done
     fi
   done


### PR DESCRIPTION
This helps people to differentiate their USB drives, if they have multiple devices inserted (e.g. Nitrokey Storage + USB drive).