### PR TITLE
Pass all modules from O2/O3 (optimized for speed) to Os (optimize for space)

### DIFF
--- a/modules/cairo
+++ b/modules/cairo
@@ -7,8 +7,8 @@ cairo_url := https://www.cairographics.org/releases/$(cairo_tar)
 cairo_hash := 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
 
 cairo_configure := \
+	CFLAGS="-DCAIRO_NO_MUTEX=1 -Os"  \
 	$(CROSS_TOOLS) \
-	CFLAGS="-DCAIRO_NO_MUTEX=1 -O3"  \
 	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix="/" \

--- a/modules/cryptsetup
+++ b/modules/cryptsetup
@@ -10,8 +10,10 @@ cryptsetup_hash := af2b04e8475cf40b8d9ffd97a1acfa73aa787c890430afd89804fb544d6ad
 
 # Use an empty prefix so that the executables will not include the
 # build path.
-cryptsetup_configure := ./configure \
+cryptsetup_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os" \
+	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix "/" \
 	--disable-gcrypt-pbkdf2 \

--- a/modules/cryptsetup2
+++ b/modules/cryptsetup2
@@ -10,8 +10,10 @@ cryptsetup2_hash := 3bca4ffe39e2f94cef50f6ea65acb873a6dbce5db34fc6bcefe38b6d095e
 
 # Use an empty prefix so that the executables will not include the
 # build path.
-cryptsetup2_configure := ./configure \
+cryptsetup2_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os" \
+	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix "/" \
 	--disable-rpath \

--- a/modules/flashtools
+++ b/modules/flashtools
@@ -10,7 +10,7 @@ flashtools_hash := 81b3c1f12318bd2942b426a99638e23d24e85819227653cd3b9302fbfc43b
 
 flashtools_target := \
 	$(CROSS_TOOLS) \
-	CFLAGS="-I$(INSTALL)/include" \
+	CFLAGS="-Os -I$(INSTALL)/include" \
 	LDFLAGS="-L$(INSTALL)/lib" \
 
 flashtools_output := \

--- a/modules/gpg
+++ b/modules/gpg
@@ -17,8 +17,10 @@ gpg_hash := 6b47a3100c857dcab3c60e6152e56a997f2c7862c1b8b2b25adf3884a1ae2276
 # Force a different host/build setting so that it detects a cross compile.
 # Otherwise it wil try to run tests.
 #
-gpg_configure := ./configure \
+gpg_configure := \
+	CFLAGS="-Os"  \
 	$(CROSS_TOOLS) \
+	./configure \
 	--build $(MUSL_ARCH)-elf-linux \
 	--host $(MUSL_ARCH)-linux-musl \
 	--with-libusb="$(INSTALL)" \

--- a/modules/gpg2
+++ b/modules/gpg2
@@ -11,8 +11,10 @@ gpg2_hash := 61e83278fb5fa7336658a8b73ab26f379d41275bb1c7c6e694dd9f9a6e8e76ec
 # be generated with the correct paths, but then re-write them when
 # we use the install target so that they will be copied to the correct
 # location.
-gpg2_configure := ./configure \
+gpg2_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
+	./configure \
 	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--host $(MUSL_ARCH)-linux-musl \
 	--with-libusb="$(INSTALL)" \

--- a/modules/kexec
+++ b/modules/kexec
@@ -6,7 +6,9 @@ kexec_tar := kexec-tools-$(kexec_version).tar.gz
 kexec_url := https://kernel.org/pub/linux/utils/kernel/kexec/$(kexec_tar)
 kexec_hash := 40623d4321be2865ef9ea2cd6ec998d31dcf93d0f74353cbd3aa06d8821e3e41
 
-kexec_configure := ./configure \
+kexec_configure := \
+	CFLAGS="-g -Os -fno-strict-aliasing -Wall -Wstrict-prototypes" \
+	./configure \
 	$(CROSS_TOOLS) \
 	--host $(MUSL_ARCH)-elf-linux \
 	--target $(MUSL_ARCH) \

