### PR TITLE
flash.sh: UX and logic fixes

### DIFF
--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -27,21 +27,23 @@ flashrom_progress() {
     local status='init'
     local prev_word=''
     local prev_prev_word=''
+    local spaces='                                                  '
+    local hashes='##################################################'
 
     progressbar2=$(for i in `seq 48` ; do echo -ne ' ' ; done)
-    echo -e "\nInitializing internal Flash Programmer"
+    echo -e "\nInitializing Flash Programmer"
     while true ; do
         prev_prev_word=$prev_word
         prev_word=$IN
-        read -r -d' ' IN || break
+        read -r -d' ' IN
         if [ "$total_bytes" != "0" ]; then
-            current=$(echo "$IN" | grep -E -o '0x[0-9a-f]+-0x[0-9a-f]+:.*' | grep -E -o "0x[0-9a-f]+" | tail -n 1)
+            current=$(echo "$IN" | sed -nE 's/.*(0x[0-9a-f]+).*/\1/p')
             if [ "${current}" != "" ]; then
                 percent=$((100 * (current + 1) / total_bytes))
                 pct1=$((percent / 2))
-                pct2=$((49 - percent / 2))
-                progressbar=$(for i in `seq $pct1 2>/dev/null` ; do echo -ne '#' ; done)
-                progressbar2=$(for i in `seq $pct2 2>/dev/null` ; do echo -ne ' ' ; done)
+                pct2=$((50 - percent / 2))
+                progressbar=${hashes:0:$pct1}
+                progressbar2=${spaces:0:$pct2}
             fi
         else
             if [ "$prev_prev_word"  == "Reading" ] && [ "$IN" == "bytes" ]; then
@@ -50,6 +52,11 @@ flashrom_progress() {
                     total_bytes=$prev_word
                     echo "Total flash size : $total_bytes bytes"
                 fi
+            fi
+            if [ "$prev_word"  == "total_size:" ]; then
+                # Next is total size in bytes
+                total_bytes=$(echo "$IN" | grep -E -o '[0-9]+')
+                echo "Total flash size : $total_bytes bytes"
             fi
         fi
         if [ "$percent" -gt 99 ]; then
@@ -77,14 +84,19 @@ flashrom_progress() {
             fi
             if echo "$IN" | grep "identical" > /dev/null ; then
                 status="done"
-		        echo ""
+                echo ""
                 echo "The flash contents are identical to the image being flashed."
+                break
             fi
         fi
         if [ "$status" == "verifying" ]; then
             if echo "${IN}" | grep "VERIFIED." > /dev/null ; then
                 status="done"
                 echo "The flash contents were verified and the image was flashed correctly."
+                break
+            elif echo "${IN}" | grep "FAILED" > /dev/null ; then
+                echo 'Error while verifying flash content'
+                break
             fi
         fi
     done
@@ -101,18 +113,8 @@ flashrom_progress() {
 flash_rom() {
   ROM=$1
   if [ "$READ" -eq 1 ]; then
-    flashrom $CONFIG_FLASHROM_OPTIONS -r "${ROM}.1" \
-    || die "$ROM: Read failed"
-    flashrom $CONFIG_FLASHROM_OPTIONS -r "${ROM}.2" \
-    || die "$ROM: Read failed"
-    flashrom $CONFIG_FLASHROM_OPTIONS -r "${ROM}.3" \
-    || die "$ROM: Read failed"
-    if [ `sha256sum ${ROM}.[123] | cut -f1 -d ' ' | uniq | wc -l` -eq 1 ]; then
-      mv ${ROM}.1 $ROM
-      rm ${ROM}.[23]
-    else
-      die "$ROM: Read inconsistent"
-    fi
+    flashrom $CONFIG_FLASHROM_OPTIONS -r "${ROM}" \
+    || die "Backup to $ROM failed"
   else
     cp "$ROM" /tmp/${CONFIG_BOARD}.rom
     sha256sum /tmp/${CONFIG_BOARD}.rom


### PR DESCRIPTION
- Have Talos II supported by detecting correctly size of mtd chip (not internal: different flashrom output needs to be parsed for chip size)
- Read SPI content only once: 66% speedup (TOCTOU? Don't think so, nothing should happen in parallel when flashing in single user mode)
- Have the main flash_progress loop not break, but break in flash_rom state subcases (otherwise, verifying step was breaking)

Next steps: 

- Review changes tested under https://github.com/osresearch/heads/commit/76d7ee5f1993594b5e1cf5e05708c3c8bb864859 for later work (after upstream flashrom project fixes its `flashrom --progress` reporting under https://ticket.coreboot.org/issues/390)
- Have https://github.com/osresearch/heads/blob/master/patches/flashrom-b1f858f65b2abd276542650d8cb9e382da258967/0100-enable-kgpe-d16.patch upstreamed at least under https://github.com/Dasharo/flashrom/ if not upstream

-----
EDIT: 
- massively edited after having tested usage of master `flashrom --progress` implementation under comment https://github.com/osresearch/heads/pull/1230#issuecomment-1293705754. We cannot use `flashrom --progress` today: that would leave the user in uncertainty under flashing operation (12 seconds with flashing status staying at 100% is really worrying UX).
- [642338e](https://github.com/osresearch/heads/pull/1230/commits/642338e3778b31698b334e56a11e5310cda24415) is equivalent of https://github.com/osresearch/heads/pull/1230#issuecomment-1289415457 which was tested for regression on master