### PR TITLE
WiP (NOT FUNCTIONAL): xx20 blobs extraction scripts fixes

### DIFF
--- a/blobs/t420/extract.sh
+++ b/blobs/t420/extract.sh
@@ -55,10 +55,9 @@ cp "$FILE" $bioscopy
 cd "$extractdir"
 $IFDTOOL -x $bioscopy
 cp "$extractdir/flashregion_3_gbe.bin" "$BLOBDIR/gbe.bin"
-$MECLEAN -O "$BLOBDIR/me.bin" -r -t "$extractdir/flashregion_2_intel_me.bin"
+$MECLEAN -r -t -d -O /tmp/unneeded.bin -D "$BLOBDIR/ifd.bin" -M "$BLOBDIR/me.bin" "$extractdir/flashregion_2_intel_me.bin" 
 $IFDTOOL -n "$BLOBDIR/layout.txt" $bioscopy
 $IFDTOOL -x $bioscopy.new
-cp "$extractdir/flashregion_0_flashdescriptor.bin" "$BLOBDIR/ifd.bin"
 
 rm "$bioscopy"
 rm "$bioscopy.new"

--- a/blobs/t420/extract.sh
+++ b/blobs/t420/extract.sh
@@ -55,7 +55,7 @@ cp "$FILE" $bioscopy
 cd "$extractdir"
 $IFDTOOL -x $bioscopy
 cp "$extractdir/flashregion_3_gbe.bin" "$BLOBDIR/gbe.bin"
-$MECLEAN -r -t -d -O /tmp/unneeded.bin -D "$BLOBDIR/ifd.bin" -M "$BLOBDIR/me.bin" "$extractdir/flashregion_2_intel_me.bin" 
+$MECLEAN -r -t -d -O /tmp/unneeded.bin -D "$BLOBDIR/ifd.bin" -M "$BLOBDIR/me.bin" "$extractdir/flashregion_2_intel_me.bin"
 $IFDTOOL -n "$BLOBDIR/layout.txt" $bioscopy
 $IFDTOOL -x $bioscopy.new
 

--- a/blobs/x220/extract.sh
+++ b/blobs/x220/extract.sh
@@ -55,10 +55,9 @@ cp "$FILE" $bioscopy
 cd "$extractdir"
 $IFDTOOL -x $bioscopy
 cp "$extractdir/flashregion_3_gbe.bin" "$BLOBDIR/gbe.bin"
-$MECLEAN -O "$BLOBDIR/me.bin" -r -t "$extractdir/flashregion_2_intel_me.bin"
+$MECLEAN -r -t -d -O /tmp/unneeded.bin -D "$BLOBDIR/ifd.bin" -M "$BLOBDIR/me.bin" "$extractdir/flashregion_2_intel_me.bin"
 $IFDTOOL -n "$BLOBDIR/layout.txt" $bioscopy
 $IFDTOOL -x $bioscopy.new
-cp "$extractdir/flashregion_0_flashdescriptor.bin" "$BLOBDIR/ifd.bin"
 
 rm "$bioscopy"
 rm "$bioscopy.new"


### PR DESCRIPTION
me_cleaner called to neuter, deactivate, trim ME and output reduced ME under blob dir, modify both ME and BIOS regions accordingly to be able to accept CONFIG_CBFS_SIZE=0x750000 defined under coreboot configs (attempt to fix #870)