### PR TITLE
non-coreboot-builds: do not error if CONFIG_COREBOOT_VERSION is not set

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -1,5 +1,7 @@
 modules-$(CONFIG_COREBOOT) += coreboot
 
+ifeq "$(CONFIG_COREBOOT)" "y"
+
 ifeq "$(CONFIG_COREBOOT_VERSION)" "4.8.1"
 	coreboot_version := 4.8.1
 	coreboot_hash := f0ddf4db0628c1fe1e8348c40084d9cbeb5771400c963fd419cda3995b69ad23
@@ -128,4 +130,5 @@ endif
 coreboot-blobs_output := .built
 coreboot-blobs_configure := echo -e 'all:\n\ttouch .built' > Makefile
 
+endif
 endif


### PR DESCRIPTION
building `BOARD=qemu-linuxboot` fails due to an error in `modules/coreboot` (which is not used for LinuxBoot builds)