### PR TITLE
init: assign CONFIG_TPM depending on /dev/tpm0 presence

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -45,7 +45,7 @@ mount_boot()
         exec /bin/usb-init
         ;;
       m )
-        skip_to_menu="true"
+        skip_gpg_check="true"
         break
         ;;
       * )
@@ -571,7 +571,9 @@ else
 fi
 
 # detect whether any GPG keys exist in the keyring, if not, initialize that first
-[[ "$skip_to_menu" != "true" ]] && check_gpg_key && update_totp && update_hotp
+[[ "$skip_gpg_check" != "true" ]] && check_gpg_key
+
+update_totp && update_hotp
 
 if [[ "$HOTP" = "Success" && $CONFIG_AUTO_BOOT_TIMEOUT ]]; then
   prompt_auto_default_boot

--- a/initrd/init
+++ b/initrd/init
@@ -43,6 +43,13 @@ hwclock -l -s
 . /etc/functions
 . /etc/config
 
+# set CONFIG_TPM dynamically before init
+if [ -e /dev/tpm0 ]; then
+	CONFIG_TPM='y'
+else
+	CONFIG_TPM='n'
+fi
+
 #Specify whiptail background colors cues under FBWhiptail only
 if [ -x /bin/fbwhiptail ]; then
 	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-"--background-gradient 0 0 0 150 125 0"}"
@@ -96,6 +103,12 @@ if [ "$boot_option" = "r" ]; then
 	exec /bin/ash
 	exit
 fi
+
+# Override CONFIG_TPM from /etc/config with runtime value determined above.
+#
+# Values in user config have higher priority during combining thus effectively
+# changing the value for the rest of the scripts which source /tmp/config.
+echo "export CONFIG_TPM=\"$CONFIG_TPM\"" >> /etc/config.user
 
 combine_configs
 . /tmp/config


### PR DESCRIPTION
A small piece of https://github.com/osresearch/heads/pull/836 ([this file](https://github.com/osresearch/heads/pull/836/files#diff-63d474ce25ab525343c0d061b286b1cd45199cd14fdf9ea535f396fd8be5de45)) to avoid adding `-tmp`/`-no-tpm` board variants in https://github.com/osresearch/heads/pull/1002 and other cases.

Is it OK that after `gui-init` prints `Unable to locate /boot files on any mounted disk` message `$skip_to_menu` equals `true`, `$TOTP` isn't set and main menu doesn't display `NO TPM` until you press <kbd>r</kbd>?

Also, with these changes all `CONFIG_TPM` in board files is ignored, so maybe it needs to be removed from them or dynamic behaviour should be used only if `CONFIG_TPM=y` in config.