### PR TITLE
kexec-boot: Streamline cmdline remove filtering

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -49,9 +49,7 @@ adjusted_cmd_line="n"
 adjust_cmd_line() {
 	if [ -n "$cmdremove" ]; then
 		for i in $cmdremove; do
-			cmdline="${cmdline#$i }"
-			cmdline="${cmdline/ $i / }"
-			cmdline="${cmdline% $i}"
+			cmdline=$(echo $cmdline | sed "s/\b$i\b//g")
 		done
 	fi
 


### PR DESCRIPTION
Use sed one-liner vs 3 bash inline commands

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>