### PR TITLE
blobs/x220|t420: Fix extract script

### DIFF
--- a/blobs/t420/extract.sh
+++ b/blobs/t420/extract.sh
@@ -28,7 +28,7 @@ while getopts ":f:m:i:" opt; do
 done
 
 if [ -z "$MECLEAN" ]; then
-  MECLEAN=`command -v $BLOBDIR/../../build/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1`
+  MECLEAN=`command -v $BLOBDIR/../../build/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1|head -n1`
   if [ -z "$MECLEAN" ]; then
     echo "me_cleaner.py required but not found or specified with -m. Aborting."
     exit 1;
@@ -36,7 +36,7 @@ if [ -z "$MECLEAN" ]; then
 fi
 
 if [ -z "$IFDTOOL" ]; then
-  IFDTOOL=`command -v $BLOBDIR/../../build/coreboot-*/util/ifdtool/ifdtool 2>&1`
+  IFDTOOL=`command -v $BLOBDIR/../../build/coreboot-*/util/ifdtool/ifdtool 2>&1|head -n1`
   if [ -z "$IFDTOOL" ]; then
     echo "ifdtool required but not found or specified with -m. Aborting."
     exit 1;

--- a/blobs/x220/extract.sh
+++ b/blobs/x220/extract.sh
@@ -28,7 +28,7 @@ while getopts ":f:m:i:" opt; do
 done
 
 if [ -z "$MECLEAN" ]; then
-  MECLEAN=`command -v $BLOBDIR/../../build/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1`
+  MECLEAN=`command -v $BLOBDIR/../../build/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1|head -n1`
   if [ -z "$MECLEAN" ]; then
     echo "me_cleaner.py required but not found or specified with -m. Aborting."
     exit 1;
@@ -36,7 +36,7 @@ if [ -z "$MECLEAN" ]; then
 fi
 
 if [ -z "$IFDTOOL" ]; then
-  IFDTOOL=`command -v $BLOBDIR/../../build/coreboot-*/util/ifdtool/ifdtool 2>&1`
+  IFDTOOL=`command -v $BLOBDIR/../../build/coreboot-*/util/ifdtool/ifdtool 2>&1|head -n1`
   if [ -z "$IFDTOOL" ]; then
     echo "ifdtool required but not found or specified with -m. Aborting."
     exit 1;


### PR DESCRIPTION
Command returns a list of utilities found. This can happen if multiple
coreboot folders are present.

Use only one to fix a crash in the following lines.

Test: Being able to extract blobs when two coreboot folders are present,
      both containing an IFDTOOL.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>