### PR TITLE
Fix kexec to work with Debian Installer (fixes #699)

### DIFF
--- a/patches/kexec-2.0.20.patch
+++ b/patches/kexec-2.0.20.patch
@@ -1,7 +1,7 @@
-diff --git ./Makefile.in ./Makefile.in
+diff --git a/Makefile.in b/Makefile.in
 index fb01134..bf1973e 100644
---- ./Makefile.in
-+++ ./Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
 @@ -157,12 +157,12 @@ include $(srcdir)/kexec/Makefile
  
  # vmcore-dmesg (read dmesg from a vmcore)
@@ -17,10 +17,24 @@ index fb01134..bf1973e 100644
  
  SPEC=$(PACKAGE_NAME).spec
  GENERATED_SRCS:= $(SPEC)
-diff --git ./kexec/kexec.c ./kexec/kexec.c
+diff --git a/kexec/arch/i386/x86-linux-setup.c b/kexec/arch/i386/x86-linux-setup.c
+index 057ee14..43e017a 100644
+--- a/kexec/arch/i386/x86-linux-setup.c
++++ b/kexec/arch/i386/x86-linux-setup.c
+@@ -137,7 +137,8 @@ static int setup_linux_vesafb(struct x86_linux_param_header *real_mode)
+ 		goto out;
+ 	if (-1 == ioctl(fd, FBIOGET_VSCREENINFO, &var))
+ 		goto out;
+-	if (0 == strcmp(fix.id, "VESA VGA")) {
++	if (0 == strcmp(fix.id, "VESA VGA")
++            || 0 == strcmp(fix.id, "inteldrmfb")) {
+ 		/* VIDEO_TYPE_VLFB */
+ 		real_mode->orig_video_isVGA = 0x23;
+ 	} else if (0 == strcmp(fix.id, "EFI VGA")) {
+diff --git a/kexec/kexec.c b/kexec/kexec.c
 index bc6ab3d..b82725b 100644
---- ./kexec/kexec.c
-+++ ./kexec/kexec.c
+--- a/kexec/kexec.c
++++ b/kexec/kexec.c
 @@ -805,6 +805,27 @@ static int my_load(const char *type, int fileind, int argc, char **argv,
  	if (sort_segments(&info) < 0) {
  		return -1;
@@ -49,10 +63,10 @@ index bc6ab3d..b82725b 100644
  	/* if purgatory is loaded update it */
  	update_purgatory(&info);
  	if (entry)
-diff --git ./purgatory/Makefile ./purgatory/Makefile
+diff --git a/purgatory/Makefile b/purgatory/Makefile
 index 2dd6c47..2de8f07 100644
---- ./purgatory/Makefile
-+++ ./purgatory/Makefile
+--- a/purgatory/Makefile
++++ b/purgatory/Makefile
 @@ -44,7 +44,6 @@ purgatory/sha256.o: $(srcdir)/util_lib/sha256.c
  	mkdir -p $(@D)
  	$(COMPILE.c) -o $@ $^
@@ -61,10 +75,10 @@ index 2dd6c47..2de8f07 100644
  $(PURGATORY): CFLAGS=$(PURGATORY_EXTRA_CFLAGS) \
  		      $($(ARCH)_PURGATORY_EXTRA_CFLAGS) \
  		      -Os -fno-builtin -ffreestanding \
-diff --git ./util/Makefile ./util/Makefile
+diff --git a/util/Makefile b/util/Makefile
 index 948ee63..833a897 100644
---- ./util/Makefile
-+++ ./util/Makefile
+--- a/util/Makefile
++++ b/util/Makefile
 @@ -2,7 +2,7 @@ BIN_TO_HEX:= bin/bin-to-hex
  
  $(BIN_TO_HEX): $(srcdir)/util/bin-to-hex.c


### PR DESCRIPTION
This patch was reported by @bemoody in issue #699

Tested via `BOARD=x230-hotp-verification` on a Thinkpad x230