### PR TITLE
CircleCI: mitigate issue #799

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,9 @@ jobs:
 
       - run:
           name: x230-flash
+          #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make --load 2 \
+            rm -rf build/make-4.2.1/ build/x230-flash/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=x230-flash \
           no_output_timeout: 3h
@@ -137,7 +138,7 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/make-4.2.1/ build/qemu-coreboot/* build/log/* && make --load 2 \
+            rm -rf build/qemu-coreboot/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=qemu-coreboot \
           no_output_timeout: 3h


### PR DESCRIPTION
removes build/make directory, else patches are reapplied on top of already existing directory causing builds to fail.