### PR TITLE
CircleCI: bring recent failing logs on CI output (forgotten librem_mini)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           command: |
             rm -rf build/librem_mini/* build/log/* && make --load 2 \
                 V=1 \
-                BOARD=librem_mini \
+                BOARD=librem_mini || (find ./build/log/ -cmin 1|xargs tail; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput librem_mini hashes


### PR DESCRIPTION
@MrChromebox : small change to approve... Sorry for the noise