### PR TITLE
busybox: CONFIG_BASH_IS_ASH is incompatible with CONFIG_BASH_IS_NONE

### DIFF
--- a/config/busybox.config
+++ b/config/busybox.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.32.0
-# Thu Nov  5 16:35:47 2020
+# Wed Dec 30 20:23:50 2020
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -1098,7 +1098,7 @@ CONFIG_SH_IS_ASH=y
 # CONFIG_SH_IS_NONE is not set
 CONFIG_BASH_IS_ASH=y
 # CONFIG_BASH_IS_HUSH is not set
-CONFIG_BASH_IS_NONE=y
+# CONFIG_BASH_IS_NONE is not set
 CONFIG_SHELL_ASH=y
 CONFIG_ASH=y
 CONFIG_ASH_OPTIMIZE_FOR_SIZE=y


### PR DESCRIPTION
Disabling the latter to have successfull build otherwise [fails](https://app.circleci.com/pipelines/github/osresearch/heads/269/workflows/48be189a-953a-4829-b6f4-0fbb76d3fb7d/jobs/295).

@Thrilleratplay amendment to https://github.com/osresearch/heads/commit/69eb81995809faee342c35b3916fdfea95a8aa4f