### PR TITLE
CircleCI: Add coreboot+musl-cross cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,23 +17,32 @@ jobs:
             git reset --hard "$CIRCLE_SHA1" \
 
       - run:
-          name: Creating all modules and patches digest
+          name: Creating all modules and patches digest (All modules cache digest)
           command: |
             find ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > /tmp/all_modules_and_patches.sha256sums \
 
       - run:
-          name: Creating musl-cross-make and musl-cross-make patches digest
+          name: Creating coreboot (and associated patches) and musl-cross-make modules digest (musl-cross-make and coreboot cache digest)
           command: |
-            find modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross_module_and_patches.sha256sums \
+            find ./modules/coreboot ./modules/musl-cross* ./patches/coreboot* -type f | sort -h | xargs sha256sum > /tmp/coreboot_musl-cross.sha256sums \
+
+      - run:
+          name: Creating musl-cross-make and musl-cross-make patches digest (musl-cross-make cache digest)
+          command: |
+            find modules/musl-cross* -type f | sort -h | xargs sha256sum > /tmp/musl-cross.sha256sums \
 
 
       - restore_cache:
           keys:
-            #Restore existing cache for modules checksums validated to be exactly the same as in github current commit
+            #Restore existing cache for matching modules digest, validated to be exactly the same as in github current commit.
+            #This cache was made on top of below caches, if previously existing. If no module definition changed, we reuse this one. Otherwise...
             - heads-modules-and-patches-{{ checksum "/tmp/all_modules_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}
-            #If precedent fails. Restore cache for musl-cross module checksum validated to be exactly the same as in github current commit
-            - heads-cross-musl-{{ checksum "/tmp/musl-cross_module_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}
-
+            #If precedent cache not found, restore cache for coreboot module (and patches) and musl-cross-make digests (bi-yearly modified)
+            #Otehrwise....
+            - heads-coreboot-musl-cross-{{ checksum "/tmp/coreboot_musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
+            #If precedent cache not found. Restore cache for musl-cross-make module digest (rarely modified).
+            #Otherwise, we build cleanly.
+            - heads-musl-cross-{{ checksum "/tmp/musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
 # linuxboot steps need something to pass in the kernel header path
 # skipping for now
 #      - run:
@@ -578,11 +587,17 @@ jobs:
 
       - save_cache:
           #Generate cache for the same musl-cross module definition if hash is not previously existing
-          key: heads-cross-musl-{{ checksum "/tmp/musl-cross_module_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}
+          key: heads-musl-cross-{{ checksum "/tmp/musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
           paths:
             - crossgcc
             - build/musl-cross-*
-
+      - save_cache:
+          #Generate cache for the same coreboot mnd musl-cross-make modules definition if hash is not previously existing
+          key: heads-coreboot-musl-cross-{{ checksum "/tmp/coreboot_musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
+          paths:
+            - build/coreboot-*
+            - crossgcc
+            - build/musl-cross-*
       - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing
           key: heads-modules-and-patches-{{ checksum "/tmp/all_modules_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}
@@ -590,6 +605,7 @@ jobs:
             - packages
             - crossgcc
             - build
+            - install
 
 workflows:
   version: 2

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -72,7 +72,7 @@ coreboot_depend += linux initrd $(musl_dep)
 
 COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
 $(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
-	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$$CPUS crossgcc-i386
+	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$(CPUS) crossgcc-i386
 
 $(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL) $(COREBOOT_TOOLCHAIN)
 $(COREBOOT_IASL): $(build)/$(coreboot_base_dir)/.canary

--- a/patches/coreboot-4.11/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
+++ b/patches/coreboot-4.11/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
@@ -1,0 +1,42 @@
+--- a/util/crossgcc/buildgcc.orig	2021-01-03 19:58:54.084000000 -0500
++++ b/util/crossgcc/buildgcc	2021-01-03 19:58:56.985000000 -0500
+@@ -67,23 +67,23 @@
+ # These are sanitized by the jenkins toolchain test builder, so if
+ # a completely new URL is added here, it probably needs to be added
+ # to the jenkins build as well, or the builder won't download it.
+-GMP_ARCHIVE="https://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
+-MPFR_ARCHIVE="https://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+-MPC_ARCHIVE="https://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
+-GCC_ARCHIVE="https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
+-BINUTILS_ARCHIVE="https://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
+-GDB_ARCHIVE="https://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
+-IASL_ARCHIVE="https://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
+-PYTHON_ARCHIVE="https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
+-EXPAT_ARCHIVE="https://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
++GMP_ARCHIVE="http://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
++MPFR_ARCHIVE="http://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
++MPC_ARCHIVE="http://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
++GCC_ARCHIVE="http://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
++BINUTILS_ARCHIVE="http://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
++GDB_ARCHIVE="http://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
++IASL_ARCHIVE="http://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
++PYTHON_ARCHIVE="http://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
++EXPAT_ARCHIVE="http://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
+ # CLANG toolchain archive locations
+-LLVM_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
+-CFE_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz"
+-CRT_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
+-CTE_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
+-MAKE_ARCHIVE="https://ftpmirror.gnu.org/make/make-${MAKE_VERSION}.tar.bz2"
+-CMAKE_ARCHIVE="https://cmake.org/files/v3.15/cmake-${CMAKE_VERSION}.tar.gz"
+-NASM_ARCHIVE="https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.bz2"
++LLVM_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
++CFE_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz"
++CRT_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
++CTE_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
++MAKE_ARCHIVE="http://ftpmirror.gnu.org/make/make-${MAKE_VERSION}.tar.bz2"
++CMAKE_ARCHIVE="http://cmake.org/files/v3.15/cmake-${CMAKE_VERSION}.tar.gz"
++NASM_ARCHIVE="http://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.bz2"
+ 
+ ALL_ARCHIVES="$GMP_ARCHIVE $MPFR_ARCHIVE $MPC_ARCHIVE \
+ 	$GCC_ARCHIVE $BINUTILS_ARCHIVE $GDB_ARCHIVE $IASL_ARCHIVE \

--- a/patches/coreboot-4.13/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
+++ b/patches/coreboot-4.13/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
@@ -1,0 +1,40 @@
+--- a/util/crossgcc/buildgcc.orig	2021-01-03 19:56:28.980000000 -0500
++++ b/util/crossgcc/buildgcc	2021-01-03 19:56:32.098000000 -0500
+@@ -52,22 +52,22 @@
+ # These are sanitized by the jenkins toolchain test builder, so if
+ # a completely new URL is added here, it probably needs to be added
+ # to the jenkins build as well, or the builder won't download it.
+-GMP_ARCHIVE="https://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
+-MPFR_ARCHIVE="https://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+-MPC_ARCHIVE="https://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
+-GCC_ARCHIVE="https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
+-BINUTILS_ARCHIVE="https://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
+-GDB_ARCHIVE="https://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
+-IASL_ARCHIVE="https://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
+-PYTHON_ARCHIVE="https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
+-EXPAT_ARCHIVE="https://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
++GMP_ARCHIVE="http://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
++MPFR_ARCHIVE="http://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
++MPC_ARCHIVE="http://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
++GCC_ARCHIVE="http://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
++BINUTILS_ARCHIVE="http://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
++GDB_ARCHIVE="http://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
++IASL_ARCHIVE="http://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
++PYTHON_ARCHIVE="http://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
++EXPAT_ARCHIVE="http://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
+ # CLANG toolchain archive locations
+-LLVM_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
+-CLANG_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-${CLANG_VERSION}.src.tar.xz"
+-CRT_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
+-CTE_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
+-CMAKE_ARCHIVE="https://cmake.org/files/v3.18/cmake-${CMAKE_VERSION}.tar.gz"
+-NASM_ARCHIVE="https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.bz2"
++LLVM_ARCHIVE="http://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
++CLANG_ARCHIVE="http://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-${CLANG_VERSION}.src.tar.xz"
++CRT_ARCHIVE="http://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
++CTE_ARCHIVE="http://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
++CMAKE_ARCHIVE="http://cmake.org/files/v3.18/cmake-${CMAKE_VERSION}.tar.gz"
++NASM_ARCHIVE="http://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.bz2"
+ 
+ ALL_ARCHIVES="$GMP_ARCHIVE $MPFR_ARCHIVE $MPC_ARCHIVE \
+ 	$GCC_ARCHIVE $BINUTILS_ARCHIVE $GDB_ARCHIVE $IASL_ARCHIVE \

--- a/patches/coreboot-4.8.1/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
+++ b/patches/coreboot-4.8.1/0080-util-crossgcc-builgcc_temp_fix_from_https_to_http.patch
@@ -1,0 +1,40 @@
+--- a/util/crossgcc/buildgcc.orig	2021-01-03 19:47:10.583000000 -0500
++++ b/util/crossgcc/buildgcc	2021-01-03 19:47:18.000000000 -0500
+@@ -66,22 +66,22 @@
+ # These are sanitized by the jenkins toolchain test builder, so if
+ # a completely new URL is added here, it probably needs to be added
+ # to the jenkins build as well, or the builder won't download it.
+-GMP_ARCHIVE="https://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
+-MPFR_ARCHIVE="https://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+-MPC_ARCHIVE="https://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
+-GCC_ARCHIVE="https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
+-BINUTILS_ARCHIVE="https://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
+-GDB_ARCHIVE="https://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
+-IASL_ARCHIVE="https://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
+-PYTHON_ARCHIVE="https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
+-EXPAT_ARCHIVE="https://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
++GMP_ARCHIVE="http://ftpmirror.gnu.org/gmp/gmp-${GMP_VERSION}.tar.xz"
++MPFR_ARCHIVE="http://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
++MPC_ARCHIVE="http://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
++GCC_ARCHIVE="http://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
++BINUTILS_ARCHIVE="http://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
++GDB_ARCHIVE="http://ftpmirror.gnu.org/gdb/gdb-${GDB_VERSION}.tar.xz"
++IASL_ARCHIVE="http://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
++PYTHON_ARCHIVE="http://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
++EXPAT_ARCHIVE="http://downloads.sourceforge.net/sourceforge/expat/expat-${EXPAT_VERSION}.tar.bz2"
+ # CLANG toolchain archive locations
+-LLVM_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
+-CFE_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz"
+-CRT_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
+-CTE_ARCHIVE="https://releases.llvm.org/${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
+-MAKE_ARCHIVE="https://ftpmirror.gnu.org/make/make-${MAKE_VERSION}.tar.bz2"
+-CMAKE_ARCHIVE="https://cmake.org/files/v3.11/cmake-${CMAKE_VERSION}.tar.gz"
++LLVM_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
++CFE_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz"
++CRT_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/compiler-rt-${CLANG_VERSION}.src.tar.xz"
++CTE_ARCHIVE="http://releases.llvm.org/${CLANG_VERSION}/clang-tools-extra-${CLANG_VERSION}.src.tar.xz"
++MAKE_ARCHIVE="http://ftpmirror.gnu.org/make/make-${MAKE_VERSION}.tar.bz2"
++CMAKE_ARCHIVE="http://cmake.org/files/v3.11/cmake-${CMAKE_VERSION}.tar.gz"
+ 
+ ALL_ARCHIVES="$GMP_ARCHIVE $MPFR_ARCHIVE $MPC_ARCHIVE \
+ 	$GCC_ARCHIVE $BINUTILS_ARCHIVE $GDB_ARCHIVE $IASL_ARCHIVE \


### PR DESCRIPTION
The idea here is a cache to restore from (musl-cross from coreboot version bound crosscomipler, from which coreboot is built)

1- Reuse existing cache for all modules and patches created digest's hash. (If a single module or patch changes, we have cache miss)
2- Reuse existing coreboot and musl-cross-make created digest's hash (If a patch was added to current coreboot, or new coreboot version was added in coreboot module definition, we have a cache miss. Otherwise, we reuse the whole musl-cross-make and coreboot cache for current used versions.)
3- Reuse existing musl-cross-make created digest's hash matching cache (If musl-cross-make module didn't change, we don't rebuild it)

Per https://github.com/osresearch/heads/pull/947#issuecomment-753507412 proposition
@Tonux599 please challenge me!