### PR TITLE
Improvements on xx30 vbios scripts

### DIFF
--- a/blobs/xx30/vbios_t530.sh
+++ b/blobs/xx30/vbios_t530.sh
@@ -21,7 +21,7 @@ sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p
 sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
-wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip
+wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip || { echo "Failed to download $ROMPARSER" && exit 1; }
 
 echo "### Verifying expected hash of rom-parser"
 echo "$ROM_PARSER_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -32,7 +32,7 @@ cd rom-parser-"$ROMPARSER" && make
 sudo cp rom-parser /usr/sbin/
 
 echo "### Downloading UEFIExtract dependency"
-wget https://github.com/LongSoft/UEFITool/releases/download/A58/"$UEFIEXTRACT"
+wget https://github.com/LongSoft/UEFITool/releases/download/A58/"$UEFIEXTRACT" || { echo "Failed to download $UEFIEXTRACT" && exit 1; }
 
 echo "### Verifying expected hash of UEFIExtract"
 echo "$UEFI_EXTRACT_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -42,7 +42,7 @@ unzip "$UEFIEXTRACT"
 sudo mv UEFIExtract /usr/sbin/
 
 echo "### Downloading VBiosFinder"
-wget https://github.com/coderobe/VBiosFinder/archive/"$VBIOSFINDER".zip
+wget https://github.com/coderobe/VBiosFinder/archive/"$VBIOSFINDER".zip || { echo "Failed to download $VBIOSFINDER" && exit 1; }
 
 echo "### Verifying expected hash of VBiosFinder"
 echo "$VBIOS_FINDER_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -52,13 +52,16 @@ unzip "$VBIOSFINDER".zip
 cd VBiosFinder-"$VBIOSFINDER" && bundle install --path=vendor/bundle
 
 echo "### Downloading latest Lenovo bios update for t530"
-wget https://download.lenovo.com/pccbbs/mobiles/"$BIOSUPDATE"
+wget https://download.lenovo.com/pccbbs/mobiles/"$BIOSUPDATE" || { echo "Failed to download $BIOSUPDATE" && exit 1; }
 
 echo "### Verifying expected hash of bios update"
 echo "$BIOS_UPDATE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
 
+echo "### Extracting bios update"
+innoextract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$BIOSUPDATE" || { echo "Failed to extract $BIOSUPDATE" && exit 1; }
+
 echo "### Finding, extracting and saving vbios"
-./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$BIOSUPDATE"
+sudo ./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"app/G4ETB7WW/\$01D5100.FL1" || { echo "Failed to extract FL1" && exit 1; }
 
 echo "Verifying expected hash of extracted roms"
 cd output
