### PR TITLE
Ignore grub device specs in boot entry paths

### DIFF
--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -94,11 +94,17 @@ grub_entry() {
 			modules="$modules|module $path"
 			;;
 		linux*)
-			kernel=`echo $trimcmd | cut -d\  -f2`
+			# Some configs have a device specification in the kernel
+			# or initrd path.  Assume this would be /boot and remove
+			# it.  Keep the '/' following the device, since this
+			# path is relative to the device root, not the config
+			# location.
+			kernel=`echo $trimcmd | sed "s/([^)]*)//g" | cut -d\  -f2`
 			append=`echo $trimcmd | cut -d\  -f3-`
 			;;
 		initrd*)
-			initrd="$val"
+			# Trim off device specification as above
+			initrd="$(echo "$val" | sed "s/([^)]*)//g")"
 			;;
 	esac
 }

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -39,41 +39,41 @@ check_path() {
 }
 
 echo_entry() {
-	if [ "$kexectype" = "elf" ]; then
-		if [ -z "$kernel" ]; then return; fi
+	if [ -z "$kernel" ]; then return; fi
 
-		fix_path $kernel
-		# The kernel must exist - if it doesn't, ignore this entry, it
-		# wouldn't work anyway.  This could happen if there was a
-		# GRUB variable in the kernel path, etc.
-		if ! check_path "$path"; then return; fi
-		entry="$name|$kexectype|kernel $path"
-		if [ -n "$initrd" ]; then
-			for init in $(echo $initrd | tr ',' ' '); do
-				fix_path $init
-				# The initrd must also exist
-				if ! check_path "$path"; then return; fi
-				entry="$entry|initrd $path"
-			done
-		fi
-		if [ -n "$append" ]; then
-			entry="$entry|append $append"
-		fi
+	fix_path $kernel
+	# The kernel must exist - if it doesn't, ignore this entry, it
+	# wouldn't work anyway.  This could happen if there was a
+	# GRUB variable in the kernel path, etc.
+	if ! check_path "$path"; then return; fi
+	entry="$name|$kexectype|kernel $path"
 
-		# Double-expand here in case there are variables in the kernel
-		# parameters - some configs do this and can boot with empty
-		# expansions (Debian Live ISOs use this for loopback boots)
-		echo $(eval "echo \"$entry\"")
-	fi
-	if [ "$kexectype" = "multiboot" -o "$kexectype" = "xen" ]; then
-		if [ -z "$kernel" ]; then return; fi
+	case "$kexectype" in
+		elf)
+			if [ -n "$initrd" ]; then
+				for init in $(echo $initrd | tr ',' ' '); do
+					fix_path $init
+					# The initrd must also exist
+					if ! check_path "$path"; then return; fi
+					entry="$entry|initrd $path"
+				done
+			fi
+			if [ -n "$append" ]; then
+				entry="$entry|append $append"
+			fi
+			;;
+		multiboot|xen)
+			entry="$entry$modules"
+			;;
+		*)
+			return
+			;;
+	esac
 
-		fix_path $kernel
-		# The kernel must exist
-		if ! check_path "$path"; then return; fi
-		# Double-expand to clear variable expansions
-		echo $(eval "echo \"$name|$kexectype|kernel $path$modules\"")
-	fi
+	# Double-expand here in case there are variables in the kernel
+	# parameters - some configs do this and can boot with empty
+	# expansions (Debian Live ISOs use this for loopback boots)
+	echo $(eval "echo \"$entry\"")
 }
 
 search_entry() {

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -28,15 +28,31 @@ fix_path() {
 	fi
 }
 
+# GRUB kernel lines (linux/multiboot) can include a command line.  Check whether
+# the file path exists in $bootdir.
+check_path() {
+	local checkpath firstval
+	checkpath="$1"
+	firstval="$(echo "$checkpath" | cut -d\  -f1)"
+	if ! [ -r "$bootdir$firstval" ]; then return 1; fi
+	return 0
+}
+
 echo_entry() {
 	if [ "$kexectype" = "elf" ]; then
 		if [ -z "$kernel" ]; then return; fi
 
 		fix_path $kernel
+		# The kernel must exist - if it doesn't, ignore this entry, it
+		# wouldn't work anyway.  This could happen if there was a
+		# GRUB variable in the kernel path, etc.
+		if ! check_path "$path"; then return; fi
 		entry="$name|$kexectype|kernel $path"
 		if [ -n "$initrd" ]; then
 			for init in $(echo $initrd | tr ',' ' '); do
 				fix_path $init
+				# The initrd must also exist
+				if ! check_path "$path"; then return; fi
 				entry="$entry|initrd $path"
 			done
 		fi
@@ -44,12 +60,18 @@ echo_entry() {
 			entry="$entry|append $append"
 		fi
 
+		# Double-expand here in case there are variables in the kernel
+		# parameters - some configs do this and can boot with empty
+		# expansions (Debian Live ISOs use this for loopback boots)
 		echo $(eval "echo \"$entry\"")
 	fi
 	if [ "$kexectype" = "multiboot" -o "$kexectype" = "xen" ]; then
 		if [ -z "$kernel" ]; then return; fi
 
 		fix_path $kernel
+		# The kernel must exist
+		if ! check_path "$path"; then return; fi
+		# Double-expand to clear variable expansions
 		echo $(eval "echo \"$name|$kexectype|kernel $path$modules\"")
 	fi
 }


### PR DESCRIPTION
Fixes #1239, #1001

Ignore device specs in GRUB boot entry paths, assume they point to /boot.  Check that boot kernel and initrd are valid files; ignore options that would not be able to boot.

Tested booting the following ISOs (directly written to USB disk): Debian (live KDE, netinst still has graphics init issues), Fedora KDE, Qubes, PureOS.

Tested booting Qubes ISO from ext4-formatted USB disk (loopback ISO boot).

Tested booting installed PureOS and Qubes.