--- a/modules/libassuan
+++ b/modules/libassuan
@@ -6,8 +6,10 @@ libassuan_tar := libassuan-$(libassuan_version).tar.bz2
 libassuan_url := https://gnupg.org/ftp/gcrypt/libassuan/$(libassuan_tar)
 libassuan_hash := 91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702
 
-libassuan_configure := ./configure \
+libassuan_configure := \
+	CFLAGS="-Os" \
 	$(CROSS_TOOLS) \
+	./configure \
 	--host $(MUSL_ARCH)-linux-musl \
 	--prefix "/" \
 	--disable-static \

--- a/modules/libgcrypt
+++ b/modules/libgcrypt
@@ -6,8 +6,10 @@ libgcrypt_tar := libgcrypt-$(libgcrypt_version).tar.bz2
 libgcrypt_url := https://gnupg.org/ftp/gcrypt/libgcrypt/$(libgcrypt_tar)
 libgcrypt_hash := 0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975
 
-libgcrypt_configure := ./configure \
+libgcrypt_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
+	./configure \
 	--host=$(MUSL_ARCH)-linux-musl \
 	--prefix "/" \
 	--disable-static \

--- a/modules/libgpg-error
+++ b/modules/libgpg-error
@@ -6,8 +6,10 @@ libgpg-error_tar := libgpg-error-$(libgpg-error_version).tar.bz2
 libgpg-error_url := https://gnupg.org/ftp/gcrypt/libgpg-error/$(libgpg-error_tar)
 libgpg-error_hash := b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763
 
-libgpg-error_configure := ./configure \
+libgpg-error_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
+	./configure \
 	--prefix "/" \
 	--host=$(MUSL_ARCH)-linux-musl \
 	--disable-static \

--- a/modules/libksba
+++ b/modules/libksba
@@ -6,8 +6,10 @@ libksba_tar := libksba-$(libksba_version).tar.bz2
 libksba_url := https://gnupg.org/ftp/gcrypt/libksba/$(libksba_tar)
 libksba_hash := bfe6a8e91ff0f54d8a329514db406667000cb207238eded49b599761bfca41b6
 
-libksba_configure := ./configure \
+libksba_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os" \
+	./configure \
 	--host $(MUSL_ARCH)-linux-musl \
 	--prefix "/" \
 	--disable-static \

--- a/modules/libpng
+++ b/modules/libpng
@@ -8,6 +8,7 @@ libpng_hash := 574623a4901a9969080ab4a2df9437026c8a87150dfd5c235e28c94b212964a7
 
 libpng_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os" \
 	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix="/" \

--- a/modules/libusb
+++ b/modules/libusb
@@ -9,7 +9,9 @@ libusb_url := https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb
 libusb_url := https://github.com/libusb/libusb/releases/download/v$(libusb_version)/$(libusb_tar)
 libusb_hash := 7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b
 
-libusb_configure := ./configure\
+libusb_configure := \
+	CFLAGS="-Os" \
+	./configure \
 	$(CROSS_TOOLS)\
 	--host $(MUSL_ARCH)-elf-linux\
 	--prefix "/"\

--- a/modules/libusb-compat
+++ b/modules/libusb-compat
@@ -11,7 +11,9 @@ libusb-compat_tar := libusb-compat-$(libusb-compat_version).tar.bz2
 libusb-compat_url := https://downloads.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-$(libusb-compat_version)/$(libusb-compat_tar)
 libusb-compat_hash := 404ef4b6b324be79ac1bfb3d839eac860fbc929e6acb1ef88793a6ea328bc55a
 
-libusb-compat_configure := ./configure \
+libusb-compat_configure := \
+	CFLAGS="-Os" \
+	./configure \
 	$(CROSS_TOOLS) \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix "/" \

