### PR TITLE
functions/recovery: loop recovery shell when exited

### DIFF
--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -25,14 +25,20 @@ recovery() {
 	if [ "$CONFIG_TPM" = y ]; then
 		tpm extend -ix 4 -ic recovery
 	fi
-	echo >&2 "!!!!! Starting recovery shell"
-	sleep 1
 
-	if [ -x /bin/setsid ]; then
-		exec /bin/setsid -c /bin/ash
-	else
-		exec /bin/ash
-	fi
+	while [ true ]
+	do
+		echo >&2 "!!!!! Starting recovery shell"
+		sleep 1
+
+		if [ -x /bin/setsid ]; then
+			/bin/setsid -c /bin/ash
+		else
+			/bin/ash
+		fi
+		# clear screen
+		printf "\033c"
+	done
 }
 
 pause_recovery() {


### PR DESCRIPTION
Currently, exiting the recovery shell results in a kernel panic,
necessitating a hard reset / power cycle. As this is less than ideal,
drop the exec and add a loop to restart the shell.

Addresses issue #833

Tested under qemu-coreboot-fbwhiptail

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>