### PR TITLE
fix bug with e.g. nosplash parameter in kernel command line

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -49,7 +49,9 @@ adjusted_cmd_line="n"
 adjust_cmd_line() {
 	if [ -n "$cmdremove" ]; then
 		for i in $cmdremove; do
-			cmdline="${cmdline//$i/}"
+			cmdline="${cmdline#$i }"
+			cmdline="${cmdline/ $i / }"
+			cmdline="${cmdline% $i}"
 		done
 	fi
 


### PR DESCRIPTION
Strings from $cmdremove should only be removed from $cmdline if they are enclosed by spaces of if they are at the beginning of $cmdline followed by a space or if they are at the end of $cmdline prepended by a space.

For more information about the bug fixed by this commit please look at https://source.puri.sm/firmware/pureboot/-/issues/4 .

If the kernel command line configured contains eg. 'nosplash' and 'splash' should have been removed from the kernel command line this left over 'no' (without the 'splash'). This led to a situation with pureboot that disabled key entry when the Nitrokey is used for decryption of a luks keyslot.