### PR TITLE
bugfix: oem-factory-reset - permit LUKS passphrase change without reencryption

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -385,6 +385,7 @@ echo
 if [ "$prompt_output" == "y" \
   -o "$prompt_output" == "Y" ];then
   test_luks_current_disk_recovery_key_passphrase
+  luks_new_Disk_Recovery_Key_desired=1
   echo -e "\n"
 fi
 
@@ -565,14 +566,14 @@ if [[ "$SKIP_BOOT" == "n" ]]; then
 fi
 
 
-if [ -n "$luks_current_Disk_Recovery_Key_passphrase" -a -n "$luks_new_Disk_Recovery_Key_passphrase" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
+if [ -n "$luks_new_Disk_Recovery_Key_desired" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
   #Reencryption of disk, disk recovery key and Disk Recovery Key passphrase change is requested
   luks_reencrypt
   luks_change_passphrase
-elif [ -n "$luks_current_Disk_Recovery_Key_passphrase" -a -z "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
+elif [ -n "$luks_new_Disk_Recovery_Key_desired" -a -z "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
   #Reencryption of disk was requested but not passphrase change
   luks_reencrypt
-elif [ -n "$luks_new_Disk_Recovery_Key_passphrase" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
+elif [ -z "$luks_new_Disk_Recovery_Key_desired" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
   #Passphrase change is requested without disk reencryption
   luks_change_passphrase
 fi

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -40,10 +40,11 @@ test_luks_current_disk_recovery_key_passphrase()
 			echo -e "\nEnter current Disk Recovery Key passphrase (Provisioned at OS installation or by OEM):"
 			read -r luks_current_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" > /tmp/luks_current_Disk_Recovery_Key_passphrase
+			warn "Test opening "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
 			cryptsetup luksOpen $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		else
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" > /tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Testing opening "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
+			warn "Test opening "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
 			cryptsetup luksOpen $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		fi
 		#Validate past cryptsetup-reencrypt attempts
@@ -81,6 +82,7 @@ while : ; do
 		echo -e "\nEnter current Disk Recovery Key passphrase (Provisioned at OS installation or by OEM):"
 		read -r luks_current_Disk_Recovery_Key_passphrase
 		echo -n "$luks_current_Disk_Recovery_Key_passphrase" > /tmp/luks_current_Disk_Recovery_Key_passphrase
+		warn "Reencrypting "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
 		cryptsetup-reencrypt -B 64 --use-directio "$LUKS" --key-slot 0 --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 	else
 		echo -n "$luks_current_Disk_Recovery_Key_passphrase" > /tmp/luks_current_Disk_Recovery_Key_passphrase


### PR DESCRIPTION
Since /etc/luks-functions are currently exporting passphrases tested good per `cryptsetup test` to be reused in caller code,
the logic calling both luks_reencrypt and luks_change_passphrase, testing for non-empty luks_current_Disk_Recovery_Key_passphrase was bogus (always exported).

This commit includes a new  `luks_new_Disk_Recovery_Key_desired` variable which is set when reencryption is desired.
The 3 use cases (reencrypt+passphrase change, reencrypt no passphrase change and passphrase change alone) now only test
for `luks_new_Disk_Recovery_Key_desired` and `luks_new_Disk_Recovery_Key_passphrase_desired` and nothing else, for clarity as well.

luks-functions: make warning consistent + typo correction.

@MrChromebox please review.