### PR TITLE
Kgpe d16 flashrom fix

### DIFF
--- a/modules/flashrom
+++ b/modules/flashrom
@@ -2,14 +2,11 @@ modules-$(CONFIG_FLASHROM) += flashrom
 
 flashrom_depends := pciutils $(musl_dep)
 
-flashrom_version := git
-flashrom_repo := https://github.com/flashrom/flashrom.git
-
 flashrom_version := b1f858f65b2abd276542650d8cb9e382da258967
 flashrom_dir := flashrom-$(flashrom_version)
-flashrom_tar := $(flashrom_dir).zip
-flashrom_url := https://github.com/flashrom/flashrom/archive/$(flashrom_tar)
-flashrom_hash := 7fc39fa2e721f84856095d377e624712714c8668175d48b1cde5f8574afc254f
+flashrom_tar := $(flashrom_dir).tar.gz
+flashrom_url := https://github.com/flashrom/flashrom/archive/$(flashrom_version).tar.gz
+flashrom_hash := 4873ad50f500629c244fc3fbee64b56403a82307d7f555dfa235336a200c336c
 
 flashrom_target := \
 	$(MAKE_JOBS) \

--- a/modules/flashrom
+++ b/modules/flashrom
@@ -15,6 +15,7 @@ flashrom_target := \
 	CONFIG_NOTHING=yes \
 	CONFIG_INTERNAL=yes \
 	CONFIG_DUMMY=yes \
+	CONFIG_AST1100=yes \
 
 flashrom_output := \
 	flashrom


### PR DESCRIPTION
Allows KGPE-D16 users to flash the BMC internally.

@MrChromebox please review also as makes modifications to your work. As laid out in the commit messages:

> * Flashrom was being fetched with git and was always using `master`
> * No patches were being applied (i.e. `0100-enable-kgpe-d16.patch` was being ignored).