### PR TITLE
Fix OEM factory reset and setting of default boot with F32

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -173,7 +173,7 @@ scan_options() {
 			kexec-parse-bls "$bootdir" "$i" "$bootdir/loader/entries" >> $option_file
 		done
 	fi
-	if [ ! -r $option_file ]; then
+	if [ ! -s $option_file ]; then
 		die "Failed to parse any boot options"
 	fi
 	if [ "$unique" = 'y' ]; then

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -209,7 +209,7 @@ set_default_boot_option()
         kexec-parse-bls "/boot" "$i" "/boot/loader/entries" >> $option_file
       done
     fi
-    [ ! -r $option_file ] \
+    [ ! -s $option_file ] \
         && whiptail_error_die "Failed to parse any boot options"
 
     # sort boot options

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -201,6 +201,14 @@ set_default_boot_option()
     for i in `find /boot -name "grub.cfg"`; do
         kexec-parse-boot "/boot" "$i" >> $option_file
     done
+    # FC29/30+ may use BLS format grub config files
+    # https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault
+    # only parse these if $option_file is still empty
+    if [ ! -s $option_file ] && [ -d "/boot/loader/entries" ]; then
+      for i in `find /boot -name "grub.cfg"`; do
+        kexec-parse-bls "/boot" "$i" "/boot/loader/entries" >> $option_file
+      done
+    fi
     [ ! -r $option_file ] \
         && whiptail_error_die "Failed to parse any boot options"
 

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -221,8 +221,11 @@ set_default_boot_option()
     # clear existing default configs
     rm "/boot/kexec_default.*.txt" 2>/dev/null
 
+    # get correct index for entry
+    index=$(grep -n "$entry" $option_file | cut -f1 -d ':')
+
     # write new config
-    echo "$entry" > /boot/kexec_default.1.txt
+    echo "$entry" > /boot/kexec_default.$index.txt
 
     # validate boot option
     cd /boot && /bin/kexec-boot -b "/boot" -e "$entry" -f \


### PR DESCRIPTION
Handful of small fixes to address bugs in oem-factory-reset and kexec-select-boot which manifested with an install of Fedora 32:

* oem-factory-reset needs to parse BLS spec grub files as well as standard ones
* oem-factory-reset needs to set the index of kexec_default.{i}.txt rather than always using 1
* oem-factory-reset and kexec-select-boot should use -s vs -r to test if any valid boot entries produced by kexec-parse-boot

