### PR TITLE
Bump coreboot 4.13 based boards to 4.18

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -5,7 +5,7 @@
 # Nitrokey Pro can also be used by forwarding the USB device from the host to
 # the VM.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=5.10.5
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-fbwhiptail-tpm1-hotp.config

--- a/boards/qemu-coreboot-fbwhiptail/qemu-coreboot-fbwhiptail.config
+++ b/boards/qemu-coreboot-fbwhiptail/qemu-coreboot-fbwhiptail.config
@@ -3,7 +3,7 @@
 #
 # Note that the TPM does not work.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-fbwhiptail.config

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -3,7 +3,7 @@
 #
 # TPM can be used with a qemu software TPM (TIS, 1.2).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=5.10.5
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-whiptail-tpm1.config

--- a/boards/qemu-coreboot/qemu-coreboot.config
+++ b/boards/qemu-coreboot/qemu-coreboot.config
@@ -4,7 +4,7 @@
 # Note that the TPM does not work, so this
 # will just drop into the recovery shell.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu.config

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -9,7 +9,7 @@
 # - dropbear
 
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t420-hotp-maximized.config

--- a/boards/t420-maximized/t420-maximized.config
+++ b/boards/t420-maximized/t420-maximized.config
@@ -8,7 +8,7 @@
 # Doesn't include (to fit in 7mb image)
 # - dropbear
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t420-maximized.config

--- a/boards/t420/t420.config
+++ b/boards/t420/t420.config
@@ -1,6 +1,6 @@
 # Configuration for a t420 running Qubes 4.1 and other OS, X220 is identical to X230 on the Linux Side of things.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t420.config

--- a/boards/t430-flash/t430-flash.config
+++ b/boards/t430-flash/t430-flash.config
@@ -1,7 +1,7 @@
 # Minimal configuration for a t430 to support flashrom and USB
 
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_FLASHROM=y

--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -7,7 +7,7 @@
 #
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t430-hotp-maximized.config

--- a/boards/t430-hotp-verification/t430-hotp-verification.config
+++ b/boards/t430-hotp-verification/t430-hotp-verification.config
@@ -8,7 +8,7 @@
 # Addition vs standard x230 board config:
 # HOTP_KEY: HOTP challenge for currently supported USB Security dongles
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t430-hotp-verification.config

--- a/boards/t430-maximized/t430-maximized.config
+++ b/boards/t430-maximized/t430-maximized.config
@@ -7,7 +7,7 @@
 #
 # - DOES NOT INCLUDE Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t430-maximized.config

--- a/boards/t430/t430.config
+++ b/boards/t430/t430.config
@@ -5,7 +5,7 @@
 # dropbear support(ssh client/server)
 # e1000e (ethernet driver)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t430.config

--- a/boards/t520-hotp-maximized/t520-hotp-maximized.config
+++ b/boards/t520-hotp-maximized/t520-hotp-maximized.config
@@ -5,7 +5,7 @@
 # - Forged 00:DE:AD:C0:FF:EE MAC address  (if not extracting gbe.bin from backup with blobs/xx20/extract.sh)
 #   - Note that this MAC address can be modified under build/coreboot-VER/util/bincfg/gbe-82579LM.set
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t520-hotp-maximized.config

--- a/boards/t520-maximized/t520-maximized.config
+++ b/boards/t520-maximized/t520-maximized.config
@@ -5,7 +5,7 @@
 # - Forged 00:DE:AD:C0:FF:EE MAC address  (if not extracting gbe.bin from backup with blobs/xx20/extract.sh)
 #   - Note that this MAC address can be modified under build/coreboot-VER/util/bincfg/gbe-82579LM.set
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t520-maximized.config

--- a/boards/t530-dgpu-hotp-maximized/t530-dgpu-hotp-maximized.config
+++ b/boards/t530-dgpu-hotp-maximized/t530-dgpu-hotp-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a t530 with a dGPU. Initialization of the dGPU is necessary in order to use an external monitor via the DisplayPort (either the in-built mini-DisplayPort or the DisplayPort in the dock). In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t530-dgpu-hotp-maximized.config

--- a/boards/t530-dgpu-maximized/t530-dgpu-maximized.config
+++ b/boards/t530-dgpu-maximized/t530-dgpu-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a t530 with a dGPU. Initialization of the dGPU is necessary in order to use an external monitor via the DisplayPort (either the in-built mini-DisplayPort or the DisplayPort in the dock). In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t530-dgpu-maximized.config

--- a/boards/t530-hotp-maximized/t530-hotp-maximized.config
+++ b/boards/t530-hotp-maximized/t530-hotp-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a t530 without a dGPU. It will work just fine for a board with a dGPU, except you will not be able to use an external monitor via the mini-displayport or the dock's displayport, though external monitors will work via VGA ports. To initialize the dGPU please use one of the dgpu boards.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t530-hotp-maximized.config

--- a/boards/t530-maximized/t530-maximized.config
+++ b/boards/t530-maximized/t530-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a t530 without a dGPU. It will work just fine for a board with a dGPU, except you will not be able to use an external monitor via the mini-displayport or the dock's displayport, though external monitors will work via VGA ports. To initialize the dGPU please use one of the dgpu boards.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-t530-maximized.config

