### PR TITLE
CircleCI seperation of main failed error and detailed logs of last minute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,14 @@ jobs:
       - run:
           name: librem_l1um
           command: |
-            rm -rf build/librem_l1um/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_l1um || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/librem_l1um/* build/log/* && make CPUS=4 V=1 BOARD=librem_l1um || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput librem_l1um hashes
+          name: Output build failing logs 
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi \
+      - run:
+          name: Output librem_l1um hashes
           command: |
             cat build/librem_l1um/hashes.txt \
       - run:
@@ -80,12 +82,14 @@ jobs:
       - run:
           name: librem_mini
           command: |
-            rm -rf build/librem_mini/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=librem_mini || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/librem_mini/* build/log/* && make CPUS=4 V=1 BOARD=librem_mini || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput librem_mini hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output librem_mini hashes
           command: |
             cat build/librem_mini/hashes.txt \
       - run:
@@ -99,12 +103,14 @@ jobs:
           name: x230-flash
           #We delete build/make-4.2.1/ directory until issue #799 is fixed.
           command: |
-            rm -rf build/x230-flash/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=x230-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230-flash/* build/log/* && make CPUS=4 V=1 BOARD=x230-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput x230-flash hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output x230-flash hashes
           command: |
             cat build/x230-flash/hashes.txt \
       - run:
@@ -117,12 +123,14 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=t430-flash || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/t430-flash/* build/log/* && make CPUS=4 V=1 BOARD=t430-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput t430-flash hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output t430-flash hashes
           command: |
             cat build/t430-flash/hashes.txt \
       - run:
@@ -135,12 +143,14 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=t430  || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/t430/* build/log/* && make CPUS=4 V=1 BOARD=t430 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput t430 hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output t430 hashes
           command: |
             cat build/t430/hashes.txt \
       - run:
@@ -153,12 +163,14 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=x230 || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230/* build/log/* && make CPUS=4 V=1 BOARD=x230 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput x230 hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output x230 hashes
           command: |
             cat build/x230/hashes.txt \
       - run:
@@ -171,12 +183,14 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=x230-hotp-verification || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 V=1 BOARD=x230-hotp-verification || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput x230-hotp-verification hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output x230-hotp-verification hashes
           command: |
             cat build/x230-hotp-verification/hashes.txt \
       - run:
@@ -189,12 +203,14 @@ jobs:
       - run:
           name: x230-nkstorecli
           command: |
-            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=x230-nkstorecli || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=4 V=1 BOARD=x230-nkstorecli || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
-          name: Ouput x230-nkstorecli hashes
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output x230-nkstorecli hashes
           command: |
             cat build/x230-nkstorecli/hashes.txt \
       - run:
@@ -207,10 +223,12 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 \
-                V=1 \
-                BOARD=qemu-coreboot || (find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1) \
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 V=1 BOARD=qemu-coreboot || touch /tmp/failed_build
           no_output_timeout: 3h
+      - run:
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
       - run:
           name: Output qemu-coreboot hashes
           command: |
@@ -221,6 +239,26 @@ jobs:
              tar zcvf build/qemu-coreboot/logs.tar.gz build/log/*
       - store-artifacts:
           path: build/qemu-coreboot
+
+      - run:
+          name: qemu-coreboot-fbwhiptail
+          command: |
+            rm -rf build/qemu-coreboot-fbwhiptail/* build/log/* && make CPUS=4 V=1 BOARD=qemu-coreboot-fbwhiptail || touch /tmp/failed_build
+          no_output_timeout: 3h
+      - run:
+          name: Output build failing logs
+          command: |
+            if [[ -f /tmp/failed_build ]]; then find ./build/ -name "*.log" -type f -mmin -1|while read log; do echo ""; echo '==>' "$log" '<=='; echo ""; cat $log;done; exit 1;else echo "Not failing. Continuing..."; fi
+      - run:
+          name: Output qemu-coreboot-fbwhiptail hashes
+          command: |
+             cat build/qemu-coreboot-fbwhiptail/hashes.txt \
+      - run:
+          name: Archiving build logs for qemu-coreboot-fbwhiptail
+          command: |
+             tar zcvf build/qemu-coreboot-fbwhiptail/logs.tar.gz build/log/*
+      - store-artifacts:
+          path: build/qemu-coreboot-fbwhiptail
 
       - save_cache:
           #Generate cache for the same musl-cross module definition if hash is not previously existing


### PR DESCRIPTION
bonus: qemu-coreboot-fbwhiptail board addition

Successful build log here: https://app.circleci.com/pipelines/github/tlaurion/heads/583/workflows/fe4eec40-336b-4fbf-bd50-e8708413d290/jobs/631

Waiting for failed log output from [here](https://app.circleci.com/pipelines/github/tlaurion/heads/585/workflows/09675c1e-f358-4c35-bc39-87b2befc63cb/jobs/633)

EDIT: good to merge @MrChromebox if you have tweaks: point here is to only show detailed logs failing when there is a fail without polluting main build output (so we know what failed without searching for "<==" as before.