### PR TITLE
kexec-parse-boot/bls: Strip boot dir from front of grub entries

### DIFF
--- a/initrd/bin/kexec-parse-bls
+++ b/initrd/bin/kexec-parse-bls
@@ -67,10 +67,10 @@ bls_entry() {
 			name=$val
 			;;
 		linux*)
-			kernel=$val
+			kernel=${val#"$bootdir"}
 			;;
 		initrd*)
-			initrd=$val
+			initrd=${val#"$bootdir"}
 			;;
 		options)
 			# default is "options $kernelopts"

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -170,11 +170,11 @@ syslinux_entry() {
 					state="search"
 					;;
 				*)
-					kernel="$val"
+					kernel="${val#"$bootdir"}"
 			esac
 			;;
 		initrd* | INITRD* )
-			initrd="$val"
+			initrd="${val#"$bootdir"}"
 			;;
 		append* | APPEND* )
 			if [ "$kexectype" = "multiboot" -o "$kexectype" = "xen" ]; then


### PR DESCRIPTION
Some grub configs/bls entries contain the full paths to the
kernel/initrd files, which the parsers currently fail to handle,
causing a failed boot without any useful error being presented to the user.

To fix this, strip the bootdir prefix from the menu entries when parsing,
should it exist.

Test: build/boot Librem 13v2 w/F32 and bls entries containing mixed relative and 
absolute paths for kernel/initrd

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>