### PR TITLE
modules/hotp-verification: source libusb headers from Makefile DESTDIR

### DIFF
--- a/modules/hotp-verification
+++ b/modules/hotp-verification
@@ -19,7 +19,7 @@ hotp-verification_output := \
 hotp-verification_configure := \
   INSTALL="$(INSTALL)" \
   CROSS="$(CROSS)" \
-  $(CROSS_TOOLS) $(MAKE) LDFLAGS="$(INSTALL)/lib/libusb-1.0.so" GITVERSION="" LIBUSB_FLAGS="-I/usr/include/libusb-1.0" PKGCONFIG="" && $(MAKE) install INSTALL="$(INSTALL)"
+  $(CROSS_TOOLS) $(MAKE) LDFLAGS="$(INSTALL)/lib/libusb-1.0.so" GITVERSION="" LIBUSB_FLAGS="-I$(INSTALL)/include/libusb-1.0" PKGCONFIG="" && $(MAKE) install INSTALL="$(INSTALL)"
 
 hotp-verification_depends  += hidapi
 modules-y += hidapi


### PR DESCRIPTION
Before, the configure script sourced these from the system FHS (`/usr/include/libusb-1.0`). The build failed on my NixOS build machine, which doesn't store dependencies in a traditional FHS. And this is the correct approach for reproducible builds.

Connects https://github.com/osresearch/heads/issues/734

---

**Testing**

See: https://github.com/osresearch/heads/pull/1282.
