### PR TITLE
CircleCI: readd forgotten x230-maximized board

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,12 @@ workflows:
             - x230-hotp-maximized
 
       - build:
+          name: x230-maximized
+          target: x230-maximized
+          subcommand: ""
+          requires:
+            - x230-hotp-maximized
+      - build:
           name: t530-hotp-maximized
           target: t530-hotp-maximized
           subcommand: ""


### PR DESCRIPTION
Oupsies.

Doesn't need review. Once built successfully, will merge.