### PR TITLE
gui-init: show boot option was not returning when verify_global_hash failed

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -535,9 +535,12 @@ show_system_info()
 select_os_boot_option()
 {
   mount_boot
-  if verify_global_hashes ; then
-    kexec-select-boot -m -b /boot -c "grub.cfg" -g
+  
+  if ! verify_global_hashes ; then
+    return
   fi
+  
+  kexec-select-boot -m -b /boot -c "grub.cfg" -g
 }
 
 attempt_default_boot()

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -253,11 +253,13 @@ check_config() {
 	fi
 
 	if [ ! -r $1/kexec.sig ]; then
-		warn '$1/kexec.sig detached signature not found. Generate new checksums and sign boot content?'
-	fi
+		warn "$1/kexec.sig detached signature not found. Generate new checksums and sign boot content??
+		return 1
+fi
 
 	if [ `find $1/kexec*.txt | wc -l` -eq 0 ]; then
-		warn '$1/kexec*.txt not found. Generate new checksums and sign /boot content?'
+		warn "$1/kexec*.txt not found. Generate new checksums and sign /boot content?"
+		return 1
 	fi
 
 	if [ "$2" != "force" ]; then

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -255,11 +255,11 @@ check_config() {
 	fi
 
 	if [ ! -r $1/kexec.sig ]; then
-		return
+		warn '$1/kexec.sig detached signature not found. Generate new checksums and sign boot content?'
 	fi
 
 	if [ `find $1/kexec*.txt | wc -l` -eq 0 ]; then
-		return
+		warn '$1/kexec*.txt not found. Generate new checksums and sign /boot content?'
 	fi
 
 	if [ "$2" != "force" ]; then

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -38,8 +38,6 @@ recovery() {
 		else
 			/bin/ash
 		fi
-		# clear screen
-		printf "\033c"
 	done
 }
 
@@ -309,8 +307,6 @@ combine_configs() {
 
 update_checksums()
 {
-	# clear screen
-	printf "\033c"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \


### PR DESCRIPTION
~Fixes #1257~
Nope