### PR TITLE
flash.sh: Fix serial number persistence

### DIFF
--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -41,7 +41,7 @@ flash_rom() {
     if cbfs -r serial_number > /tmp/serial 2>/dev/null; then
       echo "Persisting system serial"
       cbfs -o /tmp/${CONFIG_BOARD}.rom -d serial_number 2>/dev/null || true
-      cbfs -o /tmp/${CONFIG_BOARD}.rom -a serial_number -f /tmp/serial
+      [ -s /tmp/serial ] && cbfs -o /tmp/${CONFIG_BOARD}.rom -a serial_number -f /tmp/serial
     fi
 
     flashrom $CONFIG_FLASHROM_OPTIONS -w /tmp/${CONFIG_BOARD}.rom \


### PR DESCRIPTION
If the serial_number file exists in cbfs but has zero size,
adding it to the new ROM to be flashed will fail badly.
Check for non-zero size before adding to new ROM.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>