### PR TITLE
recovery call: since we operate under set -e, make sure that shred failing doesn't exit

### DIFF
--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -17,7 +17,9 @@ recovery() {
 
 	# Remove any temporary secret files that might be hanging around
 	# but recreate the directory so that new tools can use it.
-	shred -n 10 -z -u /tmp/secret/* 2> /dev/null
+
+	#safe to always be true. Otherwise "set -e" would make it exit here
+	shred -n 10 -z -u /tmp/secret/* 2> /dev/null || true
 	rm -rf /tmp/secret
 	mkdir -p /tmp/secret
 


### PR DESCRIPTION
This was exposed through testing #1262 and attempting to call `recovery` instead of `die` under proposed changeset under https://github.com/osresearch/heads/pull/1262#issuecomment-1381079323

This should be merged prior of #1262, which should be rebased on top of master.