### PR TITLE
whiptail: no more whiptail reseting console on call (--clear)

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -14,7 +14,7 @@ while true; do
     unset param
   else
     unset menu_choice
-    whiptail $BG_COLOR_MAIN_MENU --clear --title "Config Management Menu" \
+    whiptail $BG_COLOR_MAIN_MENU --title "Config Management Menu" \
     --menu "This menu lets you change settings for the current BIOS session.\n\nAll changes will revert after a reboot,\n\nunless you also save them to the running BIOS." 0 80 10 \
     'b' ' Change the /boot device' \
     's' ' Save the current configuration to the running BIOS' \

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -7,7 +7,7 @@ set -e -o pipefail
 
 while true; do
   unset menu_choice
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "Firmware Management Menu" \
+  whiptail $BG_COLOR_MAIN_MENU --title "Firmware Management Menu" \
     --menu "Select the firmware function to perform\n\nRetaining settings copies existing settings to the new firmware:\n* Keeps your GPG keyring\n* Keeps changes to the default /boot device\n\nErasing settings uses the new firmware as-is:\n* Erases any existing GPG keyring\n* Restores firmware to default factory settings\n* Clears out /boot signatures\n\nIf you are just updating your firmware, you probably want to retain\nyour settings." 0 80 10 \
     'f' ' Flash the firmware with a new ROM, retain settings' \
     'c' ' Flash the firmware with a new ROM, erase settings' \

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -140,7 +140,7 @@ gpg_add_key_reflash() {
 
 while true; do
   unset menu_choice
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "GPG Management Menu" \
+  whiptail $BG_COLOR_MAIN_MENU --title "GPG Management Menu" \
     --menu 'Select the GPG function to perform' 0 80 10 \
     'r' ' Add GPG key to running BIOS and reflash' \
     'a' ' Add GPG key to standalone BIOS image and flash' \

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -22,7 +22,7 @@ mount_boot()
 
     # CONFIG_BOOT_DEV doesn't exist or couldn't be mounted, so give user options
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
-    whiptail $BG_COLOR_ERROR --clear --title "ERROR: No Bootable OS Found!" \
+    whiptail $BG_COLOR_ERROR --title "ERROR: No Bootable OS Found!" \
         --menu "    No bootable OS was found on the default boot device $CONFIG_BOOT_DEV.
     How would you like to proceed?" 0 80 4 \
         'b' ' Select a new boot device' \
@@ -66,7 +66,7 @@ verify_global_hashes()
   if ( cd /boot && sha256sum -c "$TMP_HASH_FILE" > /tmp/hash_output ) then
     return 0
   elif [ ! -f $TMP_HASH_FILE ]; then
-    if (whiptail $BG_COLOR_ERROR --clear --title 'ERROR: Missing Hash File!' \
+    if (whiptail $BG_COLOR_ERROR --title 'ERROR: Missing Hash File!' \
         --yesno "The file containing hashes for /boot is missing!\n\nIf you are setting this system up for the first time, select Yes to update\nyour list of checksums.\n\nOtherwise this could indicate a compromise and you should select No to\nreturn to the main menu.\n\nWould you like to update your checksums now?" 0 80) then
       if update_checksums ; then
         BG_COLOR_MAIN_MENU=""
@@ -114,7 +114,7 @@ verify_global_hashes()
       fi
     fi
 
-    if (whiptail $BG_COLOR_ERROR --clear --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 0 80) then
+    if (whiptail $BG_COLOR_ERROR --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 0 80) then
       if update_checksums ; then
         BG_COLOR_MAIN_MENU=""
         return 0;
@@ -163,7 +163,7 @@ update_totp()
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
-      whiptail $BG_COLOR_ERROR --clear --title "ERROR: TOTP Generation Failed!" \
+      whiptail $BG_COLOR_ERROR --title "ERROR: TOTP Generation Failed!" \
         --menu "    ERROR: Heads couldn't generate the TOTP code.\n
   If you have just completed a Factory Reset, or just reflashed
   your BIOS, you should generate a new HOTP/TOTP secret.\n
@@ -204,7 +204,7 @@ update_hotp()
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
     if ! hotp_verification info ; then
-      if ! whiptail $BG_COLOR_WARNING --clear \
+      if ! whiptail $BG_COLOR_WARNING \
           --title "WARNING: Please Insert Your $HOTPKEY_BRANDING" \
           --yes-button "Retry" --no-button "Skip" \
           --yesno "Your $HOTPKEY_BRANDING was not detected.\n\nPlease insert your $HOTPKEY_BRANDING" 0 80 ; then
@@ -267,7 +267,7 @@ check_gpg_key()
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
-    whiptail $BG_COLOR_ERROR --clear --title "ERROR: GPG keyring empty!" \
+    whiptail $BG_COLOR_ERROR --title "ERROR: GPG keyring empty!" \
       --menu "ERROR: Heads couldn't find any GPG keys in your keyring.\n\nIf this is the first time the system has booted,\nyou should add a public GPG key to the BIOS now.\n\nIf you just reflashed a new BIOS, you'll need to add at least one\npublic key to the keyring.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 0 80 4 \
       'g' ' Add a GPG key to the running BIOS' \
       'F' ' OEM Factory Reset / Re-Ownership' \
@@ -313,7 +313,7 @@ prompt_auto_default_boot()
 show_main_menu()
 {
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "$MAIN_MENU_TITLE" \
+  whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 0 80 10 \
     'd' ' Default boot' \
     'r' ' Refresh TOTP/HOTP' \
@@ -344,7 +344,7 @@ show_main_menu()
 
 show_options_menu()
 {
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "HEADS Options" \
+  whiptail $BG_COLOR_MAIN_MENU --title "HEADS Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
     't' ' TPM/TOTP/HOTP Options -->' \
@@ -400,7 +400,7 @@ show_options_menu()
 
 show_boot_options_menu()
 {
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "Boot Options" \
+  whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
     'u' ' USB boot' \
@@ -427,7 +427,7 @@ show_boot_options_menu()
 
 show_tpm_totp_hotp_options_menu()
 {
-  whiptail $BG_COLOR_MAIN_MENU --clear --title "TPM/TOTP/HOTP Options" \
+  whiptail $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
     --menu "Select An Option" 0 80 10 \
     'g' ' Generate new TOTP/HOTP secret' \
     'r' ' Reset the TPM' \
@@ -493,7 +493,7 @@ reset_tpm()
       echo "Returning to the main menu"
     fi
   else
-    whiptail $BG_COLOR_ERROR --clear --title 'ERROR: No TPM Detected' --msgbox "This device does not have a TPM.\n\nPress OK to return to the Main Menu" 0 80
+    whiptail $BG_COLOR_ERROR --title 'ERROR: No TPM Detected' --msgbox "This device does not have a TPM.\n\nPress OK to return to the Main Menu" 0 80
   fi
 }
 

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -102,7 +102,7 @@ get_menu_option() {
 			MENU_OPTIONS="$MENU_OPTIONS $n ${name} "
 		done < $TMP_MENU_FILE
 
-		whiptail --clear --title "Select your boot option" \
+		whiptail --title "Select your boot option" \
 			--menu "Choose the boot option [1-$n, a to abort]:" 0 80 8 \
 			-- $MENU_OPTIONS \
 			2>/tmp/whiptail || die "Aborting boot attempt"
@@ -136,7 +136,7 @@ confirm_menu_option() {
 	if [ "$gui_menu" = "y" ]; then
 		default_text="Make default"
 		[[ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" = "y" ]] && default_text="${default_text} and boot"
-		whiptail $BG_COLOR_WARNING --clear --title "Confirm boot details" \
+		whiptail $BG_COLOR_WARNING --title "Confirm boot details" \
 			--menu "Confirm the boot details for $name:\n\n$(echo $kernel| fold -s -w 80) \n\n" 0 80 8 \
 			-- 'd' "${default_text}" 'y' "Boot one time" \
 			2>/tmp/whiptail || die "Aborting boot attempt"

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -65,7 +65,7 @@ if [ -z ${USB_MOUNT_DEVICE} ]; then
     done < /tmp/usb_disk_list
 
     MENU_OPTIONS="$MENU_OPTIONS a Abort"
-    whiptail $BG_COLOR --clear --title "Select your USB disk" \
+    whiptail $BG_COLOR --title "Select your USB disk" \
       --menu "Choose your USB disk [1-$n, a to abort]:" 0 80 8 \
       -- $MENU_OPTIONS \
       2>/tmp/whiptail

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -298,7 +298,7 @@ report_integrity_measurements()
             HOTP=`unseal-hotp` > /dev/null 2>&1
             enable_usb
             if ! hotp_verification info > /dev/null 2>&1 ; then
-                whiptail $CONFIG_WARNING_BG_COLOR --clear --title 'WARNING: Please insert your HOTP enabled USB Security dongle' --msgbox "Your HOTP enabled USB Security dongle was not detected.\n\nPlease remove it and insert it again." 0 80
+                whiptail $CONFIG_WARNING_BG_COLOR --title 'WARNING: Please insert your HOTP enabled USB Security dongle' --msgbox "Your HOTP enabled USB Security dongle was not detected.\n\nPlease remove it and insert it again." 0 80
             fi
             # Don't output HOTP codes to screen, so as to make replay attacks harder
             hotp_verification check $HOTP
@@ -330,7 +330,7 @@ report_integrity_measurements()
         fi
 
 	    #Show results
-	    whiptail $MAIN_MENU_BG_COLOR --clear --title "Measured Integrity Report" --msgbox "$date\nTOTP: $TOTP | HOTP: $HOTP\n/BOOT INTEGRITY: $HASH\n\nPress OK to continue or Ctrl+Alt+Delete to reboot" 0 80
+	    whiptail $MAIN_MENU_BG_COLOR --title "Measured Integrity Report" --msgbox "$date\nTOTP: $TOTP | HOTP: $HOTP\n/BOOT INTEGRITY: $HASH\n\nPress OK to continue or Ctrl+Alt+Delete to reboot" 0 80
     fi
 }
 

--- a/initrd/bin/usb-scan
+++ b/initrd/bin/usb-scan
@@ -29,7 +29,7 @@ get_menu_option() {
 			MENU_OPTIONS="$MENU_OPTIONS $n ${option}"
 		done < /tmp/iso_menu.txt
 
-		whiptail $BG_COLOR_MAIN_MENU --clear --title "Select your ISO boot option" \
+		whiptail $BG_COLOR_MAIN_MENU --title "Select your ISO boot option" \
 			--menu "Choose the ISO boot option [1-$n, s for standard boot, a to abort]:" 0 80 8 \
 			-- $MENU_OPTIONS \
 			2>/tmp/whiptail || die "Aborting boot attempt"

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -43,7 +43,7 @@ file_selector()
       done < $FILE_LIST
 
       MENU_OPTIONS="$MENU_OPTIONS a Abort"
-      whiptail --clear --title "${MENU_TITLE}" \
+      whiptail --title "${MENU_TITLE}" \
         --menu "${MENU_MSG} [1-$n, a to abort]:" 20 120 8 \
         -- $MENU_OPTIONS \
         2>/tmp/whiptail || die "Aborting"


### PR DESCRIPTION
So we have console logs to troubleshoot errors and catch them correctly

---
@JonathonHall-Purism linked to separate discussion.

This is useful to call scripts (eg. gui-init) from recovery shell so that scripts can be ctrl-c to see console output.

Any error should be corrected in caller scripts anyway and provide at least a warning (warn) to console.
