### PR TITLE
patches/coreboot-4.15: Add Librem 4.15 patches

### DIFF
--- a/patches/coreboot-4.15/0001-soc-skylake-me.c-Print-status-regardless-of-device-e.patch
+++ b/patches/coreboot-4.15/0001-soc-skylake-me.c-Print-status-regardless-of-device-e.patch
@@ -1,0 +1,36 @@
+From cf41f0aa19329802676feed24df1ba9697d065a1 Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Mon, 18 May 2020 14:02:27 -0500
+Subject: [PATCH 1/9] soc/skylake/me.c: Print status regardless of device
+ enable state
+
+Checking the CSE device status before printing means it will skip
+printing for devices with the ME disabled, leaving the user no easy
+way to verify the ME is properly disabled. Remove the check.
+
+Test: build/boot Librem 13v4, verify ME status printed as expected
+on device with disabled/neutered ME.
+
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+Change-Id: Iaa4f4a369d878a52136c3479027443ea4e731a36
+---
+ src/soc/intel/skylake/me.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/soc/intel/skylake/me.c b/src/soc/intel/skylake/me.c
+index 89491f89c3..08aceb3f83 100644
+--- a/src/soc/intel/skylake/me.c
++++ b/src/soc/intel/skylake/me.c
+@@ -188,9 +188,6 @@ void intel_me_status(void)
+ 	union me_hfsts3 hfs3;
+ 	union me_hfsts6 hfs6;
+ 
+-	if (!is_cse_enabled())
+-		return;
+-
+ 	hfs1.data = me_read_config32(PCI_ME_HFSTS1);
+ 	hfs2.data = me_read_config32(PCI_ME_HFSTS2);
+ 	hfs3.data = me_read_config32(PCI_ME_HFSTS3);
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0002-soc-cannonlake-me.c-Print-status-regardless-of-devic.patch
+++ b/patches/coreboot-4.15/0002-soc-cannonlake-me.c-Print-status-regardless-of-devic.patch
@@ -1,0 +1,36 @@
+From d7775b8a5a018930eece1ce9e50cb00863845d2e Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Fri, 19 Jun 2020 17:02:22 -0500
+Subject: [PATCH 2/9] soc/cannonlake/me.c: Print status regardless of device
+ enable state
+
+Checking the CSE device status before printing means it will skip
+printing for devices with the ME disabled, leaving the user no easy
+way to verify the ME is properly disabled. Remove the check.
+
+Test: build/boot Librem Mini, verify ME status printed as expected
+on device with disabled/neutered ME.
+
+Change-Id: I939333199aa699039fec727beb094e4eb2ad7149
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+---
+ src/soc/intel/cannonlake/me.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/soc/intel/cannonlake/me.c b/src/soc/intel/cannonlake/me.c
+index 7bbe1ae730..4fe5a96ade 100644
+--- a/src/soc/intel/cannonlake/me.c
++++ b/src/soc/intel/cannonlake/me.c
+@@ -103,9 +103,6 @@ void dump_me_status(void *unused)
+ 	union me_hfsts5 hfsts5;
+ 	union me_hfsts6 hfsts6;
+ 
+-	if (!is_cse_enabled())
+-		return;
+-
+ 	hfsts1.data = me_read_config32(PCI_ME_HFSTS1);
+ 	hfsts2.data = me_read_config32(PCI_ME_HFSTS2);
+ 	hfsts3.data = me_read_config32(PCI_ME_HFSTS3);
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0003-soc-intel-cannonlake-Add-PcieRpHotPlug-config-to-FSP.patch
+++ b/patches/coreboot-4.15/0003-soc-intel-cannonlake-Add-PcieRpHotPlug-config-to-FSP.patch
@@ -1,0 +1,47 @@
+From cda3f1eb067e07e4a7110ef482912273d690be9e Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Tue, 25 Jan 2022 12:16:44 -0600
+Subject: [PATCH 5/9] soc/intel/cannonlake: Add PcieRpHotPlug config to FSP-M
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit b67c5ed [3rdparty/fsp: Update submodule pointer to newest master]
+updated the FSP binaries/headers for Comet Lake, which included a change
+moving PcieRpHotPlug from FSP-S to FSP-M. Unfortunately the existing
+UDP in FSP-S was left in and deprecated, which allowed the change to go
+unnoticed until it was discovered that hotplug wasn't working.
+
+Since other related platforms (WHL, CFL) share the SoC code but use
+different FSP packages, add the setting of the PcieRpHotPlug UPD to
+romstage/FSP-M and guard it with '#if CONFIG(SOC_INTEL_COMETLAKE)'.
+
+Test: build/boot Purism Librem 14, verify WiFi killswitch operates
+as expected / WiFi is re-enabled when turning switch to on position.
+
+Change-Id: I4e1c2ea909933ab21921e63ddeb31cefe1ceef13
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+Reviewed-on: https://review.coreboot.org/c/coreboot/+/61377
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+Reviewed-by: Michael Niewöhner <foss@mniewoehner.de>
+Reviewed-by: Paul Menzel <paulepanter@mailbox.org>
+Reviewed-by: Nico Huber <nico.h@gmx.de>
+---
+ src/soc/intel/cannonlake/romstage/fsp_params.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/soc/intel/cannonlake/romstage/fsp_params.c b/src/soc/intel/cannonlake/romstage/fsp_params.c
+index 8cb6c92a65..0b63bd52f9 100644
+--- a/src/soc/intel/cannonlake/romstage/fsp_params.c
++++ b/src/soc/intel/cannonlake/romstage/fsp_params.c
+@@ -59,6 +59,7 @@ void platform_fsp_memory_init_params_cb(FSPM_UPD *mupd, uint32_t version)
+ 	m_cfg->EnableC6Dram = config->enable_c6dram;
+ #if CONFIG(SOC_INTEL_COMETLAKE)
+ 	m_cfg->SerialIoUartDebugControllerNumber = CONFIG_UART_FOR_CONSOLE;
++	memcpy(tconfig->PcieRpHotPlug, config->PcieRpHotPlug, sizeof(tconfig->PcieRpHotPlug));
+ #else
+ 	m_cfg->PcdSerialIoUartNumber = CONFIG_UART_FOR_CONSOLE;
+ #endif
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0004-soc-intel-skylake-move-heci_init-from-bootblock-to-r.patch
+++ b/patches/coreboot-4.15/0004-soc-intel-skylake-move-heci_init-from-bootblock-to-r.patch
@@ -1,0 +1,66 @@
+From 6d4b0be203b99e66043991796e1fdbbba26ba3ce Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Tue, 25 Jan 2022 12:41:49 -0600
+Subject: [PATCH 6/9] soc/intel/skylake: move heci_init() from bootblock to
+ romstage
+
+Aligns with all other soc/intel/common platforms calling heci_init().
+
+Test: build/boot Purism Librem 13v2
+
+Change-Id: I43029426c5683077c111b3382cf4c8773b3e5b20
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+Reviewed-on: https://review.coreboot.org/c/coreboot/+/61378
+Reviewed-by: Subrata Banik <subratabanik@google.com>
+Reviewed-by: Angel Pons <th3fanbus@gmail.com>
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+---
+ src/soc/intel/skylake/bootblock/pch.c     | 4 ----
+ src/soc/intel/skylake/romstage/romstage.c | 3 +++
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/soc/intel/skylake/bootblock/pch.c b/src/soc/intel/skylake/bootblock/pch.c
+index 1685e43e0e..ec60cabbea 100644
+--- a/src/soc/intel/skylake/bootblock/pch.c
++++ b/src/soc/intel/skylake/bootblock/pch.c
+@@ -2,7 +2,6 @@
+ #include <device/pci_ops.h>
+ #include <device/device.h>
+ #include <device/pci_def.h>
+-#include <intelblocks/cse.h>
+ #include <intelblocks/dmi.h>
+ #include <intelblocks/fast_spi.h>
+ #include <intelblocks/gspi.h>
+@@ -141,8 +140,5 @@ void bootblock_pch_init(void)
+ 
+ 	enable_rtc_upper_bank();
+ 
+-	/* initialize Heci interface */
+-	heci_init(HECI1_BASE_ADDRESS);
+-
+ 	gspi_early_bar_init();
+ }
+diff --git a/src/soc/intel/skylake/romstage/romstage.c b/src/soc/intel/skylake/romstage/romstage.c
+index 30f65eae01..7e891b19f8 100644
+--- a/src/soc/intel/skylake/romstage/romstage.c
++++ b/src/soc/intel/skylake/romstage/romstage.c
+@@ -4,6 +4,7 @@
+ #include <cbmem.h>
+ #include <console/console.h>
+ #include <fsp/util.h>
++#include <intelblocks/cse.h>
+ #include <intelblocks/pmclib.h>
+ #include <intelblocks/smbus.h>
+ #include <memory_info.h>
+@@ -127,6 +128,8 @@ void mainboard_romstage_entry(void)
+ 	systemagent_early_init();
+ 	/* Program SMBus base address and enable it */
+ 	smbus_common_init();
++	/* initialize Heci interface */
++	heci_init(HECI1_BASE_ADDRESS);
+ 	ps = pmc_get_power_state();
+ 	s3wake = pmc_fill_power_state(ps) == ACPI_S3;
+ 	fsp_memory_init(s3wake);
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0005-soc-intel-common-cse-Drop-CSE-library-usage-in-bootb.patch
+++ b/patches/coreboot-4.15/0005-soc-intel-common-cse-Drop-CSE-library-usage-in-bootb.patch
@@ -1,0 +1,36 @@
+From 237477540b03e3066ce0ffe51310a06f91e89252 Mon Sep 17 00:00:00 2001
+From: Subrata Banik <subratabanik@google.com>
+Date: Wed, 26 Jan 2022 01:42:18 +0530
+Subject: [PATCH 7/9] soc/intel/common/cse: Drop CSE library usage in bootblock
+
+This patch drops the CSE common code block from getting compiled
+in bootblock without any SoC code using heci communication so
+early in the boot flow.
+
+BUG=none
+TEST=Able to build brya, purism/librem_skl without any compilation issue.
+
+Signed-off-by: Subrata Banik <subratabanik@google.com>
+Change-Id: Ib4d221c6f19b60aeaf64696e64d0c4209dbf14e7
+Reviewed-on: https://review.coreboot.org/c/coreboot/+/61382
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+Reviewed-by: Tim Wawrzynczak <twawrzynczak@chromium.org>
+Reviewed-by: EricR Lai <ericr_lai@compal.corp-partner.google.com>
+Reviewed-by: Angel Pons <th3fanbus@gmail.com>
+Reviewed-by: Matt DeVillier <matt.devillier@gmail.com>
+---
+ src/soc/intel/common/block/cse/Makefile.inc | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/soc/intel/common/block/cse/Makefile.inc b/src/soc/intel/common/block/cse/Makefile.inc
+index eac7d90424..339ede11b8 100644
+--- a/src/soc/intel/common/block/cse/Makefile.inc
++++ b/src/soc/intel/common/block/cse/Makefile.inc
+@@ -1,4 +1,3 @@
+-bootblock-$(CONFIG_SOC_INTEL_COMMON_BLOCK_CSE) += cse.c
+ romstage-$(CONFIG_SOC_INTEL_COMMON_BLOCK_CSE) += cse.c
+ ramstage-$(CONFIG_SOC_INTEL_COMMON_BLOCK_CSE) += cse.c
+ romstage-$(CONFIG_SOC_INTEL_CSE_LITE_SKU) += cse_lite.c
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0006-soc-intel-common-cse-skip-heci_init-if-HECI1-is-disa.patch
+++ b/patches/coreboot-4.15/0006-soc-intel-common-cse-skip-heci_init-if-HECI1-is-disa.patch
@@ -1,0 +1,38 @@
+From 8d416eec8ba1d929b7afd4718161ae0c1c4e24e3 Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Tue, 25 Jan 2022 19:48:38 -0600
+Subject: [PATCH 8/9] soc/intel/common/cse: skip heci_init() if HECI1 is
+ disabled
+
+If the HECI1 PCI device is disabled, either via devicetree or other
+method (HAP, me_cleaner), then we don't want/need to program a BAR,
+set the PCI config, or call heci_reset(), as the latter will result
+in a 15s timeout delay when booting.
+
+Test: build/boot Purism Librem 13v2, verify heci_reset()
+timeout delay is no longer present.
+
+Change-Id: I0babe417173d10e37327538dc9e7aae980225367
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+---
+ src/soc/intel/common/block/cse/cse.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/soc/intel/common/block/cse/cse.c b/src/soc/intel/common/block/cse/cse.c
+index f37ff9589e..eb4597b82d 100644
+--- a/src/soc/intel/common/block/cse/cse.c
++++ b/src/soc/intel/common/block/cse/cse.c
+@@ -91,6 +91,10 @@ void heci_init(uintptr_t tempbar)
+ 
+ 	u16 pcireg;
+ 
++	/* Check if device enabled */
++	if (!is_cse_enabled())
++		return;
++
+ 	/* Assume it is already initialized, nothing else to do */
+ 	if (get_cse_bar(dev))
+ 		return;
+-- 
+2.30.2
+

