### PR TITLE
blobs/librem_*: ensure blobs placed in script dir

### DIFF
--- a/blobs/librem_kbl/get_blobs.sh
+++ b/blobs/librem_kbl/get_blobs.sh
@@ -95,6 +95,9 @@ check_and_get_blob () {
     fi
 }
 
+# ensure pwd is script dir
+cd "$(dirname "$0")"
+
 echo ""
 
 check_and_get_tools() {

--- a/blobs/librem_skl/get_blobs.sh
+++ b/blobs/librem_skl/get_blobs.sh
@@ -95,6 +95,9 @@ check_and_get_blob () {
     fi
 }
 
+# ensure pwd is script dir
+cd "$(dirname "$0")"
+
 echo ""
 
 check_and_get_tools() {


### PR DESCRIPTION
Ensure blobs end up in correct dirs, even when scripts are
called from the root project dir. Fixes issues when called
from CircleCI.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>