### PR TITLE
Add 'CPUS' as make BOARD=X argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,24 @@ jobs:
 #          path: build/qemu-linuxboot/hashes.txt
 
       - run:
+          name: librem_mini-NoTPM
+          command: |
+            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=librem_mini-NoTPM || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+          no_output_timeout: 3h
+      - run:
+          name: Ouput librem_mini-NoTPM hashes
+          command: |
+            cat build/librem_mini-NoTPM/hashes.txt \
+      - run:
+          name: Archiving build logs for librem_mini-NoTPM
+          command: |
+             tar zcvf build/librem_mini-NoTPM/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/librem_mini-NoTPM
+
+      - run:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
@@ -149,24 +167,6 @@ jobs:
              tar zcvf build/x230-hotp-verification/logs.tar.gz build/log/*
       - store-artifacts:
           path: build/x230-hotp-verification
-
-      - run:
-          name: librem_mini-NoTPM
-          command: |
-            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_mini-NoTPM || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_mini-NoTPM hashes
-          command: |
-            cat build/librem_mini-NoTPM/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_mini-NoTPM
-          command: |
-             tar zcvf build/librem_mini-NoTPM/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_mini-NoTPM
 
       - run:
           name: qemu-coreboot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                --load 2 \
+#                CPUS=2 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -63,7 +63,7 @@ jobs:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make --load 2 \
+            rm -rf build/x230-flash/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make --load 2 \
+            rm -rf build/t430-flash/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make --load 2 \
+            rm -rf build/t430/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make --load 2 \
+            rm -rf build/x230/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make --load 2 \
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: librem_mini-NoTPM
           command: |
-            rm -rf build/librem_mini-NoTPM/* build/log/* && make --load 2 \
+            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=librem_mini-NoTPM || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make --load 2 \
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=2 \
                 V=1 \
                 BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                CPUS=2 \
+#                CPUS=4 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -63,7 +63,7 @@ jobs:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make CPUS=2 \
+            rm -rf build/x230-flash/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make CPUS=2 \
+            rm -rf build/t430-flash/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make CPUS=2 \
+            rm -rf build/t430/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make CPUS=2 \
+            rm -rf build/x230/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=2 \
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: librem_mini-NoTPM
           command: |
-            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=2 \
+            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=librem_mini-NoTPM || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=2 \
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 \
                 V=1 \
                 BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ INSTALL		:= $(pwd)/install
 log_dir		:= $(build)/log
 
 # Controls how many parallel jobs are invoked in subshells
-CPUS		:= $(shell nproc)
+CPUS		?= $(shell nproc)
 #MAKE_JOBS	?= -j$(CPUS) --max-load 16
 
 # Create the log directory if it doesn't already exist

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -67,12 +67,12 @@ $(COREBOOT_TOOLCHAIN):
 else
 COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
 $(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
-	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=`nproc` crossgcc-i386
+	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$$CPUS crossgcc-i386
 endif
 
 $(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL) $(COREBOOT_TOOLCHAIN)
 $(COREBOOT_IASL): $(build)/$(coreboot_base_dir)/.canary
-	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=`nproc` iasl
+	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$$CPUS iasl
 
 # Force a rebuild if the inputs have changed
 $(build)/$(coreboot_dir)/.build: \

--- a/modules/linuxboot
+++ b/modules/linuxboot
@@ -21,7 +21,7 @@ linuxboot_configure := \
 	if [ "$(linuxboot_board)" = "qemu" ]; then \
 		echo >&2 "Pre-building edk2 OVMF" ; \
 		( cd $(build)/$(linuxboot_base_dir)/edk2/OvmfPkg ; \
-		./build.sh -n `nproc` \
+		./build.sh -n $$CPUS \
 		) || exit 1 ; \
 	fi ; \
 	touch .config ; \


### PR DESCRIPTION
This is a nifty way permitting us to limit ressource allocation if desired (CIs).

From experiementations, there is no way to limit ressource consumption on CircleCI but to pay to have more resources.
In our use case, with cache now being built when boards builds successfully for the same modules/* and patches/* hashes, a cache is built. It fallsback to taking the last available built cache for musl-cross-make having been built for its own specific module signature and existing patches.

The problem we had recently in CI was linked to the addition of coreboot 4.12 board (librem_mini-NoTPM) which, for some obscure reason, failed building with OOM being invoked. GCC expects each thread to have 1GB available, and CircleCI's guaranteed resource allocation is of 4Gb ram, with 32 softcores. So Heads magically taking nproc made explode the coreboot build toolstack for the first time.

This PR introduces the possibility of passing CPUS=X on command line, where that variable is then passed to all submodules, where nproc is taken if not defined. This seems to resolve the current failed PR builds and already passed previous failing point https://app.circleci.com/pipelines/github/tlaurion/heads/447/workflows/d1138321-3a1d-4ffb-9165-e8803d9648ac/jobs/480, where the successfull build will produce a new cache that will be picked up with following builds not touching modules/* nor patches/*

@MrChromebox 