### PR TITLE
Move enable_usb earlier

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -202,7 +202,6 @@ update_hotp()
 {
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
-    enable_usb
     if ! hotp_verification info ; then
       if ! whiptail $BG_COLOR_WARNING --clear \
           --title "WARNING: Please Insert Your $HOTPKEY_BRANDING" \
@@ -251,7 +250,6 @@ clean_boot_check()
 
    # check for USB security token
   if [ "$CONFIG_HOTPKEY" = "y" ]; then
-    enable_usb
     if ! gpg --card-status > /dev/null ; then
       return
     fi
@@ -541,6 +539,10 @@ if [ -r /boot/kexec_hotp_key ]; then
 	HOTPKEY_BRANDING="$(cat /boot/kexec_hotp_key)"
 else
 	HOTPKEY_BRANDING="HOTP USB Security Dongle"
+fi
+
+if [ "$CONFIG_HOTPKEY" = "y" ]; then
+  enable_usb
 fi
 
 if detect_boot_device ; then


### PR DESCRIPTION
It is going to be enabled later anyway (if CONFIG_HOTPKEY=y), so it can
also be simplified by enabling it at the very beginning.

This enables USB keyboard consistently during all boot menus, including
the "No Bootable OS Found" prompt. It isn't a big deal for "normal"
laptop usage, but it is important for automatic tests and also
non-laptop systems.