@@ -66,9 +69,9 @@ echo "$DGPU_ROM_SHA256SUM" | sha256sum --check || { echo "dGPU rom failed sha256
 echo "$IGPU_ROM_SHA256SUM" | sha256sum --check || { echo "iGPU rom Failed sha256sum verification..." && exit 1; }
 
 echo "### Moving extracted roms to blobs directory"
-mv vbios_10de_0def_1.rom $BLOBDIR/10de,0def.rom
-mv vbios_8086_0106_1.rom $BLOBDIR/8086,0106.rom
+sudo mv vbios_10de_0def_1.rom $BLOBDIR/10de,0def.rom
+sudo mv vbios_8086_0106_1.rom $BLOBDIR/8086,0106.rom
 
 echo "### Cleaning Up"
 cd "$BLOBDIR"
-rm -rf "$extractdir"
+sudo rm -rf "$extractdir"

--- a/blobs/xx30/vbios_w530.sh
+++ b/blobs/xx30/vbios_w530.sh
@@ -22,7 +22,7 @@ sudo apt update && sudo apt install -y wget ruby ruby-dev bundler ruby-bundler p
 sudo gem install bundler:1.17.3
 
 echo "### Downloading rom-parser dependency"
-wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip
+wget https://github.com/awilliam/rom-parser/archive/"$ROMPARSER".zip || { echo "Failed to download $ROMPARSER" && exit 1; }
 
 echo "### Verifying expected hash of rom-parser"
 echo "$ROM_PARSER_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -33,7 +33,7 @@ cd rom-parser-"$ROMPARSER" && make
 sudo cp rom-parser /usr/sbin/
 
 echo "### Downloading UEFIExtract dependency"
-wget https://github.com/LongSoft/UEFITool/releases/download/A58/"$UEFIEXTRACT"
+wget https://github.com/LongSoft/UEFITool/releases/download/A58/"$UEFIEXTRACT" || { echo "Failed to download $UEFIEXTRACT" && exit 1; }
 
 echo "### Verifying expected hash of UEFIExtract"
 echo "$UEFI_EXTRACT_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -43,7 +43,7 @@ unzip "$UEFIEXTRACT"
 sudo mv UEFIExtract /usr/sbin/
 
 echo "### Downloading VBiosFinder"
-wget https://github.com/coderobe/VBiosFinder/archive/"$VBIOSFINDER".zip
+wget https://github.com/coderobe/VBiosFinder/archive/"$VBIOSFINDER".zip || { echo "Failed to download $VBIOSFINDER" && exit 1; }
 
 echo "### Verifying expected hash of VBiosFinder"
 echo "$VBIOS_FINDER_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
@@ -53,13 +53,16 @@ unzip "$VBIOSFINDER".zip
 cd VBiosFinder-"$VBIOSFINDER" && bundle install --path=vendor/bundle
 
 echo "### Downloading latest Lenovo bios update for w530"
-wget https://download.lenovo.com/pccbbs/mobiles/"$BIOSUPDATE"
+wget https://download.lenovo.com/pccbbs/mobiles/"$BIOSUPDATE" || { echo "Failed to download $BIOSUPDATE" && exit 1; }
 
 echo "### Verifying expected hash of bios update"
 echo "$BIOS_UPDATE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification..." && exit 1; }
 
+echo "### Extracting bios update"
+innoextract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$BIOSUPDATE" || { echo "Failed to extract $BIOSUPDATE" && exit 1; }
+
 echo "### Finding, extracting and saving vbios"
-./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$BIOSUPDATE"
+sudo ./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"app/G5ETB6WW/\$01D5200.FL1" || { echo "Failed to extract FL1" && exit 1; }
 
 echo "Verifying expected hash of extracted roms"
 cd output
@@ -68,10 +71,10 @@ echo "$K1000M_ROM_SHA256SUM" | sha256sum --check || { echo "K1000M rom failed sh
 echo "$IGPU_ROM_SHA256SUM" | sha256sum --check || { echo "iGPU rom Failed sha256sum verification..." && exit 1; }
 
 echo "### Moving extracted roms to blobs directory"
-mv vbios_10de_0ffb_1.rom "$BLOBDIR"/10de,0ffb.rom
-mv vbios_10de_0ffc_1.rom "$BLOBDIR"/10de,0ffc.rom
-mv vbios_8086_0106_1.rom "$BLOBDIR"/8086,0106.rom
+sudo mv vbios_10de_0ffb_1.rom "$BLOBDIR"/10de,0ffb.rom
+sudo mv vbios_10de_0ffc_1.rom "$BLOBDIR"/10de,0ffc.rom
+sudo mv vbios_8086_0106_1.rom "$BLOBDIR"/8086,0106.rom
 
 echo "### Cleaning Up"
 cd "$BLOBDIR"
-rm -rf "$extractdir"
+sudo rm -rf "$extractdir"


### PR DESCRIPTION
- Better error handling (exits earlier)
- Better scoping of UEFIExtract to only deal with FL1 files, which is where vbios files are to be extracted from. 
- Adds sudo calls where required (CircleCI runs at root. Local builds failed, as reported https://github.com/osresearch/heads/issues/1110#issuecomment-1038223970

@eganonoa @MrChromebox : improvements welcome. CircleCI works and extraction is confirmed to build locally as well over debian-11. Consequently, this is considered a bug in original code and should be merged ASAP.

Fixes #1085 