### PR TITLE
qemu-coreboot-whiptail-tpm1: correction of boardname to reflect reality

### DIFF
--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -58,7 +58,7 @@ export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_TPM=y
 
 export CONFIG_BOOT_DEV="/dev/vda1"
-export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1-hotp"
+export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1"
 
 # Use the GPG-injected ROM if a key was given, since we can't reflash a GPG
 # keyring in QEMU.  Otherwise use the plain ROM, some things can still be tested


### PR DESCRIPTION
Trivial fix. Will merge directly: board is not fbwhiptail but whiptail, and not hotp but totp only.