### PR TITLE
boards/* : Add/uniformize missing CONFIG_BOARD_NAME for coreboot boards

### DIFF
--- a/boards/kgpe-d16_server-whiptail/kgpe-d16_server-whiptail.config
+++ b/boards/kgpe-d16_server-whiptail/kgpe-d16_server-whiptail.config
@@ -67,12 +67,11 @@ export CONFIG_BOOT_KERNEL_ADD="nohz=on console=ttyS1,115200n8 "
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_STATIC_IP=192.168.2.3
 
-
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_DEV="/dev/sda1"
+export CONFIG_BOARD_NAME="KGPE-D16 Server-whiptail"
 export CONFIG_USB_BOOT_DEV="/dev/sdb1"
-
 export CONFIG_FLASHROM_OPTIONS="--force --noverify -p internal"
 #export CONFIG_BOOT_STATIC_IP=192.168.1.2

--- a/boards/kgpe-d16_server/kgpe-d16_server.config
+++ b/boards/kgpe-d16_server/kgpe-d16_server.config
@@ -57,6 +57,7 @@ export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_DEV="/dev/sda1"
+export CONFIG_BOARD_NAME="KGPE-D16 Server"
 export CONFIG_USB_BOOT_DEV="/dev/sdb1"
 
 export CONFIG_FLASHROM_OPTIONS="--force --noverify -p internal"

--- a/boards/kgpe-d16_workstation-usb_keyboard/kgpe-d16_workstation-usb_keyboard.config
+++ b/boards/kgpe-d16_workstation-usb_keyboard/kgpe-d16_workstation-usb_keyboard.config
@@ -66,5 +66,6 @@ export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 #export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_DEV="/dev/sda1"
+export CONFIG_BOARD_NAME="KGPE-D16 Workstation-USB-Keyboard"
 export CONFIG_USB_BOOT_DEV="/dev/sdb1"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify -p internal"

--- a/boards/kgpe-d16_workstation/kgpe-d16_workstation.config
+++ b/boards/kgpe-d16_workstation/kgpe-d16_workstation.config
@@ -67,5 +67,6 @@ export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 #export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_DEV="/dev/sda1"
+export CONFIG_BOARD_NAME="KGPE-D16 Workstation"
 export CONFIG_USB_BOOT_DEV="/dev/sdb1"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify -p internal"

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -60,7 +60,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet"
 export CONFIG_BOOT_DEV="/dev/sda1"
-export CONFIG_BOARD_NAME="ThinkPad T420-maximized"
+export CONFIG_BOARD_NAME="ThinkPad T420-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin

--- a/boards/t430-flash/t430-flash.config
+++ b/boards/t430-flash/t430-flash.config
@@ -19,6 +19,7 @@ CONFIG_LINUX_USB=y
 CONFIG_LINUX_E1000E=y
 
 export CONFIG_BOOTSCRIPT=/bin/t430-flash.init
+export CONFIG_BOARD_NAME="ThinkPad T430-flash"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
 # This board is "special" in that we only want the top 4 MB of the ROM

--- a/boards/t430-hotp-verification/t430-hotp-verification.config
+++ b/boards/t430-hotp-verification/t430-hotp-verification.config
@@ -61,7 +61,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet"
 export CONFIG_BOOT_DEV="/dev/sda1"
-export CONFIG_BOARD_NAME="Thinkpad T430"
+export CONFIG_BOARD_NAME="Thinkpad T430-hotp"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
 # This board has two SPI flash chips, an 8 MB that holds the IFD,

--- a/boards/t520-hotp-maximized/t520-hotp-maximized.config
+++ b/boards/t520-hotp-maximized/t520-hotp-maximized.config
@@ -56,7 +56,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet"
 export CONFIG_BOOT_DEV="/dev/sda1"
-export CONFIG_BOARD_NAME="ThinkPad T520-maximized"
+export CONFIG_BOARD_NAME="ThinkPad T520-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -60,7 +60,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet"
 export CONFIG_BOOT_DEV="/dev/sda1"
-export CONFIG_BOARD_NAME="ThinkPad X220-maximized"
+export CONFIG_BOARD_NAME="ThinkPad X220-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin

--- a/boards/x230-flash/x230-flash.config
+++ b/boards/x230-flash/x230-flash.config
@@ -18,6 +18,7 @@ CONFIG_LINUX_USB=y
 CONFIG_LINUX_E1000E=y
 
 export CONFIG_BOOTSCRIPT=/bin/x230-flash.init
+export CONFIG_BOARD_NAME="ThinkPad X230-flash"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
 # This board is "special" in that we only want the top 4 MB of the ROM

--- a/boards/x230-hotp-verification/x230-hotp-verification.config
+++ b/boards/x230-hotp-verification/x230-hotp-verification.config
@@ -61,7 +61,7 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet"
 export CONFIG_BOOT_DEV="/dev/sda1"
-export CONFIG_BOARD_NAME="Thinkpad X230"
+export CONFIG_BOARD_NAME="Thinkpad X230-hotp"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
 # This board has two SPI flash chips, an 8 MB that holds the IFD,


### PR DESCRIPTION
fixes #1096 where some boards had wrong CONFIG_BOARD_NAME or it was missing.
