### PR TITLE
.circleci/config.yml: Add Makefile as part of measured files for cache downloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,17 +61,17 @@ jobs:
       - run:
           name: Creating all modules and patches digest (All modules cache digest)
           command: |
-            find ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > ./tmpDir/all_modules_and_patches.sha256sums \
+            find ./Makefile ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > ./tmpDir/all_modules_and_patches.sha256sums \
 
       - run:
           name: Creating coreboot (and associated patches) and musl-cross-make modules digest (musl-cross-make and coreboot cache digest)
           command: |
-            find ./modules/coreboot ./modules/musl-cross* ./patches/coreboot* -type f | sort -h | xargs sha256sum > ./tmpDir/coreboot_musl-cross.sha256sums \
+            find ./Makefile ./modules/coreboot ./modules/musl-cross* ./patches/coreboot* -type f | sort -h | xargs sha256sum > ./tmpDir/coreboot_musl-cross.sha256sums \
 
       - run:
           name: Creating musl-cross-make and musl-cross-make patches digest (musl-cross-make cache digest)
           command: |
-            find modules/musl-cross* -type f | sort -h | xargs sha256sum > ./tmpDir/musl-cross.sha256sums \
+            find ./Makefile modules/musl-cross* -type f | sort -h | xargs sha256sum > ./tmpDir/musl-cross.sha256sums \
 
       - restore_cache:
           keys:


### PR DESCRIPTION
Global Makefile is the most effective modifier of builds.
As soon as the global Makefile changes, so should not be reused caches having measured a different Makefile.

Short reminder of how CircleCI caches work:
- keys are built on top of text. Best is hashes.
- The most automated way to do this is to create a digest and measure it to create unique key in for m of a sha256sum
- That key is generated on top of git downloaded tree components on each CircleCI prep_env step
- If a cache is available matching the same key being a string $cache_type-$hash-$CACHE_VERSION, then that cache is retrieved and extracted on top of downloaded git tree and CircleCI proceeds with its step.

---

We have 3 caches "types":
- Biggest (all): includes all built components and downloaded packages
  - all modules and patches digest (All modules cache digest)
    - digest creation: `find ./Makefile ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > ./tmpDir/all_modules_and_patches.sha256sums`
    - save_cache key: `heads-modules-and-patches-{{ checksum "./tmpDir/all_modules_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}`
    - cache extracted at reuse if digest matches:
       - crossgcc
       - build
       - packages
       - install
- Mid: included coreboot built components, musl-cross-make and downloaded packages
  - coreboot (and associated patches) and musl-cross-make modules digest (musl-cross-make and coreboot cache digest)
    - digest creation `find ./Makefile ./patches/ ./modules/ -type f | sort -h |xargs sha256sum > ./tmpDir/all_modules_and_patches.sha256sums`
    - save_cache key: `heads-coreboot-musl-cross-{{ checksum "./tmpDir/coreboot_musl-cross.sha256sums" }}{{ 
.Environment.CACHE_VERSION }}`
    - cache extracted at reuse if digest matches:
      - crossgcc
      - build/musl-cross-38e52db8358c043ae82b346a2e6e66bc86a53bc1
      - packages
      - build/coreboot-4.11
      - build/coreboot-4.13
      - build/coreboot-4.14
      - build/coreboot-4.15
- Small: musl-cross-make build stack cache
  -  musl-cross-make buildstack cache and downloaded packages
    - digest creation: `find ./Makefile modules/musl-cross* -type f | sort -h | xargs sha256sum > ./tmpDir/musl-cross.sha256sums`
    - save_cache key: `heads-musl-cross-{{ checksum "./tmpDir/musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}`
     - cache extracted at reuse if digest matches:
       - crossgcc
       - build/musl-cross-38e52db8358c043ae82b346a2e6e66bc86a53bc1
       - packages

----

So if someone now changes something in global Makefile, automatically we build from a clean checkout as opposed to before, which created inconsistent builds.