### PR TITLE
CircleCI : specialized caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            - heads_modules_and_patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
             #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            - heads_cross-musl-{{ checksum "./modules/musl-cross" }}
+            - heads-cross-musl-{{ checksum "./modules/musl-cross" }}
             #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
             - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
@@ -170,16 +170,18 @@ jobs:
             - packages
             - crossgcc
             - build
+
       - save_cache:
           #Generate cache for the same musl-cross module definition if hash is not previously existing
-          key: heads_cross-musl-{{ checksum "modules/musl-cross" }}
+          key: heads-cross-musl-{{ checksum "modules/musl-cross" }}
           paths:
             - packages
             - crossgcc
             - build/musl-cross-*
+
       - - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing
-          key: heads_modules_and_patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}          
+          key: heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
           paths:
             - packages
             - crossgcc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
             #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            - heads-cross-musl-{{ checksum "./modules/musl-cross" }}
+            heads-cross-musl-{{ checksum "./modules/musl-cross" }}
             #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
-            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+            heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Creating all modules and patches digest
           command: |
-            find ./patches/ ./modules/ | sort -h |xargs sha256sum > /tmp/all_modules_patches.sha256sums \
+            find ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > /tmp/all_modules_patches.sha256sums \
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,11 @@ jobs:
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
+            heads-cross-musl-{{ checksum "./modules/musl-cross" }}
             #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
-            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+            heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now
@@ -168,6 +170,14 @@ jobs:
             - packages
             - crossgcc
             - build
+
+      - save_cache:
+          #Generate cache for the same musl-cross module definition if hash is not previously existing
+          key: heads-cross-musl-{{ checksum "modules/musl-cross" }}
+          paths:
+            - packages
+            - crossgcc
+            - build/musl-cross-*
 
       - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,20 @@ jobs:
       - run:
           name: Creating all modules and patches digest
           command: |
-            find ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > /tmp/all_modules_patches.sha256sums \
+            find ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > /tmp/all_modules_and_patches.sha256sums \
+
+      - run:
+          name: Creating musl-cross-make and musl-cross-make patches digest
+          command: |
+            find ./patches/musl-cross-* modules/musl-cross* -type f | sort | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
+
 
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
             - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
             #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            - heads-cross-musl-{{ checksum "./modules/musl-cross" }}
-            #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
-            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+            - heads-cross-musl-{{ checksum "/tmp/musl-cross_module_and_patches.sha256sums" }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now
@@ -164,24 +168,15 @@ jobs:
           path: build/qemu-coreboot
 
       - save_cache:
-          #Generate generic cache on first run if hash doesn't exist
-          key: heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
-          paths:
-            - packages
-            - crossgcc
-            - build
-
-      - save_cache:
           #Generate cache for the same musl-cross module definition if hash is not previously existing
-          key: heads-cross-musl-{{ checksum "modules/musl-cross" }}
+          key: heads-cross-musl-{{ checksum "/tmp/musl-cross_module_and_patches.sha256sums" }}
           paths:
-            - packages
             - crossgcc
             - build/musl-cross-*
 
       - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing
-          key: heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+          key: heads-modules-and-patches-{{ checksum "/tmp/all_modules_and_patches.sha256sums" }}
           paths:
             - packages
             - crossgcc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,24 @@ jobs:
             apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev
       - checkout
 
-      - restore_cache:
-          key: heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
-
       - run:
           name: git reset
           command: |
             git reset --hard "$CIRCLE_SHA1" \
+
+      - run:
+          name: Creating all modules and patches digest
+          command: |
+            find ./patches/ ./modules/ | sort -h |xargs sha256sum > /tmp/all_modules_patches.sha256sums \
+
+      - restore_cache:
+          keys:
+            #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
+            - heads_modules_and_patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
+            - heads_cross-musl-{{ checksum "./modules/musl-cross" }}
+            #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
+            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now
@@ -153,12 +164,26 @@ jobs:
           path: build/qemu-coreboot
 
       - save_cache:
-          key: heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+          #Generate generic cache on first run if hash doesn't exist
+          key: heads-{{ .Environment.CIRCLE_USERNAME }}{{ .Environment.CACHE_VERSION }}
           paths:
             - packages
             - crossgcc
             - build
-
+      - save_cache:
+          #Generate cache for the same musl-cross module definition if hash is not previously existing
+          key: heads_cross-musl-{{ checksum "modules/musl-cross" }}
+          paths:
+            - packages
+            - crossgcc
+            - build/musl-cross-*
+      - - save_cache:
+          #Generate cache for the exact same modules definitions if hash is not previously existing
+          key: heads_modules_and_patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}          
+          paths:
+            - packages
+            - crossgcc
+            - build
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
             #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            heads-cross-musl-{{ checksum "./modules/musl-cross" }}
+            - heads-cross-musl-{{ checksum "./modules/musl-cross" }}
             #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
-            heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ jobs:
       - run:
           name: Creating musl-cross-make and musl-cross-make patches digest
           command: |
-            find ./patches/musl-cross-* modules/musl-cross* -type f | sort | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
+            find ./patches/musl-cross-* modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
 
 
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
+            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_and_patches.sha256sums" }}
             #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
             - heads-cross-musl-{{ checksum "/tmp/musl-cross_module_and_patches.sha256sums" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,9 @@ jobs:
       - restore_cache:
           keys:
             #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
-            heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
-            #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            heads-cross-musl-{{ checksum "./modules/musl-cross" }}
+            - heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
             #If precedent fails. Restore statically built cache on first successful build for this CI instance with CACHE_VERSION configured on CI 
-            heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
+            - heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
 
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now
@@ -165,21 +163,13 @@ jobs:
 
       - save_cache:
           #Generate generic cache on first run if hash doesn't exist
-          key: heads-{{ .Environment.CIRCLE_USERNAME }}{{ .Environment.CACHE_VERSION }}
+          key: heads-{{ .Environment.CIRCLE_USERNAME }}-{{ .Environment.CACHE_VERSION }}
           paths:
             - packages
             - crossgcc
             - build
 
       - save_cache:
-          #Generate cache for the same musl-cross module definition if hash is not previously existing
-          key: heads-cross-musl-{{ checksum "modules/musl-cross" }}
-          paths:
-            - packages
-            - crossgcc
-            - build/musl-cross-*
-
-      - - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing
           key: heads-modules-and-patches-{{ checksum "/tmp/all_modules_patches.sha256sums" }}
           paths:


### PR DESCRIPTION
This changes the way CircleCI handles cache and limit the possibility of cache corruptions and removes the CircleCI owner bounding that was there previously.

Now:
- If modules/* and patches/* have the same hashes, that cache is restored. It saves the new cache if the hashes are different. This cache is usefull for most changes happening in Heads, which are security policy related and linked to scripts changes. If modules or hashes changes and no cache exists, if will restore the next cache.
- If musl-cross module and applied patches have the same hashes of an existing cache, that cache is restored. It is saved once for a single hash which means that the module version (commit) and applied patches are the same. This permits to economize one hour of build time for each build and rarely ever change.
