### PR TITLE
make coreboot 4.11 platforms buildable under recent OSea (CircleCI builds on debian-11 here)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
           command: |
             ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg gawk iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo
       - run:
           name: Make Board
           command: |
@@ -37,7 +37,7 @@ commands:
 jobs:
   prep_env:
     docker:
-      - image: debian:10
+      - image: debian:11
     resource_class: large
     steps:
       - run:
@@ -45,7 +45,7 @@ jobs:
           command: |
             ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime 
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg gawk iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo
       - checkout
 
       - run:
@@ -112,7 +112,7 @@ jobs:
 
   build_and_persist:
     docker:
-      - image: debian:10
+      - image: debian:11
     resource_class: large
     parameters:
       target:
@@ -132,7 +132,7 @@ jobs:
 
   build:
     docker:
-      - image: debian:10
+      - image: debian:11
     resource_class: large
     parameters:
       target:
@@ -148,7 +148,7 @@ jobs:
 
   save_cache:
     docker:
-      - image: debian:10
+      - image: debian:11
     resource_class: large
     steps:
       - attach_workspace:
@@ -192,9 +192,9 @@ workflows:
 
       # Prerequisites
       - build_and_persist:
-          name: heads_musl-cross
+          name: bootstrap_musl-cross-make
           target: x230-hotp-maximized
-          subcommand: musl-cross
+          subcommand: bootstrap musl-cross
           requires:
             - prep_env
 
@@ -204,7 +204,7 @@ workflows:
           target: x230-hotp-maximized
           subcommand: ""
           requires:
-            - heads_musl-cross
+            - bootstrap_musl-cross-make
 
       # Coreboot 4.15
       - build_and_persist:

--- a/blobs/xx30/vbios_t530.sh
+++ b/blobs/xx30/vbios_t530.sh
@@ -17,7 +17,8 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Installing basic dependencies"
-sudo apt update && sudo apt install -y wget ruby ruby-dev ruby-bundler p7zip-full upx-ucl 
+sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p7zip-full upx-ucl 
+sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
 wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip

--- a/blobs/xx30/vbios_w530.sh
+++ b/blobs/xx30/vbios_w530.sh
@@ -18,7 +18,8 @@ extractdir=$(mktemp -d)
 cd "$extractdir"
 
 echo "### Installing basic dependencies"
-sudo apt update && sudo apt install -y wget ruby ruby-dev ruby-bundler p7zip-full upx-ucl 
+sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p7zip-full upx-ucl 
+sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
 wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip

--- a/patches/coreboot-4.11/0073-build-race-condition-fixes.patch
+++ b/patches/coreboot-4.11/0073-build-race-condition-fixes.patch
@@ -1,0 +1,30 @@
+src/arch/x86: Ensure $(objgenerated) exists before it's used
+
+In some rare cases it seems that make tries to build
+$(objgenerated)/assembly.inc before the build-dirs target has finished,
+and so assembly.inc can't be written. Enforce that build-dirs is done
+before assembly.inc starts.
+
+BUG=chromium:1098215
+BRANCH=none
+TEST=none
+
+Change-Id: Ib141ea45a43836cfdde0059523c331fe5286b06d
+Signed-off-by: Patrick Georgi <pgeorgi@google.com>
+Reviewed-on: https://review.coreboot.org/c/coreboot/+/42883
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+Reviewed-by: Aaron Durbin <adurbin@chromium.org>
+
+diff --git a/src/arch/x86/Makefile.inc b/src/arch/x86/Makefile.inc
+index 6297384..1a1aa40 100644
+--- a/src/arch/x86/Makefile.inc
++++ b/src/arch/x86/Makefile.inc
+
+@@ -50,7 +50,7 @@
+ # into a single generated file.
+ crt0s = $(cpu_incs-y)
+ 
+-$(objgenerated)/assembly.inc: $$(crt0s)
++$(objgenerated)/assembly.inc: build-dirs $$(crt0s)
+ 	@printf "    GEN        $(subst $(obj)/,,$(@))\n"
+ 	printf '$(foreach crt0,$(crt0s),#include "$(crt0)"\n)' > $@


### PR DESCRIPTION
~This is WIP.~

In an attempt to investigate why car.data is not build under coreboot 4.11 builds under debian-11, I've decided to check what is going on in Heads' build system, which at the end of the day is supposed to do the right thing until we have something better to use.


To have reproducible builds, we are supposed to have fixed versions of some tools, prior of building anything in the hope of producing reproducible output:
- known make version being same as defined in module definition
- known gawk version being same as defined in module definition
- musl-cross-make toolchain as defined per musl-cross module definition to build all modules **_but coreboot_**
- coreboot version specific build toolchain so coreboot parts are reproducible.
- At that point, we should have reproducible coreboot, reproducible kernel, reproducible initrd containing all Heads related built modules (tools.cpio, heads.cpio being bundled) which should be hopefully all being reproducible again.
- Have a reproducible ROM for a specific commit ID, if and only the precedent are all true.

If initrd is not reproducible, then check individual modules output under hashes.txt. Check logs for configure output of faulty module. Diffscope. Patch. Redo.



I first noticed that local gawk was only built if make was also in wrong local version, and then noticed that most of the make calls to build all modules were actually not using the locally built make version but the host deployed version, from both configure logs and build logs under build/logs/*.


This is an attempt to correct the situation. 

My make fu not being optimal, please review and comment, and/or propose another PR with proper fixes. Also.... Please educate me if i'm doing stupid things when compared to original Makefile (which was obviously also doing stupid things.... as you can see by my attempt of improving it).


The DATE fixation Makefile statement was embedded under make version checking under Makefile as well. This is also fixed per current PR.


Still TODO: We lost rom hash output under hashes.txt. Not sure since when and why, yet. Things got broken when gawk local build was added, or around that time.