### PR TITLE
etc/functions: Filter boot device options with '/dev/'

### DIFF
--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -312,7 +312,7 @@ detect_boot_device()
 	fi
 
 	# generate list of possible boot devices
-	fdisk -l | grep "Disk" | cut -f2 -d " " | cut -f1 -d ":" > /tmp/disklist
+	fdisk -l | grep "Disk /dev/" | cut -f2 -d " " | cut -f1 -d ":" > /tmp/disklist
 
 	# filter out extraneous options
 	> /tmp/boot_device_list


### PR DESCRIPTION
Grepping on just 'Disk' can lead to disk UUID identifier strings
being added to /tmp/disklist, which then fail to parse later on.
Avoid this by grepping on 'Disk /dev' instead.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>