### PR TITLE
oem-factory-reset: Only set default boot option if no TPM Disk Unlock Key

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -156,6 +156,11 @@ generate_checksums()
         mount -o remount,rw /boot || whiptail_error_die "Unable to mount /boot"
     fi
 
+    #Check if previous TPM Disk unlock Key was set
+    if [ -e /boot/kexec_key_devices.txt ]; then
+        TPM_DISK_ENCRYPTION_KEY_SET=1
+    fi
+
     # clear any existing checksums/signatures
     rm /boot/kexec* 2>/dev/null
 
@@ -181,8 +186,10 @@ generate_checksums()
       echo "0" > /boot/kexec_hotp_counter
     fi 
 
-    # set default boot option
-    set_default_boot_option
+    # set default boot option only if no TPM Disk Unlock Key previously set
+    if [ -z "$TPM_DISK_ENCRYPTION_KEY_SET" ]; then
+        set_default_boot_option
+    fi
 
     # generate hashes
     find /boot -type f ! -name '*kexec*' -print0 \


### PR DESCRIPTION
This continues to generate checksums and detach sign them per cached GPG User PIN in all OEM Factory Reset/Re-Ownership use cases, but does not set a default boot option when kexec_encrypted_disks.txt is present on /boot (flag left on /boot when a TPM Disk Unlock Key was previously setuped.)


The user hitting Default Boot post Re-Ownership will go through the setup of a new boot default, which will ask him to setup a Disk Unlock Key if desired. Without this, hitting Default Boot goes into asking the user for its Disk Recovery Key passphrase and confuses the user, requiring him to manually setup a default boot option (Boot Options-> Show OS boot Options) to setup a TPM Disk Unlock Key.

Tested: OEM Factory Reset. Manual setup of a default boot option with LUKS Disk Unlock Key (Otherwise default boot boots setuped defaut boot option from Grub config asking for Disk Recovery Key passphrase). Re-Ownership. Default boot asks to setup a default boot option.

Implement second option of #1154. 
Fixes #1154 once merged.

@MrChromebox 