### PR TITLE
Add CONFIG_BOOT_RECOVERY_SERIAL to qemu board configs to interact with host through serial

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -53,6 +53,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -51,6 +51,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 


### PR DESCRIPTION
As a result, you will get expected pause_recovery (etc/functions) output "Hit enter to proceed to recovery shell:" prompt on ttyS0 (stdio: where qemu is launched) while whiptail is shown only once on host (qemu/kvm). 

This is important in case of TPM, since entering recovery shell will invalidate measurements and prevent TPM disk encryption key to be unsealed if going to recovery shell.

By removing the CONFIG_BOOT_RECOVERY_SERIAL board configuration export, only dmesg is redirected to ttyS0 (helpful to debug)