### PR TITLE
Apply background colors when fbwhiptail binary is present

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -44,10 +44,10 @@ hwclock -l -s
 . /etc/config
 
 #Specify whiptail background colors cues under FBWhiptail only
-if [ "$CONFIG_FBWHIPTAIL" = "y" ]; then
+if [ -x /bin/fbwhiptail ]; then
 	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-"--background-gradient 0 0 0 150 125 0"}"
 	export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-"--background-gradient 0 0 0 150 0 0"}"
-elif [ "$CONFIG_NEWT" = "y" ];then
+else
 	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-""}"
 	export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-""}"
 fi


### PR DESCRIPTION
Background colors were broken since $CONFIG_FBWHIPTAIL and $CONFIG_NEWT are defined under board configs as variables, but are not exported.

Variables cannot be checked under Heads if they do not have explicit exports under board configuration.

Instead of exporting those from all current and next platforms, the current fix just checks the presence of fbwhiptail binary to set the background colors correctly.

Tested under:
- x230-hotp-maximized (fbwhiptail)
- x230-hotp-verification (newt, whiptail console without fb)

@MrChromebox please approve.