### PR TITLE
kexec-save-default: do /boot operation in subshell

### DIFF
--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -122,9 +122,9 @@ if [ ! -d $paramsdir ]; then
 fi
 rm $paramsdir/kexec_default.*.txt 2>/dev/null || true
 echo "$entry" > $ENTRY_FILE
-kexec-boot -b "$bootdir" -e "$entry" -f | \
+( cd $bootdir && kexec-boot -b "$bootdir" -e "$entry" -f| \
 	xargs sha256sum > $HASH_FILE \
-|| die "Failed to create hashes of boot files"
+) || die "Failed to create hashes of boot files"
 if [ ! -r $ENTRY_FILE -o ! -r $HASH_FILE ]; then
 	die "Failed to write default config"
 fi


### PR DESCRIPTION
fixes screwed commit 6f6f37ec3a8d7cab1c963ce4e6614f89132aeecf

@JonathonHall-Purism : otherwise scanning / not /boot
sorry about that.