### PR TITLE
Last clear removal add reboot after totp on screen

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -157,6 +157,7 @@ generate_totp_htop()
     echo "Once you have scanned the QR code, hit Enter to continue"
     read
   fi
+  reboot
 }
 
 update_totp()

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -38,8 +38,6 @@ recovery() {
 		else
 			/bin/ash
 		fi
-		# clear screen
-		printf "\033c"
 	done
 }
 
@@ -309,8 +307,6 @@ combine_configs() {
 
 update_checksums()
 {
-	# clear screen
-	printf "\033c"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \


### PR DESCRIPTION
Recently, fbwhiptail calls removed `--clear` as part of calls clearing console output in the goal of facilitating troubleshooting.

Two last `printf clear` existed in the codebase, preventing to see full previous console output in case of errors.
This corrects this.

A separate commit currently adds a reboot after showing TOTP Qrcode on screen, which is basically the only secret showed on screen under heads. This seperate commit adds a `reboot` after asking the user to type a key.

@JonathonHall-Purism : we could alternatively replace that reboot by a `printf clear` if you prefer: let me know and I will change it.