### PR TITLE
modules/coreboot: pass EXTRA_FLAGS correctly to non coreboot 4.15 coreboot builds

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -43,7 +43,7 @@ CONFIG_COREBOOT_CONFIG ?= config/coreboot-$(BOARD).config
 # Ensure that touching the config file will force a rebuild
 $(build)/$(coreboot_dir)/.configured: $(CONFIG_COREBOOT_CONFIG)
 
-EXTRA_FLAGS :? -fdebug-prefix-map=$(pwd)=heads -gno-record-gcc-switches -Wno-error=packed-not-aligned
+EXTRA_FLAGS ?= -fdebug-prefix-map=$(pwd)=heads -gno-record-gcc-switches -Wno-error=packed-not-aligned
 
 coreboot_configure := \
 	mkdir -p "$(build)/$(coreboot_dir)" \


### PR DESCRIPTION
`:?` is invalid. `?=` defines if not previously defined (was not passed to 4.11 nor 4.13 coreboot builds)