--- a/boards/w530-dgpu-K1000m-hotp-maximized/w530-dgpu-K1000m-hotp-maximized.config
+++ b/boards/w530-dgpu-K1000m-hotp-maximized/w530-dgpu-K1000m-hotp-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a w530 with the K1000M Nvidia Quadro dGPU. Initialization of the dGPU is necessary in order to use an external monitor whether through the in-build VGA or mini-DisplayPort or via the dock. In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-dgpu-K1000m-hotp-maximized.config

--- a/boards/w530-dgpu-K1000m-maximized/w530-dgpu-K1000m-maximized.config
+++ b/boards/w530-dgpu-K1000m-maximized/w530-dgpu-K1000m-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a w530 with the K1000M Nvidia Quadro dGPU. Initialization of the dGPU is necessary in order to use an external monitor whether through the in-build VGA or mini-DisplayPort or via the dock. In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-dgpu-K1000m-maximized.config

--- a/boards/w530-dgpu-K2000m-hotp-maximized/w530-dgpu-K2000m-hotp-maximized.config
+++ b/boards/w530-dgpu-K2000m-hotp-maximized/w530-dgpu-K2000m-hotp-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a w530 with the K2000M Nvidia Quadro dGPU. Initialization of the dGPU is necessary in order to use an external monitor whether through the in-build VGA or mini-DisplayPort or via the dock. In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-dgpu-K2000m-hotp-maximized.config

--- a/boards/w530-dgpu-K2000m-maximized/w530-dgpu-K2000m-maximized.config
+++ b/boards/w530-dgpu-K2000m-maximized/w530-dgpu-K2000m-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board is designed for a w530 with the K2000M Nvidia Quadro dGPU. Initialization of the dGPU is necessary in order to use an external monitor whether through the in-build VGA or mini-DisplayPort or via the dock. In order to build this the relevant script in the blobs directory must be run (or self-pulled roms placed in that directory) and after building the rom, the nvramtool must be run on the 12MB rom to change the default graphics mode away from integrated-only graphics (see README_vbios in the blobs directory).
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-dgpu-K2000m-maximized.config

--- a/boards/w530-hotp-maximized/w530-hotp-maximized.config
+++ b/boards/w530-hotp-maximized/w530-hotp-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board ignores the in-built dGPU that comes with all w530's. In doing so the dGPU will not be initialized. This has some benefits in terms of reduced complexity in working with OS's with poor support for NVIDIA, better battery life and lower heat (making use of the thicker heatsink from a dGPU). Conversely, if you do not initialize the dGPU you will be unable to use an external monitor. To initialize the dGPU please use the dGPU boards that corresponds with the model of dGPU included with your device.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-hotp-maximized.config

--- a/boards/w530-maximized/w530-maximized.config
+++ b/boards/w530-maximized/w530-maximized.config
@@ -8,7 +8,7 @@
 # - Includes Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # This board ignores the in-built dGPU that comes with all w530's. In doing so the dGPU will not be initialized. This has some benefits in terms of reduced complexity in working with OS's with poor support for NVIDIA, better battery life and lower heat (making use of the thicker heatsink from a dGPU). Conversely, if you do not initialize the dGPU you will be unable to use an external monitor. To initialize the dGPU please use the dGPU boards that corresponds with the model of dGPU included with your device.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-w530-maximized.config

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -9,7 +9,7 @@
 # - dropbear
 
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x220-hotp-maximized.config

--- a/boards/x220-maximized/x220-maximized.config
+++ b/boards/x220-maximized/x220-maximized.config
@@ -9,7 +9,7 @@
 # - dropbear
 
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x220-maximized.config

--- a/boards/x220/x220.config
+++ b/boards/x220/x220.config
@@ -1,6 +1,6 @@
 # Configuration for a x220 running Qubes 4.1 and other OS, X220 is identical to X230 on the Linux Side of things.
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x220.config

--- a/boards/x230-flash/x230-flash.config
+++ b/boards/x230-flash/x230-flash.config
@@ -1,7 +1,7 @@
 # Minimal configuration for a x230 to support flashrom and USB
 
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_FLASHROM=y

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -7,7 +7,7 @@
 #
 # - Includes: Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x230-hotp-maximized.config

--- a/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
+++ b/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
@@ -9,7 +9,7 @@
 # 	Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 # 	USB Keyboard support
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x230-hotp-maximized_usb-kb.config

--- a/boards/x230-hotp-verification/x230-hotp-verification.config
+++ b/boards/x230-hotp-verification/x230-hotp-verification.config
@@ -8,7 +8,7 @@
 # Addition vs standard x230 board config:
 # HOTP_KEY: HOTP challenge for currently supported USB Security dongles
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x230-hotp-verification.config

--- a/boards/x230-maximized/x230-maximized.config
+++ b/boards/x230-maximized/x230-maximized.config
@@ -7,7 +7,7 @@
 #
 # - DOES NOT INCLUDE Nitrokey/Librem Key HOTP Security dongle remote attestation (in addition to TOTP remote attestation through Qr Code)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x230-maximized.config

