### PR TITLE
Change hash files only if gpg card is present

### DIFF
--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -132,7 +132,7 @@ fi
 # sign and auto-roll config counter
 extparam=
 if [ "$CONFIG_TPM" = "y" ]; then
-	extparam=-u
+	extparam=-r
 fi
 kexec-sign-config -p $paramsdir $extparam \
 || die "Failed to sign default config"

--- a/initrd/bin/kexec-save-key
+++ b/initrd/bin/kexec-save-key
@@ -62,7 +62,7 @@ kexec-seal-key $paramsdir \
 
 if [ "$skip_sign" != "y" ]; then
 	# sign and auto-roll config counter
-	kexec-sign-config -p $paramsdir -u \
+	kexec-sign-config -p $paramsdir -r \
 	|| die "Failed to sign updated config"
 fi
 

--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -5,12 +5,13 @@ set -e -o pipefail
 . /etc/functions
 
 rollback="n"
-update_counter="n"
-while getopts "p:c:u" arg; do
+update="n"
+while getopts "p:c:u:r" arg; do
 	case $arg in
 		p) paramsdir="$OPTARG" ;;
 		c) counter="$OPTARG"; rollback="y" ;;
-		u) update_counter="y"; rollback="y" ;;
+		u) update="y" ;;
+		r) rollback="y" ;;
 	esac
 done
 
@@ -21,6 +22,22 @@ fi
 paramsdir="${paramsdir%%/}"
 
 confirm_gpg_card
+
+# update hashes in /boot before signing
+if [ "$update" = "y" ]; then
+	( 
+		cd /boot
+		find ./ -type f ! -name '*kexec*' | xargs sha256sum > /boot/kexec_hashes.txt
+		if [ -e /boot/kexec_default_hashes.txt ]; then
+			DEFAULT_FILES=$(cat /boot/kexec_default_hashes.txt | cut -f3 -d ' ')
+			echo $DEFAULT_FILES | xargs sha256sum > /boot/kexec_default_hashes.txt
+		fi
+	)
+
+	# Remove any package trigger log files
+	# We don't need them after the user decides to sign
+	rm -f /boot/kexec_package_trigger*
+fi
 
 if [ "$rollback" = "y" ]; then
 	rollback_file="$paramsdir/kexec_rollback.txt"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -276,26 +276,16 @@ update_checksums()
 		mount -o ro /boot \
 		|| recovery "Unable to mount /boot"
 	fi
+
 	# remount RW
 	mount -o rw,remount /boot
-	(
-	  cd /boot
-	  find ./ -type f ! -name '*kexec*' | xargs sha256sum > /boot/kexec_hashes.txt
-	  if [ -e /boot/kexec_default_hashes.txt ]; then
-	    DEFAULT_FILES=$(cat /boot/kexec_default_hashes.txt | cut -f3 -d ' ')
-	    echo $DEFAULT_FILES | xargs sha256sum > /boot/kexec_default_hashes.txt
-	  fi
-	)
-	# Remove any package trigger log files
-	# We don't need them after the user decides to sign
-	rm -f /boot/kexec_package_trigger*
 
 	# sign and auto-roll config counter
 	extparam=
 	if [ "$CONFIG_TPM" = "y" ]; then
-	extparam=-u
+		extparam=-r
 	fi
-	if ! kexec-sign-config -p /boot $extparam ; then
+	if ! kexec-sign-config -p /boot -u $extparam ; then
 	  echo "Failed to sign default config; press Enter to continue."
 	  read
 	fi


### PR DESCRIPTION
Update_checksum was already changing files in /boot, before checking for
gpg card. If no card is present, the user will end up in the recovery
next time instead of getting the same dialog again. Therefore, the
confirm_gpg_card should be checked before altering files.

The dead -u flag/$update_counter is used to mark the necessity to
update the hash files now.

Maybe it would be nice to have a dialog explaining what's happening [here](https://github.com/osresearch/heads/blob/92e9a24902a34c4a1fa68753ec1f2500a277d9f1/initrd/etc/functions#L227) anyway? (this was the place, where you got stuck without this PR)