### PR TITLE
Add option to auto-boot default target on successful HOTP verification

### DIFF
--- a/boards/librem_13v2/librem_13v2.config
+++ b/boards/librem_13v2/librem_13v2.config
@@ -37,3 +37,4 @@ export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 13 v2/v3"
 export CONFIG_FLASHROM_OPTIONS="-p internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5

--- a/boards/librem_13v4/librem_13v4.config
+++ b/boards/librem_13v4/librem_13v4.config
@@ -37,3 +37,4 @@ export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 13 v4"
 export CONFIG_FLASHROM_OPTIONS="-p internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5

--- a/boards/librem_15v3/librem_15v3.config
+++ b/boards/librem_15v3/librem_15v3.config
@@ -37,3 +37,4 @@ export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 15 v3"
 export CONFIG_FLASHROM_OPTIONS="-p internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5

--- a/boards/librem_15v4/librem_15v4.config
+++ b/boards/librem_15v4/librem_15v4.config
@@ -37,3 +37,4 @@ export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 15 v4"
 export CONFIG_FLASHROM_OPTIONS="-p internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5

--- a/boards/librem_mini/librem_mini.config
+++ b/boards/librem_mini/librem_mini.config
@@ -38,3 +38,4 @@ export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem Mini"
 export CONFIG_FLASHROM_OPTIONS="-p internal"
 export CONFIG_USB_KEYBOARD=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -9,6 +9,8 @@ export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-"--background-gradient 0 0 0 150
 . /etc/functions
 . /tmp/config
 
+first_pass=true
+
 mount_boot()
 {
   
@@ -239,16 +241,34 @@ while true; do
       HOTP='N/A'
     fi
 
-    whiptail $MAIN_MENU_BG_COLOR --clear --title "$MAIN_MENU_TITLE" \
-      --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 20 90 10 \
-      'y' ' Default boot' \
-      'r' ' Refresh TOTP/HOTP' \
-      'a' ' Options -->' \
-      'S' ' System Info' \
-      'P' ' Power Off' \
-      2>/tmp/whiptail || recovery "GUI menu failed"
+    if [[ "$HOTP" = "Success" && $CONFIG_AUTO_BOOT_TIMEOUT && $first_pass = true ]]; then 
+      # save IFS before changing, restore after read
+      IFS_DEF=$IFS
+      IFS=''
+      first_pass=false
+      echo -e "\nHOTP verification success\n\n"
+      read -t $CONFIG_AUTO_BOOT_TIMEOUT -s -n 1 -p "Automatic boot in $CONFIG_AUTO_BOOT_TIMEOUT seconds unless interrupted by keypress... "
+      if [[ $? -ne 0 ]]; then
+        IFS=$IFS_DEF
+        # skip to default boot
+        totp_confirm='y'
+        echo -e "\n\nAttempting default boot...\n\n"
+      fi
+      IFS=$IFS_DEF
+    fi
 
-    totp_confirm=$(cat /tmp/whiptail)
+    if [ "$totp_confirm" != "y" -o -z "$totp_confirm" ]; then
+      whiptail $MAIN_MENU_BG_COLOR --clear --title "$MAIN_MENU_TITLE" \
+        --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 20 90 10 \
+        'y' ' Default boot' \
+        'r' ' Refresh TOTP/HOTP' \
+        'a' ' Options -->' \
+        'S' ' System Info' \
+        'P' ' Power Off' \
+        2>/tmp/whiptail || recovery "GUI menu failed"
+
+      totp_confirm=$(cat /tmp/whiptail)
+    fi
   fi
 
   if [ "$totp_confirm" = "a" ]; then


### PR DESCRIPTION
And enable it for all Librem boards.

On first time through gui-init loop, if CONFIG_AUTO_BOOT_TIMEOUT exists and is set, and if HOTP validation was successful, then attempt to boot the default target after CONFIG_AUTO_BOOT_TIMEOUT seconds if not interrupted by key press.

Set CONFIG_AUTO_BOOT_TIMEOUT to 5s for all Librem boards.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>