### PR TITLE
config/coreboot-librem_15v4: set kernel video mode to 1080p

### DIFF
--- a/config/coreboot-librem_15v4.config
+++ b/config/coreboot-librem_15v4.config
@@ -27,5 +27,5 @@ CONFIG_FSP_M_XIP=y
 CONFIG_DEFAULT_CONSOLE_LOGLEVEL_8=y
 CONFIG_PAYLOAD_LINUX=y
 CONFIG_PAYLOAD_FILE="../../build/librem_15v4/bzImage"
-CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=3"
+CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=3 video=eDP-1:1920x1080"
 CONFIG_LINUX_INITRD="../../build/librem_15v4/initrd.cpio.xz"


### PR DESCRIPTION
Set the kernel video mode for the internal display to 1080p,
as the native panel resolution of 2160p is difficult to read.

A recent update to fbwhiptail allows the GUI to make use of the
scaled resolution as well, provided it is set via kernel param.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>