### PR TITLE
Use a USB security key as a TPM work-alike in the absence of a physical TPM

### DIFF
--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -24,19 +24,24 @@ else
 	HOTPKEY_BRANDING="HOTP USB Security Dongle"
 fi
 
-tpm nv_readvalue \
-	-in 4d47 \
-	-sz 312 \
-	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
+if [ "$CONFIG_TPM" = "y" ]; then
+	tpm nv_readvalue \
+		-in 4d47 \
+		-sz 312 \
+		-of "$HOTP_SEALED" \
+	|| die "Unable to retrieve sealed file from TPM NV"
 
-tpm unsealfile  \
-	-hk 40000000 \
-	-if "$HOTP_SEALED" \
-	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
+	tpm unsealfile  \
+		-hk 40000000 \
+		-if "$HOTP_SEALED" \
+		-of "$HOTP_SECRET" \
+	|| die "Unable to unseal HOTP secret"
 
-shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
+	shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
+else
+	# without a TPM, use the first 20 characters of the ROM SHA256sum 
+	secret_from_rom_hash > $HOTP_SECRET
+fi
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -17,71 +17,78 @@ fi
 TOTP_SECRET="/tmp/secret/totp.key"
 TOTP_SEALED="/tmp/secret/totp.sealed"
 
-dd \
-	if=/dev/urandom \
-	of="$TOTP_SECRET" \
-	count=1 \
-	bs=20 \
-	2>/dev/null \
-|| die "Unable to generate 20 random bytes"
+if [ "$CONFIG_TPM" = "y" ]; then
+	dd \
+		if=/dev/urandom \
+		of="$TOTP_SECRET" \
+		count=1 \
+		bs=20 \
+		2>/dev/null \
+	|| die "Unable to generate 20 random bytes"
 
-secret="`base32 < $TOTP_SECRET`"
+	secret="`base32 < $TOTP_SECRET`"
 
-# Use the current values of the PCRs, which will be read
-# from the TPM as part of the sealing ("X").
-# PCR4 == 0 means that we are still in the boot process and
-# not a recovery shell.
-# should this read the storage root key?
-if ! tpm sealfile2 \
-	-if "$TOTP_SECRET" \
-	-of "$TOTP_SEALED" \
-	-hk 40000000 \
-	-ix 0 X \
-	-ix 1 X \
-	-ix 2 X \
-	-ix 3 X \
-	-ix 4 0000000000000000000000000000000000000000 \
-	-ix 7 X \
-; then
+	# Use the current values of the PCRs, which will be read
+	# from the TPM as part of the sealing ("X").
+	# PCR4 == 0 means that we are still in the boot process and
+	# not a recovery shell.
+	# should this read the storage root key?
+	if ! tpm sealfile2 \
+		-if "$TOTP_SECRET" \
+		-of "$TOTP_SEALED" \
+		-hk 40000000 \
+		-ix 0 X \
+		-ix 1 X \
+		-ix 2 X \
+		-ix 3 X \
+		-ix 4 0000000000000000000000000000000000000000 \
+		-ix 7 X \
+	; then
+		shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
+		die "Unable to seal secret"
+	fi
+
 	shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
-	die "Unable to seal secret"
-fi
-
-shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
 
 
-# to create an nvram space we need the TPM owner password
-# and the TPM physical presence must be asserted.
-#
-# The permissions are 0 since there is nothing special
-# about the sealed file
-tpm physicalpresence -s \
-|| warn "Warning: Unable to assert physical presence"
+	# to create an nvram space we need the TPM owner password
+	# and the TPM physical presence must be asserted.
+	#
+	# The permissions are 0 since there is nothing special
+	# about the sealed file
+	tpm physicalpresence -s \
+	|| warn "Warning: Unable to assert physical presence"
 
-# Try to write it without the password first, and then create
-# the NVRAM space using the owner password if it fails for some reason.
-if ! tpm nv_writevalue \
-	-in $TPM_NVRAM_SPACE \
-	-if "$TOTP_SEALED" \
-; then
-	warn 'NVRAM space does not exist? Owner password is required'
-	read -s -p "TPM Owner password: " tpm_password
-	echo
-
-	tpm nv_definespace \
-		-in $TPM_NVRAM_SPACE \
-		-sz 312 \
-		-pwdo "$tpm_password" \
-		-per 0 \
-	|| die "Unable to define NVRAM space"
-
-	tpm nv_writevalue \
+	# Try to write it without the password first, and then create
+	# the NVRAM space using the owner password if it fails for some reason.
+	if ! tpm nv_writevalue \
 		-in $TPM_NVRAM_SPACE \
 		-if "$TOTP_SEALED" \
-	|| die "Unable to write sealed secret to NVRAM"
-fi
+	; then
+		warn 'NVRAM space does not exist? Owner password is required'
+		read -s -p "TPM Owner password: " tpm_password
+		echo
 
