### PR TITLE
Add support for coreboot 4.14 for System76 Lemur Pro 10

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -19,6 +19,11 @@ else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.13"
 	coreboot_hash := 4779da645a25ddebc78f1bd2bd0b740fb1e6479572648d4650042a2b9502856a
 	coreboot-blobs_hash := 060656b46a7859d038ddeec3f7e086e85f146a50b280c4babec23c1188264dc8
 	coreboot_depends := $(if $(CONFIG_PURISM_BLOBS), purism-blobs)
+else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.14"
+	coreboot_version := 4.14
+	coreboot_hash := d907379b727561d7ddd1d80b2fabaa373db00c9805719116f591cbc948173c6e 
+	coreboot-blobs_hash := 9ee2fe5ba37d0e214000b8655acf8922de6df792adb75790559db4c160847921 
+	coreboot_depends := $(if $(CONFIG_PURISM_BLOBS), purism-blobs)
 else
 	$(error "$(BOARD): does not specify coreboot version under CONFIG_COREBOOT_VERSION")
 endif 


### PR DESCRIPTION
The System76 Lemur Pro 10 (lemp10) does not currently have upstream coreboot support (there is a WIP patch [here](https://review.coreboot.org/c/coreboot/+/52294/1) but it is unknown if it will be ready for the October release cycle).  Thus, add coreboot 4.14 support currently.  If the WIP patch set is _not_ merged, then another PR will be created to patch in lemp10 support to be applied to coreboot 4.14.  When the patchset is merged, then 4.14 will be bumped to that stable version as with #932 

Signed-off-by: Cody Ho <codyho@stanford.edu>