### PR TITLE
 Add git hash and tags for versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 GIT_HASH		:= $(shell git rev-parse HEAD)
 GIT_HASH_SHORT	:= $(shell git rev-parse --short HEAD)
 GIT_BRANCH  	:= $(shell git branch --show-current)
-GIT_TAG     	:= $(shell git describe --abbrev=0 --tags)
+GIT_TAG     	:= $(shell git describe --abbrev=1 --tags --dirty)
 GIT_STATUS		:= $(shell \
 	if git diff --exit-code >/dev/null ; then \
 		echo clean ; \

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,18 @@ $(HEADS_GAWK): $(build)/$(gawk_dir)/.configured
 		$(VERBOSE_REDIRECT)
 endif
 
+# Some things want usernames, we use the current checkout
+# so that they are reproducible
+GIT_HASH		:= $(shell git rev-parse HEAD)
+GIT_HASH_SHORT	:= $(shell git rev-parse --short HEAD)
+GIT_BRANCH  	:= $(shell git branch --show-current)
+GIT_TAG     	:= $(shell git describe --abbrev=0 --tags)
+GIT_STATUS		:= $(shell \
+	if git diff --exit-code >/dev/null ; then \
+		echo clean ; \
+	else \
+		echo dirty ; \
+	fi)
 
 BOARD		?= qemu-coreboot
 CONFIG		:= $(pwd)/boards/$(BOARD)/$(BOARD).config
@@ -99,16 +111,6 @@ include $(CONFIG)
 
 # Unless otherwise specified, we are building for heads
 CONFIG_HEADS	?= y
-
-# Some things want usernames, we use the current checkout
-# so that they are reproducible
-GIT_HASH	:= $(shell git rev-parse HEAD)
-GIT_STATUS	:= $(shell \
-	if git diff --exit-code >/dev/null ; then \
-		echo clean ; \
-	else \
-		echo dirty ; \
-	fi)
 
 # record the build date / git hashes and other files here
 HASHES		:= $(build)/$(BOARD)/hashes.txt
@@ -594,6 +596,8 @@ $(initrd_tmp_dir)/etc/config: FORCE
 	)
 	$(call do,HASH,$(GIT_HASH) $(GIT_STATUS) $(BOARD), \
 		echo export GIT_HASH=\'$(GIT_HASH)\' \
+		>> $@ ; \
+		echo export GIT_TAG=\'$(GIT_TAG)\' \
 		>> $@ ; \
 		echo export GIT_STATUS=$(GIT_STATUS) \
 		>> $@ ; \

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -393,7 +393,7 @@ while true; do
     memtotal=$((${memtotal} / 1024 / 1024 + 1))
     cpustr=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed -r 's/\(R\)//;s/\(TM\)//;s/CPU //;s/model name.*: //')
     whiptail --title 'System Info' \
-      --msgbox "VER: ${FW_VER}\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
+        --msgbox "VER: Heads $GIT_TAG ($GIT_HASH)\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
     continue
   fi
 

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -83,7 +83,7 @@ $(build)/$(coreboot_dir)/.build: \
 $(build)/$(BOARD)/coreboot.rom: $(build)/$(coreboot_dir)/.build
 	"$(build)/$(coreboot_dir)/cbfstool" "$(dir $<)coreboot.rom" print
 	$(call do-copy,$(dir $<)coreboot.rom,$@)
-	$(call do-copy,$(dir $<)coreboot.rom,$(build)/$(BOARD)/$(GIT_BRANCH)-$(GIT_TAG)-$(GIT_HASH_SHORT).rom)
+	$(call do-copy,$(dir $<)coreboot.rom,$(build)/$(BOARD)/heads-$(GIT_BRANCH)-$(GIT_TAG).rom)
 	@touch $@   # update the time stamp
 
 #

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -83,6 +83,7 @@ $(build)/$(coreboot_dir)/.build: \
 $(build)/$(BOARD)/coreboot.rom: $(build)/$(coreboot_dir)/.build
 	"$(build)/$(coreboot_dir)/cbfstool" "$(dir $<)coreboot.rom" print
 	$(call do-copy,$(dir $<)coreboot.rom,$@)
+	$(call do-copy,$(dir $<)coreboot.rom,$(build)/$(BOARD)/$(GIT_BRANCH)-$(GIT_TAG)-$(GIT_HASH_SHORT).rom)
 	@touch $@   # update the time stamp
 
 #


### PR DESCRIPTION
The reasoning behind this small set of changes is to make versioning and referencing more easy. I do not know if this is desired, but for example having the builds locally with hash instead of overwriting every build is nice to have imho.

Please have a look if heads can use anything of that. :)