### PR TITLE
xx30-*-maximized boards: typo fix in comments expend -> expand

### DIFF
--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -71,7 +71,7 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 # the ME image and part of the coreboot image, and a 4 MB one that
 # has the rest of the coreboot and the reset vector.
 #   
-# As a consequence, this replaces the need of having to flash x230-flash and expends available CBFS region (11.5Mb available CBFS space)
+# As a consequence, this replaces the need of having to flash x230-flash and expands available CBFS region (11.5Mb available CBFS space)
 #
 # When flashing via an external programmer it is easiest to have
 # two separate files for these pieces.

--- a/boards/t430-maximized/t430-maximized.config
+++ b/boards/t430-maximized/t430-maximized.config
@@ -71,7 +71,7 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 # the ME image and part of the coreboot image, and a 4 MB one that
 # has the rest of the coreboot and the reset vector.
 #   
-# As a consequence, this replaces the need of having to flash x230-flash and expends available CBFS region (11.5Mb available CBFS space)
+# As a consequence, this replaces the need of having to flash x230-flash and expands available CBFS region (11.5Mb available CBFS space)
 #
 # When flashing via an external programmer it is easiest to have
 # two separate files for these pieces.

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -71,7 +71,7 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 # the ME image and part of the coreboot image, and a 4 MB one that
 # has the rest of the coreboot and the reset vector.
 #   
-# As a consequence, this replaces the need of having to flash x230-flash and expends available CBFS region (11.5Mb available CBFS space)
+# As a consequence, this replaces the need of having to flash x230-flash and expands available CBFS region (11.5Mb available CBFS space)
 #
 # When flashing via an external programmer it is easiest to have
 # two separate files for these pieces.

--- a/boards/x230-maximized/x230-maximized.config
+++ b/boards/x230-maximized/x230-maximized.config
@@ -71,7 +71,7 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 # the ME image and part of the coreboot image, and a 4 MB one that
 # has the rest of the coreboot and the reset vector.
 #   
-# As a consequence, this replaces the need of having to flash x230-flash and expends available CBFS region (11.5Mb available CBFS space)
+# As a consequence, this replaces the need of having to flash x230-flash and expands available CBFS region (11.5Mb available CBFS space)
 #
 # When flashing via an external programmer it is easiest to have
 # two separate files for these pieces.


### PR DESCRIPTION
Misses some typos correction under #912 under comments.