### PR TITLE
Circle ci optimization build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                CPUS=4 \
+#                CPUS=16 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: kgpe-d16_workstation
           command: |
-            rm -rf build/kgpe-d16_workstation/* build/log/* && make CPUS=4 V=1 BOARD=kgpe-d16_workstation || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_workstation/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_workstation || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: kgpe-d16_workstation-usb_keyboard
           command: |
-            rm -rf build/kgpe-d16_workstation-usb_keyboard/* build/log/* && make CPUS=4 V=1 BOARD=kgpe-d16_workstation-usb_keyboard || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_workstation-usb_keyboard/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_workstation-usb_keyboard || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: kgpe-d16_server
           command: |
-            rm -rf build/kgpe-d16_server/* build/log/* && make CPUS=4 V=1 BOARD=kgpe-d16_server || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_server/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_server || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -131,7 +131,7 @@ jobs:
       - run:
           name: kgpe-d16_server-whiptail
           command: |
-            rm -rf build/kgpe-d16_server-whiptail/* build/log/* && make CPUS=4 V=1 BOARD=kgpe-d16_server-whiptail || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_server-whiptail/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_server-whiptail || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: librem_l1um
           command: |
-            rm -rf build/librem_l1um/* build/log/* && make CPUS=4 V=1 BOARD=librem_l1um || touch /tmp/failed_build
+            rm -rf build/librem_l1um/* build/log/* && make CPUS=16 V=1 BOARD=librem_l1um || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: librem_mini
           command: |
-            rm -rf build/librem_mini/* build/log/* && make CPUS=4 V=1 BOARD=librem_mini || touch /tmp/failed_build
+            rm -rf build/librem_mini/* build/log/* && make CPUS=16 V=1 BOARD=librem_mini || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: librem_mini_v2
           command: |
-            rm -rf build/librem_mini_v2/* build/log/* && make CPUS=4 V=1 BOARD=librem_mini_v2 || touch /tmp/failed_build
+            rm -rf build/librem_mini_v2/* build/log/* && make CPUS=16 V=1 BOARD=librem_mini_v2 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -215,7 +215,7 @@ jobs:
       - run:
           name: x220-hotp-maximized
           command: |
-            rm -rf build/x220-hotp-maximized/* build/log/* && make CPUS=4 V=1 BOARD=x220-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/x220-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x220-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -239,7 +239,7 @@ jobs:
       - run:
           name: x220-maximized
           command: |
-            rm -rf build/x220-maximized/* build/log/* && make CPUS=4 V=1 BOARD=x220-maximized || touch /tmp/failed_build
+            rm -rf build/x220-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x220-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: t420-hotp-maximized
           command: |
-            rm -rf build/t420-hotp-maximized/* build/log/* && make CPUS=4 V=1 BOARD=t420-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/t420-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t420-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -287,7 +287,7 @@ jobs:
       - run:
           name: t420-maximized
           command: |
-            rm -rf build/t420-maximized/* build/log/* && make CPUS=4 V=1 BOARD=t420-maximized || touch /tmp/failed_build
+            rm -rf build/t420-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t420-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -307,7 +307,7 @@ jobs:
       - run:
           name: x230-flash
           command: |
-            rm -rf build/x230-flash/* build/log/* && make CPUS=4 V=1 BOARD=x230-flash || touch /tmp/failed_build
+            rm -rf build/x230-flash/* build/log/* && make CPUS=16 V=1 BOARD=x230-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -327,7 +327,7 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make CPUS=4 V=1 BOARD=t430-flash || touch /tmp/failed_build
+            rm -rf build/t430-flash/* build/log/* && make CPUS=16 V=1 BOARD=t430-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -347,7 +347,7 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make CPUS=4 V=1 BOARD=t430 || touch /tmp/failed_build
+            rm -rf build/t430/* build/log/* && make CPUS=16 V=1 BOARD=t430 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -367,7 +367,7 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make CPUS=4 V=1 BOARD=x230 || touch /tmp/failed_build
+            rm -rf build/x230/* build/log/* && make CPUS=16 V=1 BOARD=x230 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -387,7 +387,7 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=4 V=1 BOARD=x230-hotp-verification || touch /tmp/failed_build
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=16 V=1 BOARD=x230-hotp-verification || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -407,7 +407,7 @@ jobs:
       - run:
           name: x230-nkstorecli
           command: |
-            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=4 V=1 BOARD=x230-nkstorecli || touch /tmp/failed_build
+            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=16 V=1 BOARD=x230-nkstorecli || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -431,7 +431,7 @@ jobs:
       - run:
           name: x230-maximized
           command: |
-            rm -rf build/x230-maximized/* build/log/* && make CPUS=4 V=1 BOARD=x230-maximized || touch /tmp/failed_build
+            rm -rf build/x230-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -455,7 +455,7 @@ jobs:
       - run:
           name: t430-hotp-maximized
           command: |
-            rm -rf build/t430-hotp-maximized/* build/log/* && make CPUS=4 V=1 BOARD=t430-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/t430-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t430-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -479,7 +479,7 @@ jobs:
       - run:
           name: x230-maximized
           command: |
-            rm -rf build/x230-maximized/* build/log/* && make CPUS=4 V=1 BOARD=x230-maximized || touch /tmp/failed_build
+            rm -rf build/x230-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -503,7 +503,7 @@ jobs:
       - run:
           name: x230-hotp-maximized
           command: |
-            rm -rf build/x230-hotp-maximized/* build/log/* && make CPUS=4 V=1 BOARD=x230-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/x230-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -528,7 +528,7 @@ jobs:
       - run:
           name: t430-maximized
           command: |
-            rm -rf build/t430-maximized/* build/log/* && make CPUS=4 V=1 BOARD=t430-maximized || touch /tmp/failed_build
+            rm -rf build/t430-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t430-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -548,7 +548,7 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=4 V=1 BOARD=qemu-coreboot || touch /tmp/failed_build
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=16 V=1 BOARD=qemu-coreboot || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -568,7 +568,7 @@ jobs:
       - run:
           name: qemu-coreboot-fbwhiptail
           command: |
-            rm -rf build/qemu-coreboot-fbwhiptail/* build/log/* && make CPUS=4 V=1 BOARD=qemu-coreboot-fbwhiptail || touch /tmp/failed_build
+            rm -rf build/qemu-coreboot-fbwhiptail/* build/log/* && make CPUS=16 V=1 BOARD=qemu-coreboot-fbwhiptail || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 #          command: |
 #            ./build/make-4.2.1/make \
 #                CROSS=/cross/bin/x86_64-linux-musl- \
-#                CPUS=16 \
+#                CPUS=24 \
 #                V=1 \
 #                BOARD=qemu-linuxboot \
 #
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: kgpe-d16_workstation
           command: |
-            rm -rf build/kgpe-d16_workstation/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_workstation || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_workstation/* build/log/* && make CPUS=24 V=1 BOARD=kgpe-d16_workstation || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: kgpe-d16_workstation-usb_keyboard
           command: |
-            rm -rf build/kgpe-d16_workstation-usb_keyboard/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_workstation-usb_keyboard || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_workstation-usb_keyboard/* build/log/* && make CPUS=24 V=1 BOARD=kgpe-d16_workstation-usb_keyboard || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: kgpe-d16_server
           command: |
-            rm -rf build/kgpe-d16_server/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_server || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_server/* build/log/* && make CPUS=24 V=1 BOARD=kgpe-d16_server || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -131,7 +131,7 @@ jobs:
       - run:
           name: kgpe-d16_server-whiptail
           command: |
-            rm -rf build/kgpe-d16_server-whiptail/* build/log/* && make CPUS=16 V=1 BOARD=kgpe-d16_server-whiptail || touch /tmp/failed_build
+            rm -rf build/kgpe-d16_server-whiptail/* build/log/* && make CPUS=24 V=1 BOARD=kgpe-d16_server-whiptail || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: librem_l1um
           command: |
-            rm -rf build/librem_l1um/* build/log/* && make CPUS=16 V=1 BOARD=librem_l1um || touch /tmp/failed_build
+            rm -rf build/librem_l1um/* build/log/* && make CPUS=24 V=1 BOARD=librem_l1um || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: librem_mini
           command: |
-            rm -rf build/librem_mini/* build/log/* && make CPUS=16 V=1 BOARD=librem_mini || touch /tmp/failed_build
+            rm -rf build/librem_mini/* build/log/* && make CPUS=24 V=1 BOARD=librem_mini || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: librem_mini_v2
           command: |
-            rm -rf build/librem_mini_v2/* build/log/* && make CPUS=16 V=1 BOARD=librem_mini_v2 || touch /tmp/failed_build
+            rm -rf build/librem_mini_v2/* build/log/* && make CPUS=24 V=1 BOARD=librem_mini_v2 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -215,7 +215,7 @@ jobs:
       - run:
           name: x220-hotp-maximized
           command: |
-            rm -rf build/x220-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x220-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/x220-hotp-maximized/* build/log/* && make CPUS=24 V=1 BOARD=x220-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -239,7 +239,7 @@ jobs:
       - run:
           name: x220-maximized
           command: |
-            rm -rf build/x220-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x220-maximized || touch /tmp/failed_build
+            rm -rf build/x220-maximized/* build/log/* && make CPUS=24 V=1 BOARD=x220-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: t420-hotp-maximized
           command: |
-            rm -rf build/t420-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t420-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/t420-hotp-maximized/* build/log/* && make CPUS=24 V=1 BOARD=t420-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -287,7 +287,7 @@ jobs:
       - run:
           name: t420-maximized
           command: |
-            rm -rf build/t420-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t420-maximized || touch /tmp/failed_build
+            rm -rf build/t420-maximized/* build/log/* && make CPUS=24 V=1 BOARD=t420-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -307,7 +307,7 @@ jobs:
       - run:
           name: x230-flash
           command: |
-            rm -rf build/x230-flash/* build/log/* && make CPUS=16 V=1 BOARD=x230-flash || touch /tmp/failed_build
+            rm -rf build/x230-flash/* build/log/* && make CPUS=24 V=1 BOARD=x230-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -327,7 +327,7 @@ jobs:
       - run:
           name: t430-flash
           command: |
-            rm -rf build/t430-flash/* build/log/* && make CPUS=16 V=1 BOARD=t430-flash || touch /tmp/failed_build
+            rm -rf build/t430-flash/* build/log/* && make CPUS=24 V=1 BOARD=t430-flash || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -347,7 +347,7 @@ jobs:
       - run:
           name: t430
           command: |
-            rm -rf build/t430/* build/log/* && make CPUS=16 V=1 BOARD=t430 || touch /tmp/failed_build
+            rm -rf build/t430/* build/log/* && make CPUS=24 V=1 BOARD=t430 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -367,7 +367,7 @@ jobs:
       - run:
           name: x230
           command: |
-            rm -rf build/x230/* build/log/* && make CPUS=16 V=1 BOARD=x230 || touch /tmp/failed_build
+            rm -rf build/x230/* build/log/* && make CPUS=24 V=1 BOARD=x230 || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -387,7 +387,7 @@ jobs:
       - run:
           name: x230-hotp-verification
           command: |
-            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=16 V=1 BOARD=x230-hotp-verification || touch /tmp/failed_build
+            rm -rf build/x230-hotp-verification/* build/log/* && make CPUS=24 V=1 BOARD=x230-hotp-verification || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -407,7 +407,7 @@ jobs:
       - run:
           name: x230-nkstorecli
           command: |
-            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=16 V=1 BOARD=x230-nkstorecli || touch /tmp/failed_build
+            rm -rf build/x230-nkstorecli/* build/log/* && make CPUS=24 V=1 BOARD=x230-nkstorecli || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -431,7 +431,7 @@ jobs:
       - run:
           name: x230-maximized
           command: |
-            rm -rf build/x230-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-maximized || touch /tmp/failed_build
+            rm -rf build/x230-maximized/* build/log/* && make CPUS=24 V=1 BOARD=x230-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -455,7 +455,7 @@ jobs:
       - run:
           name: t430-hotp-maximized
           command: |
-            rm -rf build/t430-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t430-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/t430-hotp-maximized/* build/log/* && make CPUS=24 V=1 BOARD=t430-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -479,7 +479,7 @@ jobs:
       - run:
           name: x230-maximized
           command: |
-            rm -rf build/x230-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-maximized || touch /tmp/failed_build
+            rm -rf build/x230-maximized/* build/log/* && make CPUS=24 V=1 BOARD=x230-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -503,7 +503,7 @@ jobs:
       - run:
           name: x230-hotp-maximized
           command: |
-            rm -rf build/x230-hotp-maximized/* build/log/* && make CPUS=16 V=1 BOARD=x230-hotp-maximized || touch /tmp/failed_build
+            rm -rf build/x230-hotp-maximized/* build/log/* && make CPUS=24 V=1 BOARD=x230-hotp-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -528,7 +528,7 @@ jobs:
       - run:
           name: t430-maximized
           command: |
-            rm -rf build/t430-maximized/* build/log/* && make CPUS=16 V=1 BOARD=t430-maximized || touch /tmp/failed_build
+            rm -rf build/t430-maximized/* build/log/* && make CPUS=24 V=1 BOARD=t430-maximized || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -548,7 +548,7 @@ jobs:
       - run:
           name: qemu-coreboot
           command: |
-            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=16 V=1 BOARD=qemu-coreboot || touch /tmp/failed_build
+            rm -rf build/qemu-coreboot/* build/log/* && make CPUS=24 V=1 BOARD=qemu-coreboot || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs
@@ -568,7 +568,7 @@ jobs:
       - run:
           name: qemu-coreboot-fbwhiptail
           command: |
-            rm -rf build/qemu-coreboot-fbwhiptail/* build/log/* && make CPUS=16 V=1 BOARD=qemu-coreboot-fbwhiptail || touch /tmp/failed_build
+            rm -rf build/qemu-coreboot-fbwhiptail/* build/log/* && make CPUS=24 V=1 BOARD=qemu-coreboot-fbwhiptail || touch /tmp/failed_build
           no_output_timeout: 3h
       - run:
           name: Output build failing logs


### PR DESCRIPTION
Dodging the problem of CircleCI limiting builds to 5h by putting CPUS=24 in CircleCI config.

Interim fix to #970, which goal is to parallelize builds.