### PR TITLE
Use issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-for-everything-except-build-errors.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-for-everything-except-build-errors.md
@@ -1,0 +1,118 @@
+---
+name: Bug report for everything except build errors
+about: Use this template for all other bugs except those related to building heads
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Please identify some basic details to help process the report
+
+### A. Provide Hardware Details
+
+**1. What board are you using (see list of boards [here](https://github.com/eganonoa/heads/tree/master/boards))?**
+
+**2. Does your computer have a dGPU or is it iGPU-only?**
+- [ ] dGPU
+- [ ] iGPU-only
+
+**3. Who installed Heads on this computer?**
+- [ ] Insurgo
+- [ ] Nitrokey
+- [ ] Purism
+- [ ] Other provider
+- [ ] Self-installed
+
+**4. What PGP key is being used?**
+- [ ] Librem Key
+- [ ] Nitrokey Pro 2
+- [ ] Nitrokey Storage
+- [ ] Yubikey
+- [ ] Other
+
+**5. Are you using the PGP key to provide HOTP verification?**
+- [ ] Yes
+- [ ] No
+- [ ] I don't know
+
+### B. Identify how the board was flashed
+
+**1. Is this problem related to updating heads or flashing it for the first time?**
+- [ ] First-time flash
+- [ ] Updating heads 
+
+**2. If the problem is related to an update, how did you attempt to apply the update?**
+- [ ] Using the Heads GUI
+- [ ] Flashrom via the Recovery Shell
+- [ ] External flashing
+
+**3. How was Heads initially flashed**
+- [ ] External flashing
+- [ ] Internal-only / 1vyrain
+- [ ] Don't know
+
+**4. Was the board flashed with a maximized or non-maximized/legacy rom?**
+- [ ] Maximized
+- [ ] Non-maximized / legacy
+- [ ] I don't know
+
+**5. If Heads was externally flashed, was IFD unlocked?**
+- [ ] Yes
+- [ ] No
+- [ ] Don't know
+
+### C. Identify the rom related to this bug report
+
+**1. Did you download or build the rom at issue in this bug report?**
+- [ ] I downloaded it
+- [ ] I built it
+
+**2. If you downloaded your rom, where did you get it from?**
+- [ ] Heads CircleCi
+- [ ] Purism
+- [ ] Nitrokey
+- [ ] Somewhere else (please identify)
+
+*Please provide the release number or otherwise identify the rom downloaded*
+
+**3. If you built your rom, which repository:branch did you use?**
+- [ ] Heads:Master
+- [ ] Other (please identify)
+
+**4. What version of coreboot did you use in building?**
+- [ ] 4.8.1 (current default in heads:master)
+- [ ] 4.13
+- [ ] 4.14
+- [ ] 4.15
+- [ ] Other (please specify)
+- [ ] I don't know
+
+**5. In building the rom where did you get the blobs?**
+- [ ] No blobs required
+- [ ] Provided by the company that installed Heads on the device
+- [ ] Extracted from a backup rom taken from this device
+- [ ] Extracted from another backup rom taken from another device (please identify the board model)
+- [ ] Extracted from the online bios using the automated tools provided in Heads
+- [ ] I don't know
+
+## Please describe the problem
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report-for-heads-build-errors.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-for-heads-build-errors.md
@@ -16,10 +16,10 @@ assignees: ''
 - [ ] Other (please specify)
 
 **3. What version of coreboot are you trying to build**
-- [ ] 4.8.1 (current heads:master default)
 - [ ] 4.13
 - [ ] 4.14
 - [ ] 4.15
+- [ ] 4.17
 - [ ] Other (please specify)
 
 **4. In building the rom where did you get the blobs?**

--- a/.github/ISSUE_TEMPLATE/bug-report-for-heads-build-errors.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-for-heads-build-errors.md
@@ -1,0 +1,60 @@
+---
+name: Bug report for Heads build errors
+about: Please use this template to identify any bugs in the build process for Heads
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Context of the Build
+
+**1. What board are you trying to build?**
+
+**2. What repository:branch are you using to build from?**
+- [ ] Heads:Master
+- [ ] Other (please specify)
+
+**3. What version of coreboot are you trying to build**
+- [ ] 4.8.1 (current heads:master default)
+- [ ] 4.13
+- [ ] 4.14
+- [ ] 4.15
+- [ ] Other (please specify)
+
+**4. In building the rom where did you get the blobs?**
+- [ ] No blobs required
+- [ ] Provided by the company that installed Heads on the device
+- [ ] Extracted from a backup rom taken from this device
+- [ ] Extracted from another backup rom taken from another device (please identify the board model)
+- [ ] Extracted from the online bios using the automated tools provided in Heads
+- [ ] I don't know
+
+**5. If using the automated tools to get the blobs did you run the relevant scripts in the blobs directory**
+- [ ] Yes
+- [ ] No
+
+**6. What operating system are you using**
+
+*please specify*
+
+## Please describe the problem
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Please use this template to suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This is a cleaned-up PR with issue templates (see #1069).  The reasoning behind #1069 was as follows:

In its current form, Heads has so many variables it appears very difficult to determine the cause of issues being raised. There is a risk in development being stalled or taken off track by a rise of very specific bugs reported that are not readily reproducible or only appears in a very specific set of circumstances. In addition, its increasingly difficult to identify separate feature requests from bug reports.

These three templates provide templates for: (a) feature requests; (b) bug reports related to build errors for Heads; and (c) bug reports that come from the flashing or operation of Heads. They are designed to better help the identification of the best people to respond to any given issue, as well as to help triage issues.