### PR TITLE
linuxboot: Pass $CPUS to edk2/OvmfPkg/build.sh unerroneously

### DIFF
--- a/modules/linuxboot
+++ b/modules/linuxboot
@@ -21,7 +21,7 @@ linuxboot_configure := \
 	if [ "$(linuxboot_board)" = "qemu" ]; then \
 		echo >&2 "Pre-building edk2 OVMF" ; \
 		( cd $(build)/$(linuxboot_base_dir)/edk2/OvmfPkg ; \
-		./build.sh -n $$CPUS \
+		./build.sh -n $(CPUS) \
 		) || exit 1 ; \
 	fi ; \
 	touch .config ; \


### PR DESCRIPTION
On a clean checkout of HEADS when attempting to build the `qemu-linuxboot` board, configuration of Linuxboot fails:

```
Pre-building edk2 OVMF
Initializing workspace
/home/docker/workspace/heads/build/linuxboot-git/edk2/BaseTools
Loading previous configuration from /home/docker/workspace/heads/build/linuxboot-git/edk2/Conf/BuildEnv.sh
WORKSPACE: /home/docker/workspace/heads/build/linuxboot-git/edk2
EDK_TOOLS_PATH: /home/docker/workspace/heads/build/linuxboot-git/edk2/BaseTools
CONF_PATH: /home/docker/workspace/heads/build/linuxboot-git/edk2/Conf
using prebuilt tools
Running edk2 build for OvmfPkgX64
Usage: build.exe [options] [all|fds|genc|genmake|clean|cleanall|cleanlib|modules|libraries|run]

build.exe: error: option -n: invalid integer value: 'PUS'
```

Changing `$$CPUS` to `$(CPUS)` in `modules/linuxboot` fixes this.