### PR TITLE
WiP : CPython3 inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,6 +459,7 @@ bin_modules-$(CONFIG_HOTPKEY) += hotp-verification
 bin_modules-$(CONFIG_MSRTOOLS) += msrtools
 bin_modules-$(CONFIG_NKSTORECLI) += nkstorecli
 bin_modules-$(CONFIG_UTIL_LINUX) += util-linux
+bin_modules-$(CONFIG_PYTHON) += python
 
 $(foreach m, $(bin_modules-y), \
 	$(call map,initrd_bin_add,$(call bins,$m)) \

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -51,6 +51,7 @@ CONFIG_FBWHIPTAIL=y
 #Additional tools:
 #SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
 CONFIG_DROPBEAR=y
+CONFIG_PYTHON=y
 
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n

--- a/modules/python
+++ b/modules/python
@@ -23,6 +23,7 @@ python_configure := \
         -L$(INSTALL)/lib" \
 	$(CROSS_TOOLS_NOCC) \
 	./configure \
+	--enable-optimizations \
 	--with-cxx-main=$(CROSS)gcc \
 	--with-libc="$(musl-cross_libraries)" \
 	--host $(MUSL_ARCH)-linux-musl \

--- a/modules/python
+++ b/modules/python
@@ -17,14 +17,19 @@ python_configure := \
 	ac_cv_file__dev_ptc=no \
 	have_openssl=no \
 	CFLAGS="-Os" \
+	CC="$(CROSS)gcc \
+        -D__MUSL__ \
+        -isystem $(INSTALL)/include \
+        -L$(INSTALL)/lib" \
+	$(CROSS_TOOLS_NOCC) \
 	./configure \
-	--with-cxx-main="$(CROSS)gcc" \
-	--host "$(MUSL_ARCH)-elf-linux" \
-	--build "$(MUSL_ARCH)-linux-gnu" \
+	--with-cxx-main=$(CROSS)gcc \
+	--with-libc="$(musl-cross_libraries)" \
+	--host $(MUSL_ARCH)-linux-musl \
+	--build $(MUSL_ARCH) \
 	--disable-ipv6 \
-	--oldincludedir="$(INSTALL)/include" \
-	--prefix="/" \
-	--exec-prefix="/" \
+	--prefix="" \
+	--exec-prefix="" \
 
 # but after building, replace prefix so that they will be installed
 # in the correct directory.
@@ -34,6 +39,7 @@ python_target := \
 		CC="$(heads_cc)" \
 		-C $(build)/$(python_dir) \
 		prefix="$(INSTALL)" \
+		DESTDIR="$(INSTALL)" \
 		install
 
 python_output := \

--- a/modules/python
+++ b/modules/python
@@ -1,0 +1,41 @@
+modules-$(CONFIG_PYTHON) += python
+
+python_depends := $(musl_dep)
+
+python_version := 3.9.2
+python_dir := python-$(python_version)
+python_tar := Python-$(python_version).tar.xz
+python_url := https://www.python.org/ftp/python/$(python_version)/$(python_tar)
+python_hash := 3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d
+
+# Use an empty prefix so that the executables will not include the
+# build path.
+python_configure := \
+	PKG_CONFIG="/bin/false" \
+	READELF="$(CROSS)readelf" \
+	ac_cv_file__dev_ptmx=no \
+	ac_cv_file__dev_ptc=no \
+	have_openssl=no \
+	CFLAGS="-Os" \
+	./configure \
+	--with-cxx-main="$(CROSS)gcc" \
+	--host "$(MUSL_ARCH)-elf-linux" \
+	--build "$(MUSL_ARCH)-linux-gnu" \
+	--disable-ipv6 \
+	--oldincludedir="$(INSTALL)/include" \
+	--prefix="/" \
+	--exec-prefix="/" \
+
+# but after building, replace prefix so that they will be installed
+# in the correct directory.
+python_target := \
+	$(MAKE_JOBS) \
+	&& $(MAKE) \
+		CC="$(heads_cc)" \
+		-C $(build)/$(python_dir) \
+		prefix="$(INSTALL)" \
+		install
+
+python_output := \
+	python \
+

--- a/patches/python-3.9.2.patch
+++ b/patches/python-3.9.2.patch
@@ -1,0 +1,92 @@
+From cd6d2577fadc4cc0275017f27f46b0a628216353 Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Thu, 25 Nov 2021 21:53:14 +0200
+Subject: [PATCH] [3.9] bpo-45881: Use CC from env first for cross building
+ (GH-29752) (GH-29754)
+
+Co-authored-by: Christian Heimes <christian@python.org>.
+Co-authored-by: Christian Heimes <christian@python.org>
+---
+ .../2021-11-24-17-14-06.bpo-45881.GTXXLk.rst     |  2 ++
+ setup.py                                         | 16 ++++++++--------
+ 2 files changed, 10 insertions(+), 8 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst b/Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst
+new file mode 100644
+index 000000000000..b697658cf3aa
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-11-24-17-14-06.bpo-45881.GTXXLk.rst
+@@ -0,0 +1,2 @@
++``setup.py`` now uses ``CC`` from environment first to discover multiarch
++and cross compile paths.
+diff --git a/setup.py b/setup.py
+index 9a5887b59ffc..c6023e1ab635 100644
+--- a/setup.py
++++ b/setup.py
+@@ -65,6 +65,9 @@ def get_platform():
+ MACOS = (HOST_PLATFORM == 'darwin')
+ AIX = (HOST_PLATFORM.startswith('aix'))
+ VXWORKS = ('vxworks' in HOST_PLATFORM)
++CC = os.environ.get("CC")
++if not CC:
++    CC = sysconfig.get_config_var("CC")
+ 
+ 
+ SUMMARY = """
+@@ -443,6 +446,9 @@ def set_compiler_executables(self):
+ 
+     def build_extensions(self):
+         self.set_srcdir()
++        self.set_compiler_executables()
++        self.configure_compiler()
++        self.init_inc_lib_dirs()
+ 
+         # Detect which modules should be compiled
+         self.detect_modules()
+@@ -451,7 +457,6 @@ def build_extensions(self):
+ 
+         self.update_sources_depends()
+         mods_built, mods_disabled = self.remove_configured_extensions()
+-        self.set_compiler_executables()
+ 
+         build_ext.build_extensions(self)
+ 
+@@ -631,12 +636,11 @@ def check_extension_import(self, ext):
+     def add_multiarch_paths(self):
+         # Debian/Ubuntu multiarch support.
+         # https://wiki.ubuntu.com/MultiarchSpec
+-        cc = sysconfig.get_config_var('CC')
+         tmpfile = os.path.join(self.build_temp, 'multiarch')
+         if not os.path.exists(self.build_temp):
+             os.makedirs(self.build_temp)
+         ret = run_command(
+-            '%s -print-multiarch > %s 2> /dev/null' % (cc, tmpfile))
++            '%s -print-multiarch > %s 2> /dev/null' % (CC, tmpfile))
+         multiarch_path_component = ''
+         try:
+             if ret == 0:
+@@ -675,11 +679,10 @@ def add_multiarch_paths(self):
+             os.unlink(tmpfile)
+ 
+     def add_cross_compiling_paths(self):
+-        cc = sysconfig.get_config_var('CC')
+         tmpfile = os.path.join(self.build_temp, 'ccpaths')
+         if not os.path.exists(self.build_temp):
+             os.makedirs(self.build_temp)
+-        ret = run_command('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        ret = run_command('%s -E -v - </dev/null 2>%s 1>/dev/null' % (CC, tmpfile))
+         is_gcc = False
+         is_clang = False
+         in_incdirs = False
+@@ -1783,9 +1786,6 @@ def detect_uuid(self):
+             self.missing.append('_uuid')
+ 
+     def detect_modules(self):
+-        self.configure_compiler()
+-        self.init_inc_lib_dirs()
+-
+         self.detect_simple_extensions()
+         if TEST_EXTENSIONS:
+             self.detect_test_extensions()
+


### PR DESCRIPTION
This is still not working, and aimed at seeking help from the community into resolving packaging problems when crosscompiling python3 even today.

- Includes upstream fixes for cross compilation recognized problems (see patch in PR.)
- Builds against python 3.9.2 (debian's 11 current python. Yes, we depend on the host's python to compile destination's)

As of current state creating this draft, I am not able to force python using its own `--with-libc="$(musl-cross_libraries)"` which should point to musl-cross-make's libc.so. Python still attempts to link against host's libc, resulting in:

> Traceback (most recent call last):
>   File "/home/user/heads/build/x86/python-3.9.2/Lib/decimal.py", line 3, in <module>
>     from _decimal import *
> ImportError: /lib/x86_64-linux-gnu/libc.so: invalid ELF header
> 
> 

Recommendations are sparse, and were documented prior into #233 #689. 

When those problems are resolved, this will:
Fixes #233 #689 