### PR TITLE
Adjust printf clears

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -157,6 +157,8 @@ generate_totp_htop()
     echo "Once you have scanned the QR code, hit Enter to continue"
     read
   fi
+  # clear screen
+  printf "\033c"
 }
 
 update_totp()

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -38,8 +38,6 @@ recovery() {
 		else
 			/bin/ash
 		fi
-		# clear screen
-		printf "\033c"
 	done
 }
 
@@ -309,8 +307,6 @@ combine_configs() {
 
 update_checksums()
 {
-	# clear screen
-	printf "\033c"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \


### PR DESCRIPTION
Recently, fbwhiptail calls removed --clear as part of calls clearing console output in the goal of facilitating troubleshooting.

This PR:
- removes last two printf clear that were getting in the way of having traces on console output (functions)
- adds only needed printf clear on console, which is after output and scan of TPMTOTP QR code confirmed to be scanned by user (was a reboot under #1275)

Replaces #1275 

@JonathonHall-Purism : please review