### PR TITLE
xx30-flash boards: produce top.rom and remove 12mb rom for clarity

### DIFF
--- a/boards/t430-flash/t430-flash.config
+++ b/boards/t430-flash/t430-flash.config
@@ -6,8 +6,13 @@ export CONFIG_COREBOOT_VERSION=4.8.1
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_FLASHROM=y
+#CONFIG_GPG=y
 CONFIG_FLASHTOOLS=y
 CONFIG_PCIUTILS=y
+#CONFIG_MBEDTLS=y
+#CONFIG_QRENCODE=y
+#CONFIG_TPMTOTP=y
+#CONFIG_DROPBEAR=y
 
 CONFIG_LINUX_CONFIG=config/linux-x230-flash.config
 CONFIG_LINUX_USB=y
@@ -20,7 +25,9 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image
 # for flashing into SPI flash 1 on the mainboard.  This is enough to
 # allow the board to boot into a minimal Heads and read the full
 # ROM from an external USB media.
-all: $(build)/$(BOARD)/$(BOARD).rom
-$(build)/$(BOARD)/$(BOARD).rom: $(build)/$(BOARD)/$(CB_OUTPUT_FILE)
-	dd of=$@ if=$< bs=65536 count=64 skip=128
-	sha256sum $@
+all: $(build)/$(BOARD)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom
+$(build)/$(BOARD)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom: $(build)/$(BOARD)/$(CB_OUTPUT_FILE)
+	$(call do,DD 4MB,$@,dd of=$@ if=$< bs=65536 count=64 skip=128 status=none)
+	@sha256sum $@
+	#We remove the original ROM, leaving only the 4mb top one
+	rm $(build)/$(BOARD)/$(CB_OUTPUT_FILE)

--- a/boards/x230-flash/x230-flash.config
+++ b/boards/x230-flash/x230-flash.config
@@ -25,7 +25,9 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image
 # for flashing into SPI flash 1 on the mainboard.  This is enough to
 # allow the board to boot into a minimal Heads and read the full
 # ROM from an external USB media.
-all: $(build)/$(BOARD)/$(BOARD).rom
-$(build)/$(BOARD)/$(BOARD).rom: $(build)/$(BOARD)/$(CB_OUTPUT_FILE)
-	dd of=$@ if=$< bs=65536 count=64 skip=128
-	sha256sum $@
+all: $(build)/$(BOARD)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom
+$(build)/$(BOARD)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom: $(build)/$(BOARD)/$(CB_OUTPUT_FILE)
+	$(call do,DD 4MB,$@,dd of=$@ if=$< bs=65536 count=64 skip=128 status=none)
+	@sha256sum $@
+	#We remove the original ROM, leaving only the 4mb top one
+	rm $(build)/$(BOARD)/$(CB_OUTPUT_FILE)


### PR DESCRIPTION
Produces only a 4mb top rom following actual name standard as other boards.

Fixes #951 (not so elegant. If you have better idea, please advise)