### PR TITLE
coreboot-4.12: Use musl-cross-make

### DIFF
--- a/config/coreboot-librem_mini.config
+++ b/config/coreboot-librem_mini.config
@@ -1,4 +1,5 @@
-CONFIG_LOCALVERSION="PureBoot-beta"
+CONFIG_LOCALVERSION="heads"
+CONFIG_ANY_TOOLCHAIN=y
 CONFIG_VENDOR_PURISM=y
 CONFIG_INTEL_GMA_VBT_FILE="3rdparty/purism-blobs/mainboard/purism/librem_whl/vbt.bin"
 CONFIG_IFD_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_whl/flashdescriptor.bin"

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -61,16 +61,7 @@ coreboot_target := \
 coreboot_output := coreboot.rom
 coreboot_depend += linux initrd $(musl_dep)
 
-ifeq "$(CONFIG_COREBOOT_VERSION)" "4.8.1"
-COREBOOT_TOOLCHAIN=""
-$(COREBOOT_TOOLCHAIN):
-else
-COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
-$(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
-	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$$CPUS crossgcc-i386
-endif
-
-$(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL) $(COREBOOT_TOOLCHAIN)
+$(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL)
 $(COREBOOT_IASL): $(build)/$(coreboot_base_dir)/.canary
 	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$$CPUS iasl
 

--- a/patches/coreboot-4.12/0010-cross-compiler-support.patch
+++ b/patches/coreboot-4.12/0010-cross-compiler-support.patch
@@ -1,0 +1,28 @@
+diff --git a/Makefile b/Makefile
+index 027aae2faa..8251a9a478 100644
+--- a/Makefile
++++ b/Makefile
+@@ -176,6 +176,23 @@ $(if $(wildcard .xcompile)$(NOCOMPILE),,$(eval $(shell util/xcompile/xcompile $(
+ 
+ -include .xcompile
+ 
++ifneq "$(CROSS)" ""
++  $(info coreboot: Using $(CROSS)gcc)
++  CROSS_COMPILE_x86_32	:= $(CROSS)
++  CC_x86_32		:= $(CROSS_COMPILE_x86_32)gcc
++  CPP_x86_32		:= $(CROSS_COMPILE_x86_32)cpp
++  AS_x86_32		:= $(CROSS_COMPILE_x86_32)as --32
++  LD_x86_32		:= $(CROSS_COMPILE_x86_32)ld.bfd -b elf32-i386 -melf_i386
++  NM_x86_32		:= $(CROSS_COMPILE_x86_32)nm
++  OBJCOPY_x86_32	:= $(CROSS_COMPILE_x86_32)objcopy
++  OBJDUMP_x86_32	:= $(CROSS_COMPILE_x86_32)objdump
++  READELF_x86_32	:= $(CROSS_COMPILE_x86_32)readelf
++  STRIP_x86_32		:= $(CROSS_COMPILE_x86_32)strip
++  AR_x86_32		:= $(CROSS_COMPILE_x86_32)ar
++  GNATBIND_x86_32	:= $(CROSS_COMPILE_x86_32)gnatbind
++  COMPILER_RT_x86_32	:= $(shell $(CC_x86_32) --print-libgcc-file-name)
++endif
++
+ ifneq ($(XCOMPILE_COMPLETE),1)
+ $(shell rm -f .xcompile)
+ $(error .xcompile deleted because it's invalid. \


### PR DESCRIPTION
- add coreboot-4.12 cross-compiler support patch
- adjust coreboot module to use musl-cross-make to build
- set librem_mini to use CONFIG_ANY_TOOLCHAIN

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>

built on top of #843 since that's a quick/easy merge