### PR TITLE
libusb: replace package origin from sourceforge to github release

### DIFF
--- a/modules/libusb
+++ b/modules/libusb
@@ -6,6 +6,7 @@ libusb_version := 1.0.21
 libusb_dir := libusb-$(libusb_version)
 libusb_tar := libusb-$(libusb_version).tar.bz2
 libusb_url := https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-$(libusb_version)/$(libusb_tar)
+libusb_url := https://github.com/libusb/libusb/releases/download/v$(libusb_version)/$(libusb_tar)
 libusb_hash := 7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b
 
 libusb_configure := ./configure\


### PR DESCRIPTION
without hardcoding url... sorry guys
as https://github.com/osresearch/heads/pull/968 should have been.

Repeating why we push this quick:
[Last CI build in master fails because of a 302 temporary redirect resulting to bad checksum](https://app.circleci.com/pipelines/github/osresearch/heads/277/workflows/1748498a-fe5e-4bb6-a12e-e334f8f76f1b/jobs/305):

```
2021-02-03 00:41:30+00:00 WGET https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2
if ! wget -O "/root/project/packages/libusb-1.0.21.tar.bz2.tmp" https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2 ; then exit 1 ; fi ; mv "/root/project/packages/libusb-1.0.21.tar.bz2.tmp" "/root/project/packages/libusb-1.0.21.tar.bz2" 
--2021-02-03 00:41:30--  https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2
Resolving downloads.sourceforge.net (downloads.sourceforge.net)... 13.32.202.67, 13.32.202.19, 13.32.202.119, ...
Connecting to downloads.sourceforge.net (downloads.sourceforge.net)|13.32.202.67|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://downloads.sourceforge.net/#!/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2 [following]
--2021-02-03 00:41:30--  https://downloads.sourceforge.net/
Reusing existing connection to downloads.sourceforge.net:443.
HTTP request sent, awaiting response... 200 OK
Length: 746 [text/html]
Saving to: '/root/project/packages/libusb-1.0.21.tar.bz2.tmp'

/root/project/packa 100%[===================>]     746  --.-KB/s    in 0s      

2021-02-03 00:41:30 (24.3 MB/s) - '/root/project/packages/libusb-1.0.21.tar.bz2.tmp' saved [746/746]

echo "7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b  /root/project/packages/libusb-1.0.21.tar.bz2" | sha256sum --check -
/root/project/packages/libusb-1.0.21.tar.bz2: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
make: *** [Makefile:441: /root/project/packages/.libusb-1.0.21_verify] Error 1
```