### PR TITLE
seal-hotp: Fix HOTP key identification

### DIFF
--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -68,9 +68,9 @@ if ! hotp_verification info ; then
 fi
 
 # Set HOTP USB Security Dongle branding based on VID
-if [ ! $(lsusb | grep -q "20a0:") ]; then
+if lsusb | grep -q "20a0:" ; then
 	HOTPKEY_BRANDING="Nitrokey"
-elif [ ! $(lsusb | grep -q "316d:") ]; then
+elif lsusb | grep -q "316d:" ; then
 	HOTPKEY_BRANDING="Librem Key"
 else
 	HOTPKEY_BRANDING="HOTP USB Security Dongle"


### PR DESCRIPTION
With current implementation, Librem Keys with VID 0x316d are
not identified properly; correct the if/else logic to resolve.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>