### PR TITLE
Newt width size additional fixes

### DIFF
--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -49,7 +49,7 @@ while true; do
               /bin/flash.sh "$ROM"
             fi
             whiptail --title 'ROM Flashed Successfully' \
-              --msgbox "${ROM#"/media/"}\n\nhas been flashed successfully.\n\nPress Enter to reboot\n" 16 60
+              --msgbox "${ROM#"/media/"}\n\nhas been flashed successfully.\n\nPress Enter to reboot\n" 16 90
             umount /media
             /bin/reboot
           else

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -86,10 +86,10 @@ gpg_post_gen_mgmt() {
     cp "/tmp/${GPG_GEN_KEY}.asc" "/media/${GPG_GEN_KEY}.asc"
     if [ $? -eq 0 ]; then
       whiptail --title "The GPG Key Copied Successfully" \
-        --msgbox "${GPG_GEN_KEY}.asc copied successfully." 16 60
+        --msgbox "${GPG_GEN_KEY}.asc copied successfully." 16 90
     else
       whiptail $BG_COLOR_ERROR --title 'ERROR: Copy Failed' \
-        --msgbox "Unable to copy ${GPG_GEN_KEY}.asc to /media" 16 60
+        --msgbox "Unable to copy ${GPG_GEN_KEY}.asc to /media" 16 90
     fi
     umount /media
   fi
@@ -204,7 +204,7 @@ while true; do
     "l" )
       GPG_KEYRING=`gpg -k`
       whiptail --title 'GPG Keyring' \
-        --msgbox "${GPG_KEYRING}" 16 60
+        --msgbox "${GPG_KEYRING}" 16 90
     ;;
     "p" )
         if (whiptail --title 'Export Public Key(s) to USB drive?' \

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -60,7 +60,7 @@ verify_global_hashes()
 		if [ "$gui_menu" = "y" ]; then
 			CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
 			whiptail $BG_COLOR_ERROR --title 'ERROR: Boot Hash Mismatch' \
-				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 60
+				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 90
 		fi
 		die "$TMP_HASH_FILE: boot hash mismatch"
 	fi
@@ -240,7 +240,7 @@ default_select() {
 		if [ "$gui_menu" = "y" ]; then
 			CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
 			whiptail $BG_COLOR_ERROR --title 'ERROR: Default Boot Hash Mismatch' \
-				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 60
+				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 16 90
 		fi
 		die "!!! $TMP_DEFAULT_HASH_FILE: default boot hash mismatch"
 	fi


### PR DESCRIPTION
NEWT as opposed to FBWhiptail enforces line width.
So if input is of different sizes, we have a chance that the lines are wrapped over multiple lines.

This is preventively fixing this by increasing such lines from 60 chars to 90.

@MrChromebox sorry for not having proactively added this in previous accepted pull request.
