### PR TITLE
gui-init: Fix RAM and firmware version strings

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -377,10 +377,10 @@ while true; do
 
   if [ "$totp_confirm" = "S" ]; then
     memtotal=$(cat /proc/meminfo | grep 'MemTotal' | tr -s ' ' | cut -f2 -d ' ')
-    memtotal=$((${memtotal} / 1024 + 1))
+    memtotal=$((${memtotal} / 1024 / 1024 + 1))
     cpustr=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed -r 's/\(R\)//;s/\(TM\)//;s/CPU //;s/model name.*: //')
     whiptail --title 'System Info' \
-      --msgbox "VER: ${FW_VER}\n\nCPU: ${cpustr}\nRAM: ${memtotal} MB\n\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
+      --msgbox "VER: ${FW_VER}\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
     continue
   fi
 

--- a/initrd/init
+++ b/initrd/init
@@ -93,7 +93,9 @@ combine_configs
 . /tmp/config
 
 # export firmware version
-export FW_VER=$(dmesg | grep 'DMI' | grep -o 'BIOS.*' | cut -f2 -d ' ')
+export FW_VER=$(dmesg | grep 'DMI' | grep -o 'BIOS.*' | cut -f2- -d ' ')
+# chop off date, since will always be epoch w/timeless builds
+FW_VER=${FW_VER::-10}
 
 # Add our boot devices into the /etc/fstab, if they are defined
 # in the configuration file.


### PR DESCRIPTION
Show RAM in GB, since the calculation in MB is imprecise as
it excludes RAM allocated for GPU (eg).

Fix display of firmware version strings which contain spaces by
adjusting cut and simply chopping off the date at the end, which
is a fixed 10-char length.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>