### PR TITLE
gui-init: Always go to main menu when selecting "continue to main menu"

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -9,6 +9,12 @@ export BG_COLOR_MAIN_MENU=""
 . /etc/luks-functions
 . /tmp/config
 
+# skip_to_menu is set if the user selects "continue to the main menu" from any
+# error, so we will indeed go to the main menu even if other errors occur.  It's
+# reset when we reach the main menu so the user can retry from the main menu and
+# # see errors again.
+skip_to_menu="false"
+
 mount_boot()
 {
   
@@ -45,7 +51,7 @@ mount_boot()
         exec /bin/usb-init
         ;;
       m )
-        skip_gpg_check="true"
+        skip_to_menu="true"
         break
         ;;
       * )
@@ -163,6 +169,9 @@ update_totp()
     TOTP=`unseal-totp`
     if [ $? -ne 0 ]; then
       BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+      if [ "$skip_to_menu" = "true" ]; then
+        return 1  # Already asked to skip to menu from a prior error
+      fi
       whiptail $BG_COLOR_ERROR --title "ERROR: TOTP Generation Failed!" \
         --menu "    ERROR: Heads couldn't generate the TOTP code.\n
   If you have just completed a Factory Reset, or just reflashed
@@ -186,6 +195,7 @@ update_totp()
           fi
           ;;
         i )
+          skip_to_menu="true"
           return 1
           ;;
         p )
@@ -204,6 +214,9 @@ update_hotp()
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
     if ! hotp_verification info ; then
+      if [ "$skip_to_menu" = "true" ]; then
+        return 1  # Already asked to skip to menu from a prior error
+      fi
       if ! whiptail $BG_COLOR_WARNING \
           --title "WARNING: Please Insert Your $HOTPKEY_BRANDING" \
           --yes-button "Retry" --no-button "Skip" \
@@ -214,13 +227,13 @@ update_hotp()
       fi
     fi
     # Don't output HOTP codes to screen, so as to make replay attacks harder
-    hotp_verification check $HOTP
+    hotp_verification check "$HOTP"
     case "$?" in
       0 )
         HOTP="Success"
         BG_COLOR_MAIN_MENU=""
       ;;
-      4 )
+      4|7 )	# 4: code was incorrect, 7: code was not a valid HOTP code at all
         HOTP="Invalid code"
         BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
       ;;
@@ -267,6 +280,9 @@ check_gpg_key()
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+    if [ "$skip_to_menu" = "true" ]; then
+      return 1  # Already asked to skip to menu from a prior error
+    fi
     whiptail $BG_COLOR_ERROR --title "ERROR: GPG keyring empty!" \
       --menu "ERROR: Heads couldn't find any GPG keys in your keyring.\n\nIf this is the first time the system has booted,\nyou should add a public GPG key to the BIOS now.\n\nIf you just reflashed a new BIOS, you'll need to add at least one\npublic key to the keyring.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 0 80 4 \
       'g' ' Add a GPG key to the running BIOS' \
@@ -281,6 +297,7 @@ check_gpg_key()
         gpg-gui.sh && BG_COLOR_MAIN_MENU=""
         ;;
       i )
+        skip_to_menu="true"
         return 1
         ;;
       F )
@@ -328,7 +345,8 @@ show_main_menu()
       attempt_default_boot
       ;;
     r )
-      update_totp && update_hotp
+      update_totp
+      update_hotp
       ;;
     o )
       show_options_menu
@@ -571,15 +589,18 @@ else
 fi
 
 # detect whether any GPG keys exist in the keyring, if not, initialize that first
-[[ "$skip_gpg_check" != "true" ]] && check_gpg_key
-
-update_totp && update_hotp
+check_gpg_key
+# Even if GPG init fails, still try to update TOTP/HOTP so the main menu can
+# show the correct status.
+update_totp
+update_hotp
 
 if [[ "$HOTP" = "Success" && $CONFIG_AUTO_BOOT_TIMEOUT ]]; then
   prompt_auto_default_boot
 fi
 
 while true; do
+  skip_to_menu="false"
   show_main_menu
 done
 


### PR DESCRIPTION
If the user selects "continue to main menu" from an error, do not show any more error prompts until reaching the main menu.

We still try to initialize everything (GPG, TOTP, HOTP) so that the main menu can still show TOTP/HOTP if GPG is not configured, etc., but no more prompts are shown after selecting "continue to main menu".

Signed-off-by: Jonathon Hall <jonathon.hall@puri.sm>