### PR TITLE
Add Heads mac address randomization for maximized boards

### DIFF
--- a/initrd/bin/network-init-recovery
+++ b/initrd/bin/network-init-recovery
@@ -1,5 +1,7 @@
 #!/bin/ash
 
+. /etc/functions
+
 # bring up the ethernet; maybe should do DHCP?
 ifconfig lo 127.0.0.1
 
@@ -11,6 +13,16 @@ for module in `echo $network_modules`; do
 done
 
 if [ -e /sys/class/net/eth0 ]; then
+	#Randomize eth0 MAC address of maximized boards
+	if echo "$CONFIG_BOARD" | grep -q maximized; then
+		ifconfig eth0 down
+		echo "Generating random MAC address (might take a while)..."
+		mac=$(generate_random_mac_address)
+		echo "Assigning randomly generated MAC: $mac to eth0..."
+		ifconfig eth0 hw ether $mac
+		ifconfig eth0 up
+	fi
+
 	# Set up static IP
 	if [ ! -z "$CONFIG_BOOT_STATIC_IP" ]; then
 		ifconfig eth0 $CONFIG_BOOT_STATIC_IP

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -374,3 +374,9 @@ print_battery_charge()
                 echo "$battery_charge"
         fi
 }
+
+generate_random_mac_address()
+{
+	#Borrowed from https://stackoverflow.com/questions/42660218/bash-generate-random-mac-address-unicast
+	hexdump -n 6 -ve '1/1 "%.2x "' /dev/urandom | awk -v a="2,6,a,e" -v r="$RANDOM" 'BEGIN{srand(r);}NR==1{split(a,b,",");r=int(rand()*4+1);printf "%s%s:%s:%s:%s:%s:%s\n",substr($1,0,1),b[r],$2,$3,$4,$5,$6}'
+}


### PR DESCRIPTION
This is a local fix where eth0 gets full randomized mac address if board config is a maximized board config when calling network-init script.

network-init script doesn't do anything fancy for the moment, but permits to set RTC clock from NTP source.

So in the present case, it makes sure that if multiple maximized machines are to be connected on LAN, each of them will get a IP from DHCP requests and then be able to sync NTP with the network.

@MrChromebox please review.
