### PR TITLE
coreboot-4.11: Fix remaining patch to work with git apply

### DIFF
--- a/patches/coreboot-4.11/0073-build-race-condition-fixes.patch
+++ b/patches/coreboot-4.11/0073-build-race-condition-fixes.patch
@@ -16,11 +16,10 @@ Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
 Reviewed-by: Aaron Durbin <adurbin@chromium.org>
 
 diff --git a/src/arch/x86/Makefile.inc b/src/arch/x86/Makefile.inc
-index 6297384..1a1aa40 100644
+index cc094d1..132c6d8 100644
 --- a/src/arch/x86/Makefile.inc
 +++ b/src/arch/x86/Makefile.inc
-
-@@ -50,7 +50,7 @@
+@@ -56,7 +56,7 @@ pci$(stripped_vgabios_dgpu_id).rom-type := optionrom
  # into a single generated file.
  crt0s = $(cpu_incs-y)
  
@@ -28,3 +27,4 @@ index 6297384..1a1aa40 100644
 +$(objgenerated)/assembly.inc: build-dirs $$(crt0s)
  	@printf "    GEN        $(subst $(obj)/,,$(@))\n"
  	printf '$(foreach crt0,$(crt0s),#include "$(crt0)"\n)' > $@
+ 


### PR DESCRIPTION
The last PR fixing these patches missed this one because it was mistakenly deleted and restored later.  Resulted in 'error: patch with only garbage at line 22'.

Built librem_l1um on Debian 11 host to verify.

Signed-off-by: Jonathon Hall <jonathon.hall@puri.sm>