--- a/boards/x230/x230.config
+++ b/boards/x230/x230.config
@@ -4,7 +4,7 @@
 # dropbear support(ssh client/server)
 # e1000e (ethernet driver)
 export CONFIG_COREBOOT=y
-export CONFIG_COREBOOT_VERSION=4.13
+export CONFIG_COREBOOT_VERSION=4.18
 export CONFIG_LINUX_VERSION=4.14.62
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-x230.config

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -35,6 +35,12 @@ else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.17"
 	coreboot-blobs_hash := a2277fe7a2b2aab5da0aa335158460e00b852382f6736f2179992805702eb607
 	coreboot_depends := $(if $(CONFIG_PURISM_BLOBS), purism-blobs)
 	EXTRA_FLAGS := -fdebug-prefix-map=$(pwd)=heads -gno-record-gcc-switches -Wno-error=packed-not-aligned -Wno-error=address-of-packed-member
+else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.18"
+        coreboot_version := 4.18
+        coreboot_hash := 068f242857911c52090ecbf586a65802c5dead6c82e8bf2047d10ce8e5f28128
+        coreboot-blobs_hash := 50b695724874900731c92b820dc30b2c26f27f53b81018c7bd8709e612274c1d
+        coreboot_depends := $(if $(CONFIG_PURISM_BLOBS), purism-blobs)
+        EXTRA_FLAGS := -fdebug-prefix-map=$(pwd)=heads -gno-record-gcc-switches -Wno-error=packed-not-aligned -Wno-error=address-of-packed-member
 else ifeq "$(CONFIG_COREBOOT_VERSION)" "talos_2"
 	coreboot_version = git
 	coreboot_commit_hash = 2207bbcccba31ad89cf21607b0d8d05d8dc47c03


### PR DESCRIPTION
No config change on that one. Just a coreboot version bump for all boards that were pinned to coreboot 4.13

-------

Logic on that is that a lot of coreboot defaults are now under defconfig for unknown reasons from me. Copying actual x230-hotp-maximized coreboot config over 4.18/.config, make savedefconfig and comparing with saved in tree defconfig results in:
```
user@heads-tests:~/heads/build/x86/coreboot-4.18$ diff defconfig ../../../config/coreboot-x230-hotp-maximized.config
8d7
< CONFIG_CONSOLE_CBMEM_BUFFER_SIZE=0x80000
10,12d8
< CONFIG_PCIEXP_HOTPLUG_BUSES=8
< CONFIG_PCIEXP_HOTPLUG_MEM=0x800000
< CONFIG_PCIEXP_HOTPLUG_PREFETCH_MEM=0x10000000
14a11
> CONFIG_UART_PCI_ADDR=0
18,21d14
< CONFIG_PCIEXP_HOTPLUG_IO=0x2000
< CONFIG_SUBSYSTEM_VENDOR_ID=0x0000
< CONFIG_SUBSYSTEM_DEVICE_ID=0x0000
< CONFIG_I2C_TRANSFER_TIMEOUT_US=500000
23a17
> CONFIG_CONSOLE_CBMEM_BUFFER_SIZE=0x80000
```
Only `CONFIG_CONSOLE_CBMEM_BUFFER_SIZE=0x80000` changed position in config file.

Which no other config parameters there changed compared to defaults, so those are simply not written back under config/coreboot* as of now. And saving them into non-savedefconfig should be subject to discussion under another issue, where past discussions were advertising into keeping configs under tree as savedefconfig output. 
So I'm following this without agreeing for the moment.


Activating other new features that happened since  4.13, like BOM, CBFS file measurements (not TPM but bootblock based) or on boot memory wipe (needs additional boot time, untested) will need additional discussions with the community prior of being added. Personally, I would addmemory wiping on boot as default for all boards supporting it.


-----

Testing that was done

- [x] all 4.13 previous board configs built 4.18 without errors under https://app.circleci.com/pipelines/github/tlaurion/heads/1245/workflows/e4753fab-b47d-41d7-9d20-41d468b849dd
- [x] x230-maximized flashed from master with cbfs configuration persistence
- [x] x230-maximized reflash with still valid TOTP
- [x] suspend/resume worked for x230-maximized under Qubes 4.1.1

Other platforms tested:
- [x] x220 (xx20): @srgrint 
- [x] [t420](https://doc.coreboot.org/mainboard/lenovo/t420.html) (xx20): @natterangell (iGPU) 
- [x] [t430](https://doc.coreboot.org/mainboard/lenovo/t430.html) (xx30): @weyounsix (t430-dgpu)
- [x] [w530](https://doc.coreboot.org/mainboard/lenovo/w530.html) (xx30): @weyounsix (dGPU: w530-k2000m) 
- [ ] [t520](https://doc.coreboot.org/mainboard/lenovo/t520.html) (xx30): @eganonoa
- [ ] [t530](https://doc.coreboot.org/mainboard/lenovo/t530.html) (xx30): @eganonoa
