### PR TITLE
Fix exit codes for ME download scripts

### DIFF
--- a/blobs/xx20/download_parse_me.sh
+++ b/blobs/xx20/download_parse_me.sh
@@ -12,22 +12,22 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Downloading https://download.lenovo.com/ibmdl/pub/pc/pccbbs/mobiles/83rf46ww.exe..."
-wget  https://download.lenovo.com/ibmdl/pub/pc/pccbbs/mobiles/83rf46ww.exe || ( echo "ERROR: wget not found" && exit 1 )
+wget  https://download.lenovo.com/ibmdl/pub/pc/pccbbs/mobiles/83rf46ww.exe || { echo "ERROR: wget not found" && exit 1; }
 echo "### Verifying expected hash of 83rf46ww.exe"
-echo "$ME_EXE_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on downloaded binary..." && exit 1 )
+echo "$ME_EXE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on downloaded binary..." && exit 1; }
 
 
 echo "### Extracting 83rf46ww.exe..."
-innoextract -I app/ME7_5M_UPD_Production.bin 83rf46ww.exe || ( echo "Failed calling innoextract. Tool installed on host?" && exit 1)
+innoextract -I app/ME7_5M_UPD_Production.bin 83rf46ww.exe || { echo "Failed calling innoextract. Tool installed on host?" && exit 1; }
 echo "### Verifying expected hash of app/ME7_5M_UPD_Production.bin"
-echo "$ME7_5M_UPD_PRODUCTION_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on extracted binary..." && exit 1 )
+echo "$ME7_5M_UPD_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
 
 
 echo "###Generating neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
-python3 "$BLOBDIR/me7_update_parser.py" -O "$BLOBDIR/me.bin" app/ME7_5M_UPD_Production.bin || ( echo "Failed to generate ME binary..." && exit 1 )
+python3 "$BLOBDIR/me7_update_parser.py" -O "$BLOBDIR/me.bin" app/ME7_5M_UPD_Production.bin || { echo "Failed to generate ME binary..." && exit 1; }
 
 echo "### Verifying expected hash of me.bin"
-echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on final binary..." && exit 1 )
+echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
 
 
 echo "###Cleaning up..."

--- a/blobs/xx30/download_clean_me.sh
+++ b/blobs/xx30/download_clean_me.sh
@@ -36,19 +36,19 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Downloading https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe..."
-wget  https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe || ( echo "ERROR: wget not found" && exit 1 ) 
+wget  https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe || { echo "ERROR: wget not found" && exit 1; }
 echo "### Verifying expected hash of g1rg24ww.exe"
-echo "$ME_EXE_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on downloaded binary..." && exit 1 )
+echo "$ME_EXE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on downloaded binary..." && exit 1; }
 
 echo "### Extracting g1rg24ww.exe..."
-innoextract ./g1rg24ww.exe || exit 1 "Failed calling innoextract. Tool installed on host?"
+innoextract ./g1rg24ww.exe || { echo "Failed calling innoextract. Tool installed on host?" && exit 1;}
 echo "### Verifying expected hash of app/ME8_5M_Production.bin"
-echo "$ME8_5M_PRODUCTION_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on extracted binary..." && exit 1 )
+echo "$ME8_5M_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
 
 echo "###Applying me_cleaner to neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
 $MECLEAN -r -t -O "$BLOBDIR/me.bin" app/ME8_5M_Production.bin
 echo "### Verifying expected hash of me.bin"
-echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || ( echo "Failed sha256sum verification on final binary..." && exit 1 )
+echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
 
 
 echo "###Cleaning up..."


### PR DESCRIPTION
Incorrect parentheses brackets used in those scripts meant that the script as a whole did not return the correct exit code. The use of `( )` brackets created a sub-shell to which the exit code applied to that sub-shell. Changing to `{ }` does not create a sub-shell and as such, the script will return its true return code.

This is evident by changing a character of `FINAL_ME_BIN_SHA256SUM` in `./blobs/xx20/download_parse_me.sh` and running `./download_parse_me.sh && echo "Okay" || echo "Failed"`.

It is important that the exit codes are correct as we want to catch errors as early as possible in CI builds.