### PR TITLE
Makefile: replace patch with git apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ define define_module =
 	git clone $($1_repo) "$(build)/$($1_base_dir)"
 	cd $(build)/$($1_base_dir) && git submodule update --init --checkout
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+		( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -250,7 +250,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+			( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \
@@ -278,7 +278,7 @@ define define_module =
 	mkdir -p "$$(dir $$@)"
 	tar -xf "$(packages)/$($1_tar)" $(or $($1_tar_opt),--strip 1) -C "$$(dir $$@)"
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( cd $$(dir $$@) ; patch -p1 ) \
+		( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -286,7 +286,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( cd $$(dir $$@) ; patch -p1 ) \
+			( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \

--- a/patches/flashrom-b1f858f65b2abd276542650d8cb9e382da258967/0100-enable-kgpe-d16.patch
+++ b/patches/flashrom-b1f858f65b2abd276542650d8cb9e382da258967/0100-enable-kgpe-d16.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 7242b09..c2fb32e 100644
+index e475cbdb..27197f08 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -236,6 +236,16 @@ UNSUPPORTED_FEATURES += CONFIG_GFXNVIDIA=yes
+@@ -263,6 +263,16 @@ UNSUPPORTED_FEATURES += CONFIG_GFXNVIDIA=yes
  else
  override CONFIG_GFXNVIDIA = no
  endif
@@ -19,7 +19,7 @@ index 7242b09..c2fb32e 100644
  ifeq ($(CONFIG_SATASII), yes)
  UNSUPPORTED_FEATURES += CONFIG_SATASII=yes
  else
-@@ -492,6 +502,16 @@ UNSUPPORTED_FEATURES += CONFIG_GFXNVIDIA=yes
+@@ -565,6 +575,16 @@ UNSUPPORTED_FEATURES += CONFIG_GFXNVIDIA=yes
  else
  override CONFIG_GFXNVIDIA = no
  endif
@@ -36,7 +36,7 @@ index 7242b09..c2fb32e 100644
  ifeq ($(CONFIG_SATASII), yes)
  UNSUPPORTED_FEATURES += CONFIG_SATASII=yes
  else
-@@ -616,6 +636,12 @@ CONFIG_NIC3COM ?= yes
+@@ -692,6 +712,12 @@ CONFIG_NIC3COM ?= yes
  # Enable NVIDIA graphics cards. Note: write and erase do not work properly.
  CONFIG_GFXNVIDIA ?= yes
  
@@ -49,7 +49,7 @@ index 7242b09..c2fb32e 100644
  # Always enable SiI SATA controllers for now.
  CONFIG_SATASII ?= yes
  
-@@ -728,6 +754,8 @@ ifeq ($(CONFIG_ENABLE_LIBPCI_PROGRAMMERS), no)
+@@ -819,6 +845,8 @@ ifeq ($(CONFIG_ENABLE_LIBPCI_PROGRAMMERS), no)
  override CONFIG_INTERNAL = no
  override CONFIG_NIC3COM = no
  override CONFIG_GFXNVIDIA = no
@@ -58,7 +58,7 @@ index 7242b09..c2fb32e 100644
  override CONFIG_SATASII = no
  override CONFIG_ATAHPT = no
  override CONFIG_ATAVIA = no
-@@ -840,6 +868,18 @@ PROGRAMMER_OBJS += gfxnvidia.o
+@@ -946,6 +974,18 @@ PROGRAMMER_OBJS += gfxnvidia.o
  NEED_LIBPCI += CONFIG_GFXNVIDIA
  endif
  
@@ -79,7 +79,7 @@ index 7242b09..c2fb32e 100644
  PROGRAMMER_OBJS += satasii.o
 diff --git a/ast1100.c b/ast1100.c
 new file mode 100644
-index 0000000..c7474e5
+index 00000000..c7474e5d
 --- /dev/null
 +++ b/ast1100.c
 @@ -0,0 +1,420 @@
@@ -505,7 +505,7 @@ index 0000000..c7474e5
 +}
 diff --git a/ast2400.c b/ast2400.c
 new file mode 100644
-index 0000000..761a38d
+index 00000000..761a38d4
 --- /dev/null
 +++ b/ast2400.c
 @@ -0,0 +1,425 @@
@@ -935,10 +935,10 @@ index 0000000..761a38d
 +	return 0;
 +}
 diff --git a/flashchips.c b/flashchips.c
-index 58dd4f3..719185b 100644
+index 7d10abf5..7d4b3ee8 100644
 --- a/flashchips.c
 +++ b/flashchips.c
-@@ -12273,7 +12273,7 @@ const struct flashchip flashchips[] = {
+@@ -12388,7 +12388,7 @@ const struct flashchip flashchips[] = {
  		.total_size	= 1024,
  		.page_size	= 256,
  		.feature_bits	= FEATURE_WRSR_WREN,
@@ -947,7 +947,7 @@ index 58dd4f3..719185b 100644
  		.probe		= probe_spi_rdid,
  		.probe_timing	= TIMING_ZERO,
  		.block_erasers	=
-@@ -16659,11 +16659,20 @@ const struct flashchip flashchips[] = {
+@@ -16774,11 +16774,20 @@ const struct flashchip flashchips[] = {
  		.block_erasers	=
  		{
  			{
@@ -969,7 +969,7 @@ index 58dd4f3..719185b 100644
  				.eraseblocks = { {64 * 1024, 512} },
  				.block_erase = spi_block_erase_d8,
 diff --git a/flashrom.c b/flashrom.c
-index e540027..75bfd89 100644
+index c18a04fc..42ce989a 100644
 --- a/flashrom.c
 +++ b/flashrom.c
 @@ -6,6 +6,7 @@
@@ -980,7 +980,7 @@ index e540027..75bfd89 100644
   * (Written by Nico Huber <nico.huber@secunet.com> for secunet)
   *
   * This program is free software; you can redistribute it and/or modify
-@@ -133,6 +134,30 @@ const struct programmer_entry programmer_table[] = {
+@@ -157,6 +158,30 @@ const struct programmer_entry programmer_table[] = {
  	},
  #endif
  
@@ -1012,7 +1012,7 @@ index e540027..75bfd89 100644
  	{
  		.name			= "drkaiser",
 diff --git a/pcidev.c b/pcidev.c
-index 54c1fd3..97c8c1f 100644
+index e13b78ce..4af1c556 100644
 --- a/pcidev.c
 +++ b/pcidev.c
 @@ -33,11 +33,13 @@ enum pci_bartype {
@@ -1052,7 +1052,7 @@ index 54c1fd3..97c8c1f 100644
  	case TYPE_IOBAR:
  		msg_pdbg("I/O\n");
 diff --git a/programmer.h b/programmer.h
-index 3cf53b9..7be47d1 100644
+index 9a7892d7..192bff1e 100644
 --- a/programmer.h
 +++ b/programmer.h
 @@ -5,6 +5,7 @@
@@ -1073,10 +1073,10 @@ index 3cf53b9..7be47d1 100644
 +#if CONFIG_AST2400 == 1
 +	PROGRAMMER_AST2400,
 +#endif
- #if CONFIG_DRKAISER == 1
- 	PROGRAMMER_DRKAISER,
+ #if CONFIG_RAIDEN == 1
+ 	PROGRAMMER_RAIDEN,
  #endif
-@@ -401,6 +408,18 @@ int gfxnvidia_init(void);
+@@ -416,6 +423,18 @@ int gfxnvidia_init(void);
  extern const struct dev_entry gfx_nvidia[];
  #endif
  
@@ -1092,6 +1092,6 @@ index 3cf53b9..7be47d1 100644
 +extern const struct dev_entry bmc_aspeed_ast2400[];
 +#endif
 +
- /* drkaiser.c */
- #if CONFIG_DRKAISER == 1
- int drkaiser_init(void);
+ /* raiden_debug_spi.c */
+ #if CONFIG_RAIDEN == 1
+ int raiden_debug_spi_init(void);

--- a/patches/gpg2-2.2.21.patch
+++ b/patches/gpg2-2.2.21.patch
@@ -12,7 +12,7 @@ diff -u --recursive /home/tlaurion/build/clean/gnupg-2.2.10/configure gnupg-2.2.
  MAKEFLAGS=
 diff -u --recursive gnupg-2.2.10/common/ttyio.c gnupg-2.2.10/common/ttyio.c.mod 
 --- gnupg-2.2.10/common/ttyio.c	2017-08-28 06:22:54.000000000 -0400
-+++ gnupg-2.2.10/common/ttyio.c.mod	2018-09-18 23:00:07.386250017 -0400
++++ gnupg-2.2.10/common/ttyio.c	2018-09-18 23:00:07.386250017 -0400
 @@ -190,7 +190,9 @@
  #elif defined (HAVE_W32CE_SYSTEM)
      ttyfp = stderr;


### PR DESCRIPTION
Otherwise binary patches cannot be patched/created

Additional fixes needed
- flashrom patch was invalid and got catched by git apply. Correcting
- gpg2-2.2.21.patch was pointing to bad target. Correcting

----

This commit is included by #967 as of now, otherwise coreboot patchsets (and other patches including binary patches) cannot be applied by patch.

Once this is merged, #967 will be rebased on master.

Without the present change, [x230-fhd-edp patchset, targeting graphical configuration blob (vbt) cannot be applied](https://github.com/osresearch/heads/pull/967/files#diff-4eeb4abb7c19d1c1aaf5c84906b32586eb85230907d6ee12e2bc885178a23dfbR132-R172)

Discussions on removing `--reject`, adding `--3way` etc happened under https://github.com/osresearch/heads/pull/967#issuecomment-1217046809

Switching to git patch with `--reject` is actually giving better insights on patch failing to apply in builds, showing which chunks failed to apply and producing reject files for those chunks which are easier to understand.

As a consequence, two patches needed to be remade, since git apply doesn't apply fuzzing. Those are included in this PR as they were part of the changes needed to pass `patch` to `git apply`.

This was used to build all boards successfully while x230-hotp-maximized and x230-maximized-fhd_edp rom images were tested functional under #967.

Leaving this PR open for review for a couple of days prior of merging. 