### PR TITLE
WiP: gpg2 2.21 LTS upgrade (gnupg toolstack)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           name: Install dependencies
           command: |
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync
       - checkout
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                --load 2 \
+#                V=1 --load 2 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -63,9 +63,9 @@ jobs:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230-flash/* build/log/* && \
+            make V=1 --load 2 BOARD=x230-flash || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Ouput x230-flash hashes
@@ -81,9 +81,9 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/t430-flash/* build/log/* && \
+            make V=1 --load 2 BOARD=t430-flash || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Ouput t430-flash hashes
@@ -99,9 +99,9 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/t430/* build/log/* && \
+            make V=1 --load 2 BOARD=t430 || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Ouput t430 hashes
@@ -117,9 +117,9 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230/* build/log/* && \
+            make V=1 --load 2 BOARD=x230 || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Ouput x230 hashes
@@ -135,9 +135,9 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230-hotp-verification/* build/log/* && \
+            make V=1 --load 2 BOARD=x230-hotp-verification || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Ouput x230-hotp-verification hashes
@@ -151,29 +151,11 @@ jobs:
           path: build/x230-hotp-verification
 
       - run:
-          name: librem_mini
-          command: |
-            rm -rf build/librem_mini/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_mini hashes
-          command: |
-            cat build/librem_mini/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_mini
-          command: |
-             tar zcvf build/librem_mini/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_mini
-
-      - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make --load 2 \
-                V=1 \
-                BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/qemu-coreboot/* build/log/* && \
+            make V=1 --load 2 BOARD=qemu-coreboot || \
+            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
           no_output_timeout: 3h
       - run:
           name: Output qemu-coreboot hashes
@@ -200,6 +182,7 @@ jobs:
             - packages
             - crossgcc
             - build
+
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,23 +77,23 @@ jobs:
       - store-artifacts:
           path: build/librem_l1um
 
-#      - run:
-#          name: librem_mini
-#          command: |
-#            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
-#                V=1 \
-#                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-#          no_output_timeout: 3h
-#      - run:
-#          name: Ouput librem_mini hashes
-#          command: |
-#            cat build/librem_mini/hashes.txt \
-#      - run:
-#          name: Archiving build logs for librem_mini
-#          command: |
-#             tar zcvf build/librem_mini/logs.tar.gz build/log/*
-#      - store-artifacts:
-#          path: build/librem_mini
+      - run:
+          name: librem_mini
+          command: |
+            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+          no_output_timeout: 3h
+      - run:
+          name: Ouput librem_mini hashes
+          command: |
+            cat build/librem_mini/hashes.txt \
+      - run:
+          name: Archiving build logs for librem_mini
+          command: |
+             tar zcvf build/librem_mini/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/librem_mini
 
       - run:
           name: x230-flash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           name: Install dependencies
           command: |
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev
       - checkout
 
       - run:
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Creating musl-cross-make and musl-cross-make patches digest
           command: |
-            find modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
+            find ./patches/musl-cross-* modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
 
 
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                CPUS=4 \
+#                --load 2 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -60,46 +60,10 @@ jobs:
 #          path: build/qemu-linuxboot/hashes.txt
 
       - run:
-          name: librem_l1um
-          command: |
-            rm -rf build/librem_l1um/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_l1um || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_l1um hashes
-          command: |
-            cat build/librem_l1um/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_l1um
-          command: |
-             tar zcvf build/librem_l1um/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_l1um
-
-      - run:
-          name: librem_mini
-          command: |
-            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_mini hashes
-          command: |
-            cat build/librem_mini/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_mini
-          command: |
-             tar zcvf build/librem_mini/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_mini
-
-      - run:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make CPUS=4 \
+            rm -rf build/x230-flash/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -117,7 +81,7 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make CPUS=4 \
+            rm -rf build/t430-flash/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -135,7 +99,7 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make CPUS=4 \
+            rm -rf build/t430/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -153,7 +117,7 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make CPUS=4 \
+            rm -rf build/x230/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -171,7 +135,7 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 \
+            rm -rf build/x230-hotp-verification/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
@@ -187,27 +151,27 @@ jobs:
           path: build/x230-hotp-verification
 
       - run:
-          name: x230-nkstorecli
+          name: librem_mini
           command: |
-            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=4 \
+            rm -rf build/librem_mini/* build/log/* && make --load 2 \
                 V=1 \
-                BOARD=x230-nkstorecli || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
-          name: Ouput x230-nkstorecli hashes
+          name: Ouput librem_mini hashes
           command: |
-            cat build/x230-nkstorecli/hashes.txt \
+            cat build/librem_mini/hashes.txt \
       - run:
-          name: Archiving build logs for x230-nkstorecli
+          name: Archiving build logs for librem_mini
           command: |
-             tar zcvf build/x230-nkstorecli/logs.tar.gz build/log/*
+             tar zcvf build/librem_mini/logs.tar.gz build/log/*
       - store-artifacts:
-          path: build/x230-nkstorecli
+          path: build/librem_mini
 
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 \
+            rm -rf build/qemu-coreboot/* build/log/* && make --load 2 \
                 V=1 \
                 BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                V=1 --load 2 \
+#                CPUS=4 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -60,12 +60,30 @@ jobs:
 #          path: build/qemu-linuxboot/hashes.txt
 
       - run:
+          name: librem_mini
+          command: |
+            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+          no_output_timeout: 3h
+      - run:
+          name: Ouput librem_mini hashes
+          command: |
+            cat build/librem_mini/hashes.txt \
+      - run:
+          name: Archiving build logs for librem_mini
+          command: |
+             tar zcvf build/librem_mini/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/librem_mini
+
+      - run:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && \
-            make V=1 --load 2 BOARD=x230-flash || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/x230-flash/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput x230-flash hashes
@@ -81,9 +99,9 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && \
-            make V=1 --load 2 BOARD=t430-flash || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/t430-flash/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput t430-flash hashes
@@ -99,9 +117,9 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && \
-            make V=1 --load 2 BOARD=t430 || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/t430/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput t430 hashes
@@ -117,9 +135,9 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && \
-            make V=1 --load 2 BOARD=x230 || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/x230/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput x230 hashes
@@ -135,9 +153,9 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && \
-            make V=1 --load 2 BOARD=x230-hotp-verification || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Ouput x230-hotp-verification hashes
@@ -153,9 +171,9 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && \
-            make V=1 --load 2 BOARD=qemu-coreboot || \
-            EXIT_CODE=$? && find ./ -type f -name "*.log" -type f -mmin -1 -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d ' ' -f5- | while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit $EXIT_CODE \
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
           no_output_timeout: 3h
       - run:
           name: Output qemu-coreboot hashes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,23 +77,23 @@ jobs:
       - store-artifacts:
           path: build/librem_l1um
 
-      - run:
-          name: librem_mini
-          command: |
-            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
-          no_output_timeout: 3h
-      - run:
-          name: Ouput librem_mini hashes
-          command: |
-            cat build/librem_mini/hashes.txt \
-      - run:
-          name: Archiving build logs for librem_mini
-          command: |
-             tar zcvf build/librem_mini/logs.tar.gz build/log/*
-      - store-artifacts:
-          path: build/librem_mini
+#      - run:
+#          name: librem_mini
+#          command: |
+#            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
+#                V=1 \
+#                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+#          no_output_timeout: 3h
+#      - run:
+#          name: Ouput librem_mini hashes
+#          command: |
+#            cat build/librem_mini/hashes.txt \
+#      - run:
+#          name: Archiving build logs for librem_mini
+#          command: |
+#             tar zcvf build/librem_mini/logs.tar.gz build/log/*
+#      - store-artifacts:
+#          path: build/librem_mini
 
       - run:
           name: x230-flash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           name: Install dependencies
           command: |
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool
       - checkout
 
       - run:
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Creating musl-cross-make and musl-cross-make patches digest
           command: |
-            find ./patches/musl-cross-* modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
+            find modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
 
 
       - restore_cache:
@@ -58,6 +58,24 @@ jobs:
 #          path: build/qemu-linuxboot/linuxboot.rom
 #      - store-artifacts:
 #          path: build/qemu-linuxboot/hashes.txt
+
+      - run:
+          name: librem_l1um
+          command: |
+            rm -rf build/librem_l1um/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=librem_l1um || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+          no_output_timeout: 3h
+      - run:
+          name: Ouput librem_l1um hashes
+          command: |
+            cat build/librem_l1um/hashes.txt \
+      - run:
+          name: Archiving build logs for librem_l1um
+          command: |
+             tar zcvf build/librem_l1um/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/librem_l1um
 
       - run:
           name: librem_mini
@@ -167,6 +185,24 @@ jobs:
              tar zcvf build/x230-hotp-verification/logs.tar.gz build/log/*
       - store-artifacts:
           path: build/x230-hotp-verification
+
+      - run:
+          name: x230-nkstorecli
+          command: |
+            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=4 \
+                V=1 \
+                BOARD=x230-nkstorecli || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+          no_output_timeout: 3h
+      - run:
+          name: Ouput x230-nkstorecli hashes
+          command: |
+            cat build/x230-nkstorecli/hashes.txt \
+      - run:
+          name: Archiving build logs for x230-nkstorecli
+          command: |
+             tar zcvf build/x230-nkstorecli/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/x230-nkstorecli
 
       - run:
           name: qemu-coreboot

--- a/modules/gpg2
+++ b/modules/gpg2
@@ -39,6 +39,9 @@ gpg2_configure := ./configure \
 	--disable-wks-tools \
 	--disable-gnutls \
 	--disable-dirmngr \
+	--disable-zip \
+	--disable-sqlite \
+	--disable-gpgsm \
 
 # Run one build to generate the executables with the pre-defined
 # exec_prefix and datarootdir, then a second make to install the binaries

--- a/modules/gpg2
+++ b/modules/gpg2
@@ -1,10 +1,10 @@
 modules-$(CONFIG_GPG2) += gpg2
 
-gpg2_version := 2.2.10
+gpg2_version := 2.2.21
 gpg2_dir := gnupg-$(gpg2_version)
 gpg2_tar := gnupg-$(gpg2_version).tar.bz2
 gpg2_url := https://www.gnupg.org/ftp/gcrypt/gnupg/$(gpg2_tar)
-gpg2_hash := 799dd37a86a1448732e339bd20440f4f5ee6e69755f6fd7a73ee8af30840c915
+gpg2_hash := 04a7c9d48b74c399168ee8270e548588ddbe52218c337703d7f06373d326ca30
 
 # For reproducibility reasons we have to override the exec_prefix
 # and datarootdir on the configure line so that the Makefiles will
@@ -16,7 +16,7 @@ gpg2_configure := ./configure \
 	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--host x86_64-linux-musl \
 	--with-libusb="$(INSTALL)" \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--with-libgcrypt-prefix="$(INSTALL)" \
 	--with-libassuan-prefix="$(INSTALL)" \
 	--with-ksba-prefix="$(INSTALL)" \
@@ -30,19 +30,12 @@ gpg2_configure := ./configure \
         --disable-regex \
         --disable-doc \
 	--disable-bzip2 \
-	--disable-asm \
 	--disable-exec \
 	--disable-photo-viewers \
-	--disable-keyserver-helpers \
 	--disable-ldap \
-	--disable-hkp \
-	--disable-finger \
-	--disable-dns-srv \
-	--disable-dns-cert \
 	--disable-regex \
 	--disable-nls \
 	--disable-all-tests \
-	--disable-wks-server \
 	--disable-wks-tools \
 	--disable-gnutls \
 	--disable-dirmngr \

--- a/modules/gpg2
+++ b/modules/gpg2
@@ -4,7 +4,7 @@ gpg2_version := 2.2.21
 gpg2_dir := gnupg-$(gpg2_version)
 gpg2_tar := gnupg-$(gpg2_version).tar.bz2
 gpg2_url := https://www.gnupg.org/ftp/gcrypt/gnupg/$(gpg2_tar)
-gpg2_hash := 04a7c9d48b74c399168ee8270e548588ddbe52218c337703d7f06373d326ca30
+gpg2_hash := 61e83278fb5fa7336658a8b73ab26f379d41275bb1c7c6e694dd9f9a6e8e76ec
 
 # For reproducibility reasons we have to override the exec_prefix
 # and datarootdir on the configure line so that the Makefiles will

--- a/modules/libassuan
+++ b/modules/libassuan
@@ -1,18 +1,16 @@
 modules-$(CONFIG_GPG2) += libassuan
-libassuan_version := 2.5.1
+libassuan_version := 2.5.3
 libassuan_dir := libassuan-$(libassuan_version)
 libassuan_tar := libassuan-$(libassuan_version).tar.bz2
 libassuan_url := https://gnupg.org/ftp/gcrypt/libassuan/$(libassuan_tar)
-libassuan_hash := 47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449
+libassuan_hash := 91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702
 
 libassuan_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 libassuan_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/libassuan
+++ b/modules/libassuan
@@ -10,6 +10,7 @@ libassuan_configure := ./configure \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
+	--disable-debug \
 	--with-gpg-error-prefix="$(INSTALL)" \
 
 libassuan_target := $(MAKE_JOBS) \

--- a/modules/libgcrypt
+++ b/modules/libgcrypt
@@ -3,7 +3,7 @@ libgcrypt_version := 1.8.6
 libgcrypt_dir := libgcrypt-$(libgcrypt_version)
 libgcrypt_tar := libgcrypt-$(libgcrypt_version).tar.bz2
 libgcrypt_url := https://gnupg.org/ftp/gcrypt/libgcrypt/$(libgcrypt_tar)
-libgcrypt_hash := 3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
+libgcrypt_hash := 0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975
 
 libgcrypt_configure := ./configure \
 	$(CROSS_TOOLS) \

--- a/modules/libgcrypt
+++ b/modules/libgcrypt
@@ -1,16 +1,16 @@
 modules-$(CONFIG_GPG2) += libgcrypt
-libgcrypt_version := 1.8.3
+libgcrypt_version := 1.8.6
 libgcrypt_dir := libgcrypt-$(libgcrypt_version)
 libgcrypt_tar := libgcrypt-$(libgcrypt_version).tar.bz2
 libgcrypt_url := https://gnupg.org/ftp/gcrypt/libgcrypt/$(libgcrypt_tar)
-libgcrypt_hash := 66ec90be036747602f2b48f98312361a9180c97c68a690a5f376fa0f67d0af7c
+libgcrypt_hash := 3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
 
 libgcrypt_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--host=x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--disable-asm \
 
 libgcrypt_target := $(MAKE_JOBS) \

--- a/modules/libgpg-error
+++ b/modules/libgpg-error
@@ -1,9 +1,9 @@
 modules-$(CONFIG_GPG2) += libgpg-error
-libgpg-error_version := 1.32
+libgpg-error_version := 1.37
 libgpg-error_dir := libgpg-error-$(libgpg-error_version)
 libgpg-error_tar := libgpg-error-$(libgpg-error_version).tar.bz2
 libgpg-error_url := https://gnupg.org/ftp/gcrypt/libgpg-error/$(libgpg-error_tar)
-libgpg-error_hash := c345c5e73cc2332f8d50db84a2280abfb1d8f6d4f1858b9daa30404db44540ca
+libgpg-error_hash := b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763
 
 libgpg-error_configure := ./configure \
 	$(CROSS_TOOLS) \
@@ -14,7 +14,6 @@ libgpg-error_configure := ./configure \
 	--disable-languages \
 	--disable-doc \
 	--disable-tests \
-	--disable-asm \
 
 libgpg-error_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/libksba
+++ b/modules/libksba
@@ -1,5 +1,5 @@
 modules-$(CONFIG_GPG2) += libksba
-libksba_version := 1.3.5
+libksba_version := 1.4.0
 libksba_dir := libksba-$(libksba_version)
 libksba_tar := libksba-$(libksba_version).tar.bz2
 libksba_url := https://gnupg.org/ftp/gcrypt/libksba/$(libksba_tar)
@@ -10,9 +10,7 @@ libksba_configure := ./configure \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 libksba_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/libksba
+++ b/modules/libksba
@@ -3,7 +3,7 @@ libksba_version := 1.4.0
 libksba_dir := libksba-$(libksba_version)
 libksba_tar := libksba-$(libksba_version).tar.bz2
 libksba_url := https://gnupg.org/ftp/gcrypt/libksba/$(libksba_tar)
-libksba_hash := 41444fd7a6ff73a79ad9728f985e71c9ba8cd3e5e53358e70d5f066d35c1a340
+libksba_hash := bfe6a8e91ff0f54d8a329514db406667000cb207238eded49b599761bfca41b6
 
 libksba_configure := ./configure \
 	$(CROSS_TOOLS) \

--- a/modules/npth
+++ b/modules/npth
@@ -10,9 +10,7 @@ npth_configure := ./configure \
 	--host x86_64-linux-musl \
 	--prefix "/" \
 	--disable-static \
-	--disable-nls \
-	--with-libgpg-error-prefix="$(INSTALL)" \
-	--disable-asm \
+	--with-gpg-error-prefix="$(INSTALL)" \
 
 npth_target := $(MAKE_JOBS) \
 	DESTDIR="$(INSTALL)" \

--- a/modules/pinentry
+++ b/modules/pinentry
@@ -27,7 +27,8 @@ pinentry_configure := ./configure \
 	--disable-pinentry-fltk \
 	--disable-pinentry-emacs \
 	--disable-fallback-curses \
-	--with-libgpg-error-prefix="$(INSTALL)" \
+	--disable-pinentry-qt5   \
+	--with-gpg-error-prefix="$(INSTALL)" \
 	--with-libassuan-prefix="$(INSTALL)" \
 
 # Run one build to generate the executables with the pre-defined

--- a/patches/gpg2-2.2.21.patch
+++ b/patches/gpg2-2.2.21.patch
@@ -1,0 +1,27 @@
+diff -u --recursive /home/tlaurion/build/clean/gnupg-2.2.10/configure gnupg-2.2.10/configure
+--- /home/tlaurion/build/clean/gnupg-2.2.10/configure	2016-08-17 09:20:25.000000000 -0400
++++ gnupg-2.2.10/configure	2018-01-20 16:55:14.502067084 -0500
+@@ -572,7 +572,7 @@
+ ac_clean_files=
+ ac_config_libobj_dir=.
+ LIBOBJS=
+-cross_compiling=no
++cross_compiling=yes
+ subdirs=
+ MFLAGS=
+ MAKEFLAGS=
+diff -u --recursive gnupg-2.2.10/common/ttyio.c gnupg-2.2.10/common/ttyio.c.mod 
+--- gnupg-2.2.10/common/ttyio.c	2017-08-28 06:22:54.000000000 -0400
++++ gnupg-2.2.10/common/ttyio.c.mod	2018-09-18 23:00:07.386250017 -0400
+@@ -190,7 +190,9 @@
+ #elif defined (HAVE_W32CE_SYSTEM)
+     ttyfp = stderr;
+ #else
+-    ttyfp = batchmode? stderr : fopen (tty_get_ttyname (), "r+");
++    //ttyfp = batchmode? stderr : fopen( tty_get_ttyname (), "r+");
++    ttyfp = stderr;
++
+     if( !ttyfp ) {
+ 	log_error("cannot open '%s': %s\n", tty_get_ttyname (),
+                   strerror(errno) );
+

--- a/patches/libassuan-2.5.3.patch
+++ b/patches/libassuan-2.5.3.patch
@@ -1,0 +1,176 @@
+diff -u -r libassuan-2.5.1-clean/configure libassuan-2.5.1/configure
+--- libassuan-2.5.1-clean/configure	2017-12-07 06:55:50.000000000 -0800
++++ libassuan-2.5.1/configure	2020-01-12 13:39:50.655638965 -0800
+@@ -10781,7 +10781,7 @@
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$host_cpu" = ia64; then
+     # AIX 5 supports IA64
+     library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
+@@ -11020,16 +11020,16 @@
+     ;;
+   freebsd3.[01]* | freebsdelf3.[01]*)
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   freebsd3.[2-9]* | freebsdelf3.[2-9]* | \
+   freebsd4.[0-5] | freebsdelf4.[0-5] | freebsd4.1.1 | freebsdelf4.1.1)
+     shlibpath_overrides_runpath=no
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   *) # from 4.6 on, and DragonFly
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   esac
+   ;;
+@@ -11042,7 +11042,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ haiku*)
+@@ -11055,7 +11055,7 @@
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11067,7 +11067,7 @@
+   case $host_cpu in
+   ia64*)
+     shrext_cmds='.so'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11082,7 +11082,7 @@
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11115,7 +11115,7 @@
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ irix5* | irix6* | nonstopux*)
+@@ -11152,7 +11152,7 @@
+   shlibpath_overrides_runpath=no
+   sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+   sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ # No shared lib support for Linux oldld, aout, or coff.
+@@ -11173,7 +11173,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   dynamic_linker='Android linker'
+   # Don't embed -rpath directories since the linker doesn't support them.
+@@ -11228,7 +11228,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   # Append ld.so.conf contents to the search path
+   if test -f /etc/ld.so.conf; then
+@@ -11253,7 +11253,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='NetBSD ld.elf_so'
+   ;;
+ 
+@@ -11272,7 +11272,7 @@
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ newsos6)
+@@ -11290,7 +11290,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+@@ -11352,7 +11352,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   # ldd complains unless libraries are executable
+   postinstall_cmds='chmod +x $lib'
+   ;;
+@@ -11409,7 +11409,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$with_gnu_ld" = yes; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+@@ -11431,7 +11431,7 @@
+   library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ uts4*)
+@@ -15680,7 +15680,7 @@
+ postuninstall_cmds='`$ECHO "$postuninstall_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_cmds='`$ECHO "$finish_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_eval='`$ECHO "$finish_eval" | $SED "$delay_single_quote_subst"`'
+-hardcode_into_libs='`$ECHO "$hardcode_into_libs" | $SED "$delay_single_quote_subst"`'
++hardcode_into_libs=no
+ sys_lib_search_path_spec='`$ECHO "$sys_lib_search_path_spec" | $SED "$delay_single_quote_subst"`'
+ sys_lib_dlsearch_path_spec='`$ECHO "$sys_lib_dlsearch_path_spec" | $SED "$delay_single_quote_subst"`'
+ hardcode_action='`$ECHO "$hardcode_action" | $SED "$delay_single_quote_subst"`'
+@@ -16896,7 +16896,7 @@
+ finish_eval=$lt_finish_eval
+ 
+ # Whether we should hardcode library paths into libraries.
+-hardcode_into_libs=$hardcode_into_libs
++hardcode_into_libs=no
+ 
+ # Compile-time system search path for libraries.
+ sys_lib_search_path_spec=$lt_sys_lib_search_path_spec

--- a/patches/libgcrypt-1.8.6.patch
+++ b/patches/libgcrypt-1.8.6.patch
@@ -1,0 +1,176 @@
+diff -u -r libgcrypt-1.8.3-clean/configure libgcrypt-1.8.3/configure
+--- libgcrypt-1.8.3-clean/configure	2018-06-13 00:39:33.000000000 -0700
++++ libgcrypt-1.8.3/configure	2020-01-12 13:32:34.840010800 -0800
+@@ -11292,7 +11292,7 @@
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$host_cpu" = ia64; then
+     # AIX 5 supports IA64
+     library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
+@@ -11531,16 +11531,16 @@
+     ;;
+   freebsd3.[01]* | freebsdelf3.[01]*)
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   freebsd3.[2-9]* | freebsdelf3.[2-9]* | \
+   freebsd4.[0-5] | freebsdelf4.[0-5] | freebsd4.1.1 | freebsdelf4.1.1)
+     shlibpath_overrides_runpath=no
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   *) # from 4.6 on, and DragonFly
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   esac
+   ;;
+@@ -11553,7 +11553,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ haiku*)
+@@ -11566,7 +11566,7 @@
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11578,7 +11578,7 @@
+   case $host_cpu in
+   ia64*)
+     shrext_cmds='.so'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11593,7 +11593,7 @@
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11626,7 +11626,7 @@
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ irix5* | irix6* | nonstopux*)
+@@ -11663,7 +11663,7 @@
+   shlibpath_overrides_runpath=no
+   sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+   sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ # No shared lib support for Linux oldld, aout, or coff.
+@@ -11684,7 +11684,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   dynamic_linker='Android linker'
+   # Don't embed -rpath directories since the linker doesn't support them.
+@@ -11739,7 +11739,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   # Append ld.so.conf contents to the search path
+   if test -f /etc/ld.so.conf; then
+@@ -11764,7 +11764,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='NetBSD ld.elf_so'
+   ;;
+ 
+@@ -11783,7 +11783,7 @@
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ newsos6)
+@@ -11801,7 +11801,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+@@ -11863,7 +11863,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   # ldd complains unless libraries are executable
+   postinstall_cmds='chmod +x $lib'
+   ;;
+@@ -11920,7 +11920,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$with_gnu_ld" = yes; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+@@ -11942,7 +11942,7 @@
+   library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ uts4*)
+@@ -19824,7 +19824,7 @@
+ postuninstall_cmds='`$ECHO "$postuninstall_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_cmds='`$ECHO "$finish_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_eval='`$ECHO "$finish_eval" | $SED "$delay_single_quote_subst"`'
+-hardcode_into_libs='`$ECHO "$hardcode_into_libs" | $SED "$delay_single_quote_subst"`'
++hardcode_into_libs=no
+ sys_lib_search_path_spec='`$ECHO "$sys_lib_search_path_spec" | $SED "$delay_single_quote_subst"`'
+ sys_lib_dlsearch_path_spec='`$ECHO "$sys_lib_dlsearch_path_spec" | $SED "$delay_single_quote_subst"`'
+ hardcode_action='`$ECHO "$hardcode_action" | $SED "$delay_single_quote_subst"`'
+@@ -21088,7 +21088,7 @@
+ finish_eval=$lt_finish_eval
+ 
+ # Whether we should hardcode library paths into libraries.
+-hardcode_into_libs=$hardcode_into_libs
++hardcode_into_libs=no
+ 
+ # Compile-time system search path for libraries.
+ sys_lib_search_path_spec=$lt_sys_lib_search_path_spec

--- a/patches/libksba-1.4.0.patch
+++ b/patches/libksba-1.4.0.patch
@@ -1,0 +1,176 @@
+diff -u -r libksba-1.3.5-clean/configure libksba-1.3.5/configure
+--- libksba-1.3.5-clean/configure	2016-08-22 02:56:54.000000000 -0700
++++ libksba-1.3.5/configure	2020-01-12 13:34:53.557259138 -0800
+@@ -10734,7 +10734,7 @@
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$host_cpu" = ia64; then
+     # AIX 5 supports IA64
+     library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
+@@ -10973,16 +10973,16 @@
+     ;;
+   freebsd3.[01]* | freebsdelf3.[01]*)
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   freebsd3.[2-9]* | freebsdelf3.[2-9]* | \
+   freebsd4.[0-5] | freebsdelf4.[0-5] | freebsd4.1.1 | freebsdelf4.1.1)
+     shlibpath_overrides_runpath=no
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   *) # from 4.6 on, and DragonFly
+     shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     ;;
+   esac
+   ;;
+@@ -10995,7 +10995,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ haiku*)
+@@ -11008,7 +11008,7 @@
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11020,7 +11020,7 @@
+   case $host_cpu in
+   ia64*)
+     shrext_cmds='.so'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11035,7 +11035,7 @@
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+-    hardcode_into_libs=yes
++    hardcode_into_libs=no
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+@@ -11068,7 +11068,7 @@
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ irix5* | irix6* | nonstopux*)
+@@ -11105,7 +11105,7 @@
+   shlibpath_overrides_runpath=no
+   sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+   sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ # No shared lib support for Linux oldld, aout, or coff.
+@@ -11126,7 +11126,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   dynamic_linker='Android linker'
+   # Don't embed -rpath directories since the linker doesn't support them.
+@@ -11181,7 +11181,7 @@
+   # This implies no fast_install, which is unacceptable.
+   # Some rework will be needed to allow for fast_install
+   # before this can be enabled.
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+ 
+   # Append ld.so.conf contents to the search path
+   if test -f /etc/ld.so.conf; then
+@@ -11206,7 +11206,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='NetBSD ld.elf_so'
+   ;;
+ 
+@@ -11225,7 +11225,7 @@
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ newsos6)
+@@ -11243,7 +11243,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+@@ -11305,7 +11305,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   # ldd complains unless libraries are executable
+   postinstall_cmds='chmod +x $lib'
+   ;;
+@@ -11362,7 +11362,7 @@
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   if test "$with_gnu_ld" = yes; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+@@ -11384,7 +11384,7 @@
+   library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
++  hardcode_into_libs=no
+   ;;
+ 
+ uts4*)
+@@ -15804,7 +15804,7 @@
+ postuninstall_cmds='`$ECHO "$postuninstall_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_cmds='`$ECHO "$finish_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_eval='`$ECHO "$finish_eval" | $SED "$delay_single_quote_subst"`'
+-hardcode_into_libs='`$ECHO "$hardcode_into_libs" | $SED "$delay_single_quote_subst"`'
++hardcode_into_libs=no
+ sys_lib_search_path_spec='`$ECHO "$sys_lib_search_path_spec" | $SED "$delay_single_quote_subst"`'
+ sys_lib_dlsearch_path_spec='`$ECHO "$sys_lib_dlsearch_path_spec" | $SED "$delay_single_quote_subst"`'
+ hardcode_action='`$ECHO "$hardcode_action" | $SED "$delay_single_quote_subst"`'
+@@ -17021,7 +17021,7 @@
+ finish_eval=$lt_finish_eval
+ 
+ # Whether we should hardcode library paths into libraries.
+-hardcode_into_libs=$hardcode_into_libs
++hardcode_into_libs=no
+ 
+ # Compile-time system search path for libraries.
+ sys_lib_search_path_spec=$lt_sys_lib_search_path_spec


### PR DESCRIPTION
It builds for all boards but cannot be injected for librem_mini: https://app.circleci.com/pipelines/github/tlaurion/heads/524/workflows/1605502b-5125-40de-8896-05a5d69086a5/jobs/568
```
librem_mini/util/cbfstool/cbfstool librem_mini/coreboot.pre.tmp add-payload -f ../../build/librem_mini/bzImage -n fallback/payload  -c none  -r COREBOOT   -C "intel_iommu=igfx_off quiet loglevel=2" -I "../../build/librem_mini/initrd.cpio.xz"
E: Could not add [../../build/librem_mini/bzImage, 7154226 bytes (6986 KB)@0x0]; too big?
E: Failed to add '../../build/librem_mini/bzImage' into ROM image.
E: Failed while operating on 'COREBOOT' region!
E: The image will be left unmodified.
make[1]: *** [Makefile.inc:1020: librem_mini/coreboot.pre] Error 1
rm librem_mini/util/cbfstool/fmd_parser.c librem_mini/util/cbfstool/fmd_scanner.c
make[1]: Leaving directory '/root/project/build/coreboot-4.12'
```
@MrChromebox #590 ? Can some kernel modules be removed, support for some changed?

Other boards CI built was successful https://app.circleci.com/pipelines/github/tlaurion/heads/525/workflows/0b48848e-9c14-49c1-971d-c4c3e5d297c4/jobs/569

No reproducibility testing was done. First step addressing #777.
