### PR TITLE
init: remove double heads motd banner, keeping the one sent to tty0 

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -33,7 +33,6 @@ mkdir -p /tmp/secret
 
 # Now it is safe to print a banner
 if [ -r /etc/motd ]; then
-	cat /etc/motd
 	cat /etc/motd > /dev/tty0
 fi
 


### PR DESCRIPTION
The banner sent to tty0 is sent both local and remote in past tests.
@MrChromebox please approve.