### PR TITLE
Makefile: Use path agnostic bash location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(shell mkdir -p "$(initrd_lib_dir)" "$(initrd_bin_dir)")
 # proceed with the build.
 
 # Force pipelines to fail if any of the commands in the pipe fail
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 .SHELLFLAGS := -o pipefail -c
 
 # Include the musl-cross module early so that $(CROSS) will


### PR DESCRIPTION
This patch changes the bash location in the makefile from /bin/bash to /usr/bin/env bash. The latter is a more reproducible location as it is common to more *nix systems which don't contain the former, such as NixOS.