### PR TITLE
Emergency revert of git apply instead of patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ define define_module =
 	git clone $($1_repo) "$(build)/$($1_base_dir)"
 	cd $(build)/$($1_base_dir) && git submodule update --init --checkout
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
+		( cd $(build)/$($1_base_dir) ; patch -p1 ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -268,7 +268,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
+			( cd $(build)/$($1_base_dir) ; patch -p1 ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \
@@ -296,7 +296,7 @@ define define_module =
 	mkdir -p "$$(dir $$@)"
 	tar -xf "$(packages)/$($1_tar)" $(or $($1_tar_opt),--strip 1) -C "$$(dir $$@)"
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
+		( cd $$(dir $$@) ; patch -p1 ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -304,7 +304,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( git apply --verbose --reject --binary --directory build/$($1_base_dir) ) \
+			( cd $$(dir $$@) ; patch -p1 ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \


### PR DESCRIPTION
Revert Makefile to use patch -p1 instead of git apply, something changed and this doesn't apply the same.
Fixed regression for first built boards: https://app.circleci.com/pipelines/github/tlaurion/heads/1166/workflows/76e79591-dbaa-4900-9756-f9c6cc86f793

Path of patch application are not good for the moment for `patches/module-version/*.patch`, that is when multiple patches are to be applied on decompressed archive dir.

https://app.circleci.com/pipelines/github/osresearch/heads/437/workflows/00934a21-4834-4398-b41a-b5488135d3eb/jobs/4311?invite=true#step-103-55

Will work on this separately without affecting master for the time being.

Sorry for the noise and revert of that change.