### PR TITLE
librem_mini-NoTPM: drop '-noTPM' suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,22 +60,22 @@ jobs:
 #          path: build/qemu-linuxboot/hashes.txt
 
       - run:
-          name: librem_mini-NoTPM
+          name: librem_mini
           command: |
-            rm -rf build/librem_mini-NoTPM/* build/log/* && make CPUS=4 \
+            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
                 V=1 \
-                BOARD=librem_mini-NoTPM || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
-          name: Ouput librem_mini-NoTPM hashes
+          name: Ouput librem_mini hashes
           command: |
-            cat build/librem_mini-NoTPM/hashes.txt \
+            cat build/librem_mini/hashes.txt \
       - run:
-          name: Archiving build logs for librem_mini-NoTPM
+          name: Archiving build logs for librem_mini
           command: |
-             tar zcvf build/librem_mini-NoTPM/logs.tar.gz build/log/*
+             tar zcvf build/librem_mini/logs.tar.gz build/log/*
       - store-artifacts:
-          path: build/librem_mini-NoTPM
+          path: build/librem_mini
 
       - run:
           name: x230-flash

--- a/boards/librem_mini/librem_mini.config
+++ b/boards/librem_mini/librem_mini.config
@@ -1,6 +1,6 @@
 # Configuration for a librem mini
 CONFIG_LINUX_CONFIG=config/linux-librem_common.config
-CONFIG_COREBOOT_CONFIG=config/coreboot-librem_mini-NoTPM.config
+CONFIG_COREBOOT_CONFIG=config/coreboot-librem_mini.config
 
 export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.12
@@ -35,7 +35,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
-export CONFIG_BOOT_GUI_MENU_NAME="Purism Librem Mini NoTPM Heads Boot Menu"
+export CONFIG_BOOT_GUI_MENU_NAME="Purism Librem Mini Heads Boot Menu"
 export CONFIG_WARNING_BG_COLOR="--background-gradient 0 0 0 150 125 0"
 export CONFIG_ERROR_BG_COLOR="--background-gradient 0 0 0 150 0 0"
 export CONFIG_FLASHROM_OPTIONS="-p internal"

--- a/config/coreboot-librem_mini.config
+++ b/config/coreboot-librem_mini.config
@@ -9,6 +9,6 @@ CONFIG_CPU_MICROCODE_CBFS_EXTERNAL_BINS=y
 CONFIG_CPU_UCODE_BINARIES="3rdparty/purism-blobs/mainboard/purism/librem_whl/cpu_microcode_blob.bin"
 CONFIG_HAVE_ME_BIN=y
 CONFIG_PAYLOAD_LINUX=y
-CONFIG_PAYLOAD_FILE="../../build/librem_mini-NoTPM/bzImage"
-CONFIG_LINUX_INITRD="../../build/librem_mini-NoTPM/initrd.cpio.xz"
+CONFIG_PAYLOAD_FILE="../../build/librem_mini/bzImage"
+CONFIG_LINUX_INITRD="../../build/librem_mini/initrd.cpio.xz"
 CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=2"


### PR DESCRIPTION
There's only one Librem Mini board, it doesn't use a TPM,
no reason to unnecesarily lengthen the board name.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>