### PR TITLE
gui-init: Have TPMTOTP QrCode named under TOTP app with $BOARD_NAME

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -142,7 +142,7 @@ prompt_update_checksums()
 generate_totp_htop()
 {
   echo "Scan the QR code to add the new TOTP secret"
-  /bin/seal-totp
+  /bin/seal-totp "$BOARD_NAME"
   if [ -x /bin/hotp_verification ]; then
     echo "Once you have scanned the QR code, hit Enter to configure your HOTP USB Security Dongle (e.g. Librem Key or Nitrokey)"
     read


### PR DESCRIPTION
Fixes #1181 

@MrChromebox Please review.
Question: should we also add commit ID?