### PR TITLE
System info: add battery status (health and charge)

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -474,12 +474,19 @@ reset_tpm()
 
 show_system_info()
 {
+  battery_charge="$(print_battery_charge)"
+  battery_health="$(print_battery_health)"
+  if [ -n $battery_charge -a -n $battery_health ];then
+	  battery_status="\nBattery charge: $battery_charge%\nBattery health: $battery_health%\n"
+  fi
+
   memtotal=$(cat /proc/meminfo | grep 'MemTotal' | tr -s ' ' | cut -f2 -d ' ')
   memtotal=$((${memtotal} / 1024 / 1024 + 1))
   cpustr=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed -r 's/\(R\)//;s/\(TM\)//;s/CPU //;s/model name.*: //')
   kernel=$(uname -s -r)
+  
   whiptail $BG_COLOR_MAIN_MENU --title 'System Info' \
-    --msgbox "${BOARD_NAME}\n\nFW_VER: ${FW_VER}\nKernel: ${kernel}\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
+    --msgbox "${BOARD_NAME}\n\nFW_VER: ${FW_VER}\nKernel: ${kernel}\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n$battery_status\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 16 60
 }
 
 select_os_boot_option()

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -345,3 +345,24 @@ detect_boot_device()
 	umount /boot 2>/dev/null
 	return 1
 }
+
+calc()
+{ 
+	awk "BEGIN { print "$*" }"; 
+}
+
+print_battery_health()
+{
+	if [ -d /sys/class/power_supply/BAT0 ]; then
+        	battery_health=$(calc $(cat /sys/class/power_supply/BAT0/charge_full)/$(cat /sys/class/power_supply/BAT0/charge_full_design)*100 | awk -F "." {'print $1'})
+		echo "$battery_health"
+	fi
+}
+
+print_battery_charge()
+{
+	if [ -d /sys/class/power_supply/BAT0 ]; then
+                battery_charge=$(calc $(cat /sys/class/power_supply/BAT0/charge_now)/$(cat /sys/class/power_supply/BAT0/charge_full)*100 | awk -F "." {'print $1'})
+                echo "$battery_charge"
+        fi
+}


### PR DESCRIPTION
Actual full charge capacity vs design full charge capacity is an important thing to know. For OEMs QA as for users.

This adds 
- a calc function under /etc/functions
- a print_battery_health function under /etc/functions which returns current battery capacity/factory capacity. (percent integer)
- a print_battery_charge function under /etc/functions which returns current battery capacity/factory capacity. (percent integer)
- an additional battery status block under System Info that is present only if BAT0 exists for the moment. Otherwise the output is unchanged.
- Changed header of etc/gui_functions since gui-init is usable without fbwhiptail (whiptail: without fbwhiptail nor cairo).

Why: 
- To be able to test for battery health in custom init scripts.
- For users to know if their battery not lasting long is because really used and quickly ask for replacement.
- For OEMs to be able to test this in custom scripts if desired prior of order fulfillment...

Edited after discussion and force push.