### PR TITLE
patches/coreboot-4.8.1: Measure firmware into PCR2

### DIFF
--- a/patches/coreboot-4.8.1/0000-measuredboot.patch
+++ b/patches/coreboot-4.8.1/0000-measuredboot.patch
@@ -167,7 +167,7 @@ index 6fd55d7..b5b7d91 100644
 +{
 +	if (IS_ENABLED(CONFIG_MEASURED_BOOT) && !(flags & SEG_NO_MEASURE))
 +	{
-+		tlcl_measure(3, (const void*) start, size);
++		tlcl_measure(2, (const void*) start, size);
 +	}
 +}
 +

--- a/patches/coreboot-4.8.1/0009-Add-heads-TPM-measurements-to-Skylake-Kabylake.patch
+++ b/patches/coreboot-4.8.1/0009-Add-heads-TPM-measurements-to-Skylake-Kabylake.patch
@@ -51,9 +51,9 @@ index 30987ce..4957bc0 100644
 +		tlcl_lib_init();
 +		const void * const bootblock = (const void*) 0xFFFFF800;
 +		const unsigned bootblock_size = 0x800;
-+		tlcl_measure(0, bootblock, bootblock_size);
++		tlcl_measure(2, bootblock, bootblock_size);
 +
-+		tlcl_measure(1, _romstage, _eromstage - _romstage);
++		tlcl_measure(2, _romstage, _eromstage - _romstage);
 +	}
 +
  	/* Signal that FSP component has been loaded. */
@@ -66,7 +66,7 @@ index 30987ce..4957bc0 100644
 +void platform_segment_loaded(uintptr_t start, size_t size, int flags)
 +{
 +	if (IS_ENABLED(CONFIG_MEASURED_BOOT) && !(flags & SEG_NO_MEASURE)) {
-+		tlcl_measure(1, (const void*) start, size);
++		tlcl_measure(2, (const void*) start, size);
 +	}
 +}
 +
@@ -87,7 +87,7 @@ index bda88d1..49568f6 100644
  		die("Failed to read FSPS!\n");
  
 +	if (IS_ENABLED(CONFIG_MEASURED_BOOT)) {
-+		tlcl_measure(1, (const void*) dest, size);
++		tlcl_measure(2, (const void*) dest, size);
 +	}
 +
  	if (fsp_component_relocate((uintptr_t)dest, dest, size) < 0)

--- a/patches/coreboot-4.8.1/0030-sandybridge.patch
+++ b/patches/coreboot-4.8.1/0030-sandybridge.patch
@@ -22,10 +22,10 @@ index 0426b83..d348b9e 100644
 +		tlcl_lib_init();
 +		const void * const bootblock = (const void*) 0xFFFFF800;
 +		const unsigned bootblock_size = 0x800;
-+		tlcl_measure(0, bootblock, bootblock_size);
++		tlcl_measure(2, bootblock, bootblock_size);
 +
 +		extern char _romstage, _eromstage;
-+		tlcl_measure(1, &_romstage, &_eromstage - &_romstage);
++		tlcl_measure(2, &_romstage, &_eromstage - &_romstage);
 +	}
 +
  	/* USB is initialized in MRC if MRC is used.  */


### PR DESCRIPTION
As part of migration to coreboot 4.12, which includes measured boot
without additional patches, measure all parts of the firmware and the
payload into PCR2.

The same is done in coreboot 4.12. This commit ensures that boards not
migrated yet will show the same behaviour.

TODO: Update heads-wiki.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>