### PR TITLE
Encapsulate changes to working directory inside subshells

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -42,7 +42,7 @@ verify_global_hashes()
   TMP_PACKAGE_TRIGGER_PRE="/tmp/kexec/kexec_package_trigger_pre.txt"
   TMP_PACKAGE_TRIGGER_POST="/tmp/kexec/kexec_package_trigger_post.txt"
 
-  if cd /boot && sha256sum -c "$TMP_HASH_FILE" > /tmp/hash_output ; then
+  if ( cd /boot && sha256sum -c "$TMP_HASH_FILE" > /tmp/hash_output ) then
     return 0
   elif [ ! -f $TMP_HASH_FILE ]; then
     if (whiptail $CONFIG_ERROR_BG_COLOR --clear --title 'ERROR: Missing Hash File!' \

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -217,8 +217,8 @@ set_default_boot_option()
     echo "$entry" > /boot/kexec_default.1.txt
 
     # validate boot option
-    cd /boot && /bin/kexec-boot -b "/boot" -e "$entry" -f \
-        | xargs sha256sum > $hash_file 2>/dev/null \
+    ( cd /boot && /bin/kexec-boot -b "/boot" -e "$entry" -f \
+        | xargs sha256sum > $hash_file 2>/dev/null ) \
         || whiptail_error_die "Failed to create hashes of boot files"
 }
 

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -271,13 +271,15 @@ update_checksums()
 		|| recovery "Unable to mount /boot"
 	fi
 	# remount RW
-    	mount -o rw,remount /boot
-	cd /boot
-	find ./ -type f ! -name '*kexec*' | xargs sha256sum > /boot/kexec_hashes.txt
-	if [ -e /boot/kexec_default_hashes.txt ]; then
-	  DEFAULT_FILES=$(cat /boot/kexec_default_hashes.txt | cut -f3 -d ' ')
-	  echo $DEFAULT_FILES | xargs sha256sum > /boot/kexec_default_hashes.txt
-	fi
+	mount -o rw,remount /boot
+	(
+	  cd /boot
+	  find ./ -type f ! -name '*kexec*' | xargs sha256sum > /boot/kexec_hashes.txt
+	  if [ -e /boot/kexec_default_hashes.txt ]; then
+	    DEFAULT_FILES=$(cat /boot/kexec_default_hashes.txt | cut -f3 -d ' ')
+	    echo $DEFAULT_FILES | xargs sha256sum > /boot/kexec_default_hashes.txt
+	  fi
+	)
 	# Remove any package trigger log files
 	# We don't need them after the user decides to sign
 	rm -f /boot/kexec_package_trigger*
@@ -301,7 +303,7 @@ update_checksums()
 detect_boot_device()
 {
 	# unmount /boot to be safe
-	umount /boot 2>/dev/null
+	cd / && umount /boot 2>/dev/null
 
 	# check $CONFIG_BOOT_DEV if set/valid
 	if [ -e "$CONFIG_BOOT_DEV" ]; then


### PR DESCRIPTION
For the handful of operations which need to be done with /boot
as the pwd, encapsulate them in subshells to ensure the pwd
doesn't unexpectedly change for other operations, as functions
which need to mount/unmount /boot may fail if the pwd isn't root.

Also, set the pwd to root at the start of detect_boot_device as an
added safety measure.

Test: run oem-factory-reset function, ensure it doesn't fail to
detect boot device due to incorrect working directory.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>