### PR TITLE
etc/functions: add a confirmation prompt in warn prior of continuing

### DIFF
--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -8,6 +8,7 @@ die() {
 
 warn() {
 	echo >&2 "$*";
+	read -p 'Hit Enter to continue.'
 }
 
 recovery() {


### PR DESCRIPTION
A lot of calls to warn in code are happening in between GUI prompts and are not reaching the user (going to console and show error there on called scripts do not reach user eyes).

@MrChromebox : this may become an annoyance in current codebase, but as of now, we only have `die` and `warn`, where warn is used _supposedly to warn_ user of something that happened, without actually showing output on screen sometimes; the next fbwhiptail output resetting the screen and leaving the user unaware of what wrong happened (where die is radical failing)

An alternative could be to add an `error` prompt beside `die` and `warn` in functions and review code for what should be used in which case. Thoughts?