### PR TITLE
xx20-hotp-maximized: forgot to fix path to initrd, failed under CI.

### DIFF
--- a/config/coreboot-t420-hotp-maximized.config
+++ b/config/coreboot-t420-hotp-maximized.config
@@ -20,5 +20,5 @@ CONFIG_DEFAULT_CONSOLE_LOGLEVEL_5=y
 CONFIG_PAYLOAD_LINUX=y
 CONFIG_PAYLOAD_FILE="../../build/t420-hotp-maximized/bzImage"
 CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=3"
-CONFIG_LINUX_INITRD="../../build/t420-maximized/initrd.cpio.xz"
+CONFIG_LINUX_INITRD="../../build/t420-hotp-maximized/initrd.cpio.xz"
 CONFIG_DEBUG_SMM_RELOCATION=y

--- a/config/coreboot-x220-hotp-maximized.config
+++ b/config/coreboot-x220-hotp-maximized.config
@@ -20,5 +20,5 @@ CONFIG_CONSOLE_CBMEM_BUFFER_SIZE=0x80000
 CONFIG_PAYLOAD_LINUX=y
 CONFIG_PAYLOAD_FILE="../../build/x220-hotp-maximized/bzImage"
 CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=3"
-CONFIG_LINUX_INITRD="../../build/x220-maximized/initrd.cpio.xz"
+CONFIG_LINUX_INITRD="../../build/x220-hotp-maximized/initrd.cpio.xz"
 CONFIG_DEBUG_SMM_RELOCATION=y


### PR DESCRIPTION
Sorry about that. Would have swore that CI was successful prior of merging https://github.com/osresearch/heads/commit/0f1f547eb13ebe90a5fe68f3637db9ab7ec43df0

- Missed correcting the paths to initrd since copied from xx20-maximized boards config.