### PR TITLE
xx30 vbios extraction scripts fix for Ubuntu 21.04

### DIFF
--- a/blobs/xx30/vbios_t530.sh
+++ b/blobs/xx30/vbios_t530.sh
@@ -17,7 +17,8 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Installing basic dependencies"
-sudo apt update && sudo apt install -y wget ruby ruby-dev ruby-bundler p7zip-full upx-ucl 
+sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p7zip-full upx-ucl 
+sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
 wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip

--- a/blobs/xx30/vbios_w530.sh
+++ b/blobs/xx30/vbios_w530.sh
@@ -18,7 +18,8 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Installing basic dependencies"
-sudo apt update && sudo apt install -y wget ruby ruby-dev ruby-bundler p7zip-full upx-ucl 
+sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p7zip-full upx-ucl 
+sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
 wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip


### PR DESCRIPTION
-add apt bundler requirement, and gem install bundler:1.17.3 per vbios extraction error:

```
Traceback (most recent call last):
	2: from /usr/bin/bundle:23:in `<main>'
	1: from /usr/lib/ruby/vendor_ruby/rubygems.rb:300:in `activate_bin_path'
/usr/lib/ruby/vendor_ruby/rubygems.rb:281:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /tmp/tmp.kSHWa8Rn6g/rom-parser-94a615302f89b94e70446270197e0f5138d678f3/VBiosFinder-c2d764975115de466fdb4963d7773b5bc8468a06/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3
```
----------

-TODO: Extraction scripts are not doing any error validation and continues even if failing at this point:
```
Verifying expected hash of extracted roms
./blobs/xx30/vbios_t530.sh: line 63: cd: output: No such file or directory
sha256sum: vbios_10de_0def_1.rom: No such file or directory
vbios_10de_0def_1.rom: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
dGPU rom failed sha256sum verification...
```


@eganonoa This requires proper error management scripts similar to:  `SuccessfulCommand || { echo "failed blahblah"; exit 1; }`
cross-linked to issue #1085 for additional documentation


-----------------------
Source of testing and error logs: https://app.circleci.com/pipelines/github/tlaurion/heads/942/workflows/08c9044f-2f78-40cc-b6b0-b7202a7e7790/jobs/3563/parallel-runs/0/steps/0$
(Does not affect current Debian 10 tested through CircleCI docker, but affects Ubuntu 21.04 and probably other OSes.)