### PR TITLE
kexec-sign-config: fix args to `getopts`

### DIFF
--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -6,7 +6,7 @@ set -e -o pipefail
 
 rollback="n"
 update="n"
-while getopts "p:c:u:r" arg; do
+while getopts "p:c:ur" arg; do
 	case $arg in
 		p) paramsdir="$OPTARG" ;;
 		c) counter="$OPTARG"; rollback="y" ;;


### PR DESCRIPTION
The -u arg does not take a parameter, so remove the trailing colon.

Fixes /boot hashes not being updated when update_checksums() is called.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>