--- a/patches/coreboot-4.15/0007-mb-purism-librem_skl-disable-HECI-PCI-device.patch
+++ b/patches/coreboot-4.15/0007-mb-purism-librem_skl-disable-HECI-PCI-device.patch
@@ -1,0 +1,34 @@
+From 7e8b5f1b32f2d7b12ed3df191d3f4b1f1254489c Mon Sep 17 00:00:00 2001
+From: Matt DeVillier <matt.devillier@puri.sm>
+Date: Tue, 25 Jan 2022 19:52:44 -0600
+Subject: [PATCH 9/9] mb/purism/librem_skl: disable HECI PCI device
+
+As all librem_skl devices ship with the ME disabled via HAP bit and ME
+firmware "neutralized" via me_cleaner, the HECI1 PCI device should be
+marked off/disabled to ensure that heci_reset() is not called at the end
+of heci_init(), as this causes a 15s timeout delay when booting
+(introduced in commit cb2fd20 [soc/intel/common: Add HECI Reset flow in
+the CSE driver]).
+
+Change-Id: Ib6bfcfd97e32bb9cf5be33535d77eea8227a8f9f
+Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>
+---
+ src/mainboard/purism/librem_skl/devicetree.cb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mainboard/purism/librem_skl/devicetree.cb b/src/mainboard/purism/librem_skl/devicetree.cb
+index 5efb1e2aed..68fa343b3c 100644
+--- a/src/mainboard/purism/librem_skl/devicetree.cb
++++ b/src/mainboard/purism/librem_skl/devicetree.cb
+@@ -162,7 +162,7 @@ chip soc/intel/skylake
+ 		device pci 14.1 on  end # USB xDCI (OTG)
+ 		device pci 14.2 on  end # Thermal Subsystem
+ 		device pci 14.3 off end # Camera
+-		device pci 16.0 on  end # Management Engine Interface 1
++		device pci 16.0 off  end # Management Engine Interface 1
+ 		device pci 16.1 off end # Management Engine Interface 2
+ 		device pci 16.2 off end # Management Engine IDE-R
+ 		device pci 16.3 off end # Management Engine KT Redirection
+-- 
+2.30.2
+


### PR DESCRIPTION
Add patches to coreboot 4.15 to:
- show ME status even when device is disabled
- fix PCIe RP hotplug on Librem 14
- fix ME reset timeout on Librem 13/15

This synchronizes with Purism's coreboot 4.15-Purism-3 tag.

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>