### PR TITLE
modules/hotp-verification: update to upstream master

### DIFF
--- a/modules/hotp-verification
+++ b/modules/hotp-verification
@@ -2,11 +2,11 @@ modules-$(CONFIG_HOTPKEY) += hotp-verification
 
 hotp-verification_depends := libusb $(musl_dep)
 
-hotp-verification_version := 5fb260e631b237a298b6dcca47bbd728f2c5ac3a
+hotp-verification_version := 03a198c418a60c54ef3ec67ea8a9a2d29b675b9b
 hotp-verification_dir := hotp-verification-$(hotp-verification_version)
 hotp-verification_tar := nitrokey-hotp-verification-$(hotp-verification_version).tar.gz
 hotp-verification_url := https://github.com/Nitrokey/nitrokey-hotp-verification/archive/$(hotp-verification_version).tar.gz
-hotp-verification_hash := 5d98d158ba97fb970061d68e2c6f41582395e687b7752efb1a8038762b0e7b79
+hotp-verification_hash := 0fca30856b38517db6a0bb420b8b3a76730af17ce987b7dd9e700992c82559b4
 
 hotp-verification_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
modules/hotp-verification: update to upstream master

Update hotp-verification to Nitrokey upstream commit 03a198c4.

Test: build/boot Librem 13v4, verify Librem key verification functional.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>