### PR TITLE
modules/coreboot: don't build IASL separate from toolchain

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -84,9 +84,7 @@ COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
 $(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
 	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$(CPUS) crossgcc-i386
 
-$(build)/$(coreboot_dir)/.configured: $(COREBOOT_IASL) $(COREBOOT_TOOLCHAIN)
-$(COREBOOT_IASL): $(build)/$(coreboot_base_dir)/.canary
-	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$(CPUS) iasl
+$(build)/$(coreboot_dir)/.configured: $(COREBOOT_TOOLCHAIN)
 
 # Force a rebuild if the inputs have changed
 $(build)/$(coreboot_dir)/.build: \


### PR DESCRIPTION
Older coreboot versions (pre-4.11) required IASL to be built separate
from the main toolchain (crossgcc), but that is no longer the case,
and doing so causes random failures from trying to build IASL as
part of the toolchain and separately, in parallel, each using
-j$(CPUS) threads.

Test: build any board using coreboot 4.15 under Debian 11, observe
no random failures from building the toolchain due to false positives
for a missing depencency .

Signed-off-by: Matt DeVillier <matt.devillier@puri.sm>