### PR TITLE
Bugfix: fix accidental removal of --menu statement in kexec-select-boot 

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -137,7 +137,7 @@ confirm_menu_option() {
 		default_text="Make default"
 		[[ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" = "y" ]] && default_text="${default_text} and boot"
 		whiptail $BG_COLOR_WARNING --clear --title "Confirm boot details" \
-			Confirm the boot details for $name:\n\n$(echo $kernel| fold -s -w 80) \n\n" 20 120 8 \
+			--menu "Confirm the boot details for $name:\n\n$(echo $kernel| fold -s -w 80) \n\n" 20 120 8 \
 			-- 'd' "${default_text}" 'y' "Boot one time" \
 			2>/tmp/whiptail || die "Aborting boot attempt"
 


### PR DESCRIPTION
Was introduced at commit ba054b15c3740228ba3e327c3442a9f7594a9fe8 (fold wrapper to show boot options selected)