### PR TITLE
Remove quotes to fix use of asterisk in command

### DIFF
--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -120,7 +120,7 @@ if [ ! -d $paramsdir ]; then
 	mkdir -p $paramsdir \
 	|| die "Failed to create params directory"
 fi
-rm "$paramsdir/kexec_default.*.txt" 2>/dev/null || true
+rm $paramsdir/kexec_default.*.txt 2>/dev/null || true
 echo "$entry" > $ENTRY_FILE
 cd $bootdir && kexec-boot -b "$bootdir" -e "$entry" -f | \
 	xargs sha256sum > $HASH_FILE \


### PR DESCRIPTION
Changing the default boot was failing because remove the old entries did
not work as `rm "/some/path/*.txt"` does not work as intended, e.g. the
asterisk is no catch-all.