### PR TITLE
Improve handling of missing or empty boot disk

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -14,27 +14,41 @@ mount_boot()
   
   # Mount local disk if it is not already mounted
   while ! grep -q /boot /proc/mounts ; do
-    # ensure default boot device is set
-    if [ ! -e "$CONFIG_BOOT_DEV" ]; then
-      if (whiptail $BG_COLOR_ERROR --clear --title "ERROR: $CONFIG_BOOT_DEV missing!" \
-          --yesno "The /boot device $CONFIG_BOOT_DEV could not be found!\n\nYou will need to configure the correct device for /boot.\n\nWould you like to configure the /boot device now?" 30 90) then
+    # try to mount if CONFIG_BOOT_DEV exists
+    if [ -e "$CONFIG_BOOT_DEV" ]; then
+      mount -o ro $CONFIG_BOOT_DEV /boot 
+      [[ $? -eq 0 ]] && continue
+    fi
+
+    # CONFIG_BOOT_DEV doesn't exist or couldn't be mounted, so give user options
+    whiptail $BG_COLOR_ERROR --clear --title "ERROR: No Bootable OS Found!" \
+        --menu "    No bootable OS was found on the default boot device $CONFIG_BOOT_DEV.
+    How would you like to proceed?" 30 90 4 \
+        'b' ' Select a new boot device' \
+        'u' ' Boot from USB' \
+        'm' ' Continue to the main menu' \
+        'x' ' Exit to recovery shell' \
+        2>/tmp/whiptail || recovery "GUI menu failed"
+
+    option=$(cat /tmp/whiptail)
+    case "$option" in 
+      b )
         config-gui.sh boot_device_select
-      else
-        # exit to main menu
+        if [ $? -eq 0 ]; then
+          # update CONFIG_BOOT_DEV
+          . /tmp/config
+        fi
+        ;;
+      u )
+        exec /bin/usb-init
+        ;;
+      m )
         break
-      fi
-    fi
-    # update CONFIG_BOOT_DEV
-    . /tmp/config
-    mount -o ro $CONFIG_BOOT_DEV /boot 
-    if [ $? -ne 0 ]; then
-      if (whiptail $BG_COLOR_ERROR --clear --title 'ERROR: Cannot mount /boot' \
-      --yesno "The /boot partition at $CONFIG_BOOT_DEV could not be mounted!\n\nWould you like to configure the /boot device now?" 30 90) then
-        config-gui.sh boot_device_select
-      else
-        recovery "Unable to mount /boot"
-      fi
-    fi
+        ;;
+      * )
+        recovery "User requested recovery shell"
+        ;;
+    esac
   done
 }
 verify_global_hashes()

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -24,6 +24,7 @@ GPG_USER_NAME="OEM Key"
 GPG_KEY_NAME=`date +%Y%m%d%H%M%S`
 GPG_USER_MAIL="oem-${GPG_KEY_NAME}@example.com"
 GPG_USER_COMMENT="OEM-generated key"
+SKIP_BOOT="n"
 
 ## External files sourced
 
@@ -368,14 +369,16 @@ fi
 # detect and set /boot device
 echo -e "\nDetecting and setting boot device...\n"
 if ! detect_boot_device ; then
-  whiptail_error_die "Unable to locate /boot files on any mounted disk"
+  SKIP_BOOT="y"
 else
   echo -e "Boot device set to $CONFIG_BOOT_DEV\n"
 fi
 
 # update configs
-replace_config /etc/config.user "CONFIG_BOOT_DEV" "$CONFIG_BOOT_DEV"
-combine_configs
+if [[ "$SKIP_BOOT" == "n" ]]; then
+  replace_config /etc/config.user "CONFIG_BOOT_DEV" "$CONFIG_BOOT_DEV"
+  combine_configs
+fi
 
 ## reset TPM and set default password
 if [ "$CONFIG_TPM" = "y" ]; then
@@ -481,8 +484,10 @@ if ! /bin/flash.sh /tmp/oem-setup.rom >/dev/null 2>/tmp/error ; then
 fi
 
 ## sign files in /boot and generate checksums
-echo -e "\nSigning boot files and generating checksums...\n"
-generate_checksums
+if [[ "$SKIP_BOOT" == "n" ]]; then
+  echo -e "\nSigning boot files and generating checksums...\n"
+  generate_checksums
+fi
 
 ## all done -- reboot
 whiptail --msgbox "


### PR DESCRIPTION
In gui-init, check for presence of CONFIG_BOOT_DEV, and if missing or unable to be mounted, present the user with a menu offering the option to select another disk, boot from USB, continue to main menu, or drop to a recovery shell.

In oem-factory-reset, if an installed OS is not detected, then skip setting the default boot device or generating /boot checksums.

These changes facilitate ease of use for users when installing a new/empty boot disk, or for delivering an OEM system with preconfigured keys but no installed OS.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>