### PR TITLE
CircleCI: removing librem_mini board under CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,24 +151,6 @@ jobs:
           path: build/x230-hotp-verification
 
       - run:
-          name: librem_mini
-          command: |
-            rm -rf build/librem_mini/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=librem_mini \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_mini hashes
-          command: |
-            cat build/librem_mini/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_mini
-          command: |
-             tar zcvf build/librem_mini/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_mini
-
-      - run:
           name: qemu-coreboot
           command: |
             rm -rf build/qemu-coreboot/* build/log/* && make --load 2 \


### PR DESCRIPTION
Coreboot 4.12, on which the librem_mini depends, doesn't build under debian:10 docker image as of right now.
	It was building over debian:bullseye (where 4.8.1 boards didn't) which constructed a valid cache that
	was reused when building #806 (https://app.circleci.com/pipelines/github/tlaurion/heads/364/workflows/df9bad8d-8ff1-40da-b8d8-1b87a05be509/jobs/392)

Consequently, more troubleshooting would need to be done under local debian:10 docker image.