-shred -n 10 -z -u "$TOTP_SEALED" 2> /dev/null
+		tpm nv_definespace \
+			-in $TPM_NVRAM_SPACE \
+			-sz 312 \
+			-pwdo "$tpm_password" \
+			-per 0 \
+		|| die "Unable to define NVRAM space"
+
+		tpm nv_writevalue \
+			-in $TPM_NVRAM_SPACE \
+			-if "$TOTP_SEALED" \
+		|| die "Unable to write sealed secret to NVRAM"
+	fi
+
+	shred -n 10 -z -u "$TOTP_SEALED" 2> /dev/null
+else
+	# without a TPM, use the first 20 characters of the ROM SHA256sum 
+	secret_from_rom_hash > $TOTP_SECRET
+	secret="`base32 < $TOTP_SECRET`"
+	shred -n 10 -z -u "$TOTP_SECRET" 2> /dev/null
+fi
 
 url="otpauth://totp/$HOST?secret=$secret"
 secret=""

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -36,19 +36,24 @@ fi
 
 #counter_value=$(printf "%d" 0x${counter_value})
 
-tpm nv_readvalue \
-	-in 4d47 \
-	-sz 312 \
-	-of "$HOTP_SEALED" \
-|| die "Unable to retrieve sealed file from TPM NV"
+if [ "$CONFIG_TPM" = "y" ]; then
+	tpm nv_readvalue \
+		-in 4d47 \
+		-sz 312 \
+		-of "$HOTP_SEALED" \
+	|| die "Unable to retrieve sealed file from TPM NV"
 
-tpm unsealfile  \
-	-hk 40000000 \
-	-if "$HOTP_SEALED" \
-	-of "$HOTP_SECRET" \
-|| die "Unable to unseal HOTP secret"
+	tpm unsealfile  \
+		-hk 40000000 \
+		-if "$HOTP_SEALED" \
+		-of "$HOTP_SECRET" \
+	|| die "Unable to unseal HOTP secret"
 
-shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
+	shred -n 10 -z -u "$HOTP_SEALED" 2> /dev/null
+else
+	# without a TPM, use the first 20 characters of the ROM SHA256sum 
+	secret_from_rom_hash > $HOTP_SECRET
+fi
 
 if ! hotp $counter_value < "$HOTP_SECRET"; then
 	shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -267,6 +267,19 @@ combine_configs() {
 	cat /etc/config* > /tmp/config
 }
 
+# Generate secret value using first 40 chars of ROM SHA256 hash
+secret_from_rom_hash() {
+	local ROM_IMAGE="/tmp/coreboot-notpm.rom"
+
+	echo -e "\nTPM not detected; measuring ROM directly\n" 1>&2
+	# use a previously-copied image if it exists
+	if [ -f ${ROM_IMAGE} ]; then
+		sha256sum ${ROM_IMAGE} | cut -f1 -d ' ' | cut -c 1-40 | tr -d '\n'
+	else
+		flash.sh -s ${ROM_IMAGE} | cut -c 1-40 | tr -d '\n'
+	fi
+}
+
 update_checksums()
 {
 	# clear screen

--- a/initrd/init
+++ b/initrd/init
@@ -44,6 +44,13 @@ hwclock -l -s
 . /etc/functions
 . /etc/config
 
+# set CONFIG_TPM dynamically before init
+if [ -e /dev/tpm0 ]; then
+  export CONFIG_TPM='y'
+else
+  export CONFIG_TPM='n'
+fi
+
 if [ "$CONFIG_COREBOOT" = "y" ]; then
 	/bin/cbfs-init
 fi
@@ -87,6 +94,13 @@ if [ "$boot_option" = "r" ]; then
 	fi
 	exec /bin/ash
 	exit
+fi
+
+# Override CONFIG_TPM and persist via user config
+if [ -e /dev/tpm0 ]; then
+  echo "CONFIG_TPM=y" >> /etc/config.user
+else
+  echo "CONFIG_TPM=n" >> /etc/config.user
 fi
 
 combine_configs


### PR DESCRIPTION
On machines without a TPM, we'd still like some way for the BIOS to
attest that it has not been modified. With a USB security key, we can have
the BIOS use its own ROM measurement converted to a SHA256sum and truncated
so it fits within an HOTP secret. Like with a TPM, a malicious BIOS with
access to the correct measurements can send pre-known good measurements
to the USB security key.

This approach provides one big drawback in that we have to truncate the
SHA256sum to 20 characters so that it fits within the limitations of
HOTP secrets. This means the possibility of collisions is much higher
but again, an attacker could also capture and spoof an existing ROM's
measurements if they have prior access to it, either with this approach
or with a TPM.

This supersedes #493

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>