### PR TITLE
Librem Mini: increase size of CBFS

### DIFF
--- a/config/coreboot-librem_mini.config
+++ b/config/coreboot-librem_mini.config
@@ -1,5 +1,6 @@
 CONFIG_LOCALVERSION="heads"
 CONFIG_ANY_TOOLCHAIN=y
+CONFIG_CBFS_SIZE=0xC00000
 CONFIG_VENDOR_PURISM=y
 CONFIG_INTEL_GMA_VBT_FILE="3rdparty/purism-blobs/mainboard/purism/librem_whl/vbt.bin"
 CONFIG_IFD_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_whl/flashdescriptor.bin"

--- a/modules/purism-blobs
+++ b/modules/purism-blobs
@@ -1,11 +1,11 @@
 modules-$(CONFIG_PURISM_BLOBS) += purism-blobs
 
 purism-blobs_base_dir := coreboot-$(CONFIG_COREBOOT_VERSION)/3rdparty/purism-blobs
-purism-blobs_version := f53d4074a81c70352d39839884caac20181274d1
+purism-blobs_version := 7ea83c3759fa1a6f444d14cd426ca81b039c9144
 purism-blobs_tar := purism-blobs-${purism-blobs_version}.tar.gz
 purism-blobs_tar_opt := --strip 1
 purism-blobs_url := https://source.puri.sm/coreboot/purism-blobs/-/archive/${purism-blobs_version}/${purism-blobs_tar}
-purism-blobs_hash := f1abd419f085a6d519a2b9b141aee9900553aabf644f0fe1801618fb54157556
+purism-blobs_hash := 79b4914167357b7c7984ba82ae69338ac735879783ad6e922d4d24140259aaa3
 
 ## there is nothing to be built
 purism-blobs_output := .built


### PR DESCRIPTION
Increase size of CBFS to 0xC00000 (from 0x800000) to accomodate
newer/larger kernels.

Update purism-blobs module so an update/modified IFD and smaller
ME blob are used.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>