--- a/modules/lvm2
+++ b/modules/lvm2
@@ -10,6 +10,7 @@ lvm2_hash := 23a3d1cddd41b3ef51812ebf83e9fa491f502fe74130d4263be327a91914660d
 # so we force it via the configure cache.
 lvm2_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
 	PKG_CONFIG=/bin/false \
 	MODPROBE_CMD=/bin/false \
 	ac_cv_func_malloc_0_nonnull=yes \

--- a/modules/mbedtls
+++ b/modules/mbedtls
@@ -12,6 +12,7 @@ mbedtls_configure :=
 
 mbedtls_target := \
 	SHARED=1 \
+	CFLAGS="-Os"  \
 	DESTDIR=$(INSTALL) \
 	$(CROSS_TOOLS) \
 	$(MAKE_JOBS) \

--- a/modules/newt
+++ b/modules/newt
@@ -20,7 +20,8 @@ newt_output := \
 newt_libraries := \
 	libnewt.so.0.52 \
 
-newt_configure := ./autogen.sh; ./configure \
+newt_configure := \
+	./autogen.sh && CFLAGS="-Os" ./configure \
 	$(CROSS_TOOLS) \
 	--prefix "/" \
 	--host $(MUSL_ARCH)-elf-linux \

--- a/modules/pinentry
+++ b/modules/pinentry
@@ -13,8 +13,10 @@ pinentry_hash := 68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f5657
 # be generated with the correct paths, but then re-write them when
 # we use the install target so that they will be copied to the correct
 # location.
-pinentry_configure := ./configure \
+pinentry_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os" \
+	./configure \
 	--host $(MUSL_ARCH)-linux-musl \
 	--prefix "/" \
 	--enable-pinentry-tty \

--- a/modules/pixman
+++ b/modules/pixman
@@ -8,6 +8,7 @@ pixman_hash := 21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e
 
 pixman_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
 	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix="/" \

--- a/modules/qrencode
+++ b/modules/qrencode
@@ -8,7 +8,9 @@ qrencode_hash := e794e26a96019013c0e3665cb06b18992668f352c5553d0a553f5d144f7f2a7
 
 qrencode_libraries := .libs/libqrencode.so.3
 
-qrencode_configure := ./configure \
+qrencode_configure := \
+	CFLAGS="-Os" \
+	./configure \
 	$(CROSS_TOOLS) \
 	--prefix "/" \
 	--without-tools \

--- a/modules/tpmtotp
+++ b/modules/tpmtotp
@@ -13,7 +13,7 @@ tpmtotp_hash := 1082f2b0e4af833e04220dddedcc21a39eb39ee4dc5668bb010e7bcc795c606c
 
 tpmtotp_target := \
 	$(CROSS_TOOLS) \
-	CFLAGS="-I$(INSTALL)/include" \
+	CFLAGS="-I$(INSTALL)/include -Os" \
 	LDFLAGS="-L$(INSTALL)/lib" \
 
 tpmtotp_output := \

--- a/modules/util-linux
+++ b/modules/util-linux
@@ -6,8 +6,10 @@ util-linux_tar := util-linux-$(util-linux_version).tar.xz
 util-linux_url := https://www.kernel.org/pub/linux/utils/util-linux/v2.29/$(util-linux_tar)
 util-linux_hash := accea4d678209f97f634f40a93b7e9fcad5915d1f4749f6c47bee6bf110fe8e3
 
-util-linux_configure := ./configure \
+util-linux_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
+	./configure \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix "/" \
 	--oldincludedir "$(INSTALL)/include" \


### PR DESCRIPTION
Adresses @aesrentai suggestion to pass modules optimization from O2 (performance) to Os (space) here: https://github.com/osresearch/heads/issues/590#issuecomment-821788703

Will comment on gains after build succeeds.
~Still impossible as of now to build xx30-flash boards on top of linux 5.10.4......~ EDIT: without kernel networking support, this now passes.