### PR TITLE
oem-factory-reset: fix keygen prompt order (fixes Yubikey. Breaks Nitrokey/Librem Keys)

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -102,13 +102,12 @@ gpg_key_reset()
         echo admin
         echo generate
         echo n
-        echo ${ADMIN_PIN_DEF}
         echo ${USER_PIN_DEF}
         echo 0
-        echo y
         echo ${GPG_USER_NAME} 
         echo ${GPG_USER_MAIL}
         echo ${GPG_USER_COMMENT}
+        echo ${ADMIN_PIN_DEF}
     } | gpg --command-fd=0 --status-fd=2 --pinentry-mode=loopback --card-edit \
         > /tmp/gpg_card_edit_output 2>/dev/null 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Edit: Yubikey related. Does not affect Librem key/Nitrokey and seem to be linked to OpenGPG implemented standards being different between Yubikey and Nitrokey/Librem Key.

---------------------

- gpg --version: gpg (GnuPG) 2.2.21
- An "okay" was requested after Comment
- Admin PIN was requested after "okay"
- Prompts observed:

Make off-card backup of encryption key? (Y/n)
PIN:
Key is valid for? (0)
Is this correct? (y/N)
Real name:
Email address:
Comment:
Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit?
Admin PIN: