### PR TITLE
Change patch to git apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ define define_module =
 	git clone $($1_repo) "$(build)/$($1_base_dir)"
 	cd $(build)/$($1_base_dir) && git reset --hard $($1_commit_hash) && git submodule update --init --checkout
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+		( git apply --verbose --reject --binary --directory build/$(CONFIG_TARGET_ARCH)/$($1_base_dir) ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -268,7 +268,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( cd $(build)/$($1_base_dir) ; patch -p1 ) \
+			( git apply --verbose --reject --binary --directory build/$(CONFIG_TARGET_ARCH)/$($1_base_dir) ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \
@@ -296,7 +296,7 @@ define define_module =
 	mkdir -p "$$(dir $$@)"
 	tar -xf "$(packages)/$($1_tar)" $(or $($1_tar_opt),--strip 1) -C "$$(dir $$@)"
 	if [ -r patches/$($1_patch_name).patch ]; then \
-		( cd $$(dir $$@) ; patch -p1 ) \
+		( git apply --verbose --reject --binary --directory build/$(CONFIG_TARGET_ARCH)/$($1_base_dir) ) \
 			< patches/$($1_patch_name).patch \
 			|| exit 1 ; \
 	fi
@@ -304,7 +304,7 @@ define define_module =
 	   [ -r patches/$($1_patch_name) ] ; then \
 		for patch in patches/$($1_patch_name)/*.patch ; do \
 			echo "Applying patch file : $$$$patch " ;  \
-			( cd $$(dir $$@) ; patch -p1 ) \
+			( git apply --verbose --reject --binary --directory build/$(CONFIG_TARGET_ARCH)/$($1_base_dir) ) \
 				< $$$$patch \
 				|| exit 1 ; \
 		done ; \


### PR DESCRIPTION
Change patch to git apply, permitting to apply binary diffs and give better hints on console of builds when patches fail to be applied.

Was already tested fonctional against:
- talos II #1002 (https://app.circleci.com/pipelines/github/tlaurion/heads/1170/workflows/d05b2802-ddb3-45e5-84d1-9fdc1d0cd395)
- master (https://app.circleci.com/pipelines/github/tlaurion/heads/1170/workflows/d05b2802-ddb3-45e5-84d1-9fdc1d0cd395/jobs/9805)

@SergiiDmytruk ?