### PR TITLE
modules/musl-cross: use echo from the PATH to support NixOS

### DIFF
--- a/modules/musl-cross
+++ b/modules/musl-cross
@@ -34,8 +34,8 @@ else
 # Force a full build of the cross compiler for target platform
 # No need to build i386 for x86 since coreboot uses its own compiler
 musl-cross_configure := \
-	/bin/echo -e >> Makefile 'musl-target:' ; \
-	/bin/echo -e >> Makefile '\t$$$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ;
+	echo -e >> Makefile 'musl-target:' ; \
+	echo -e >> Makefile '\t$$$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ;
 
 CROSS_PATH ?= $(pwd)/crossgcc/$(CONFIG_TARGET_ARCH)
 


### PR DESCRIPTION
NixOS doesn't have a traditional FHS where echo is available at `/bin/echo`. Instead, we must rely on the PATH for any distribution-managed utilities. Reverses https://github.com/osresearch/heads/issues/106.

---

**Testing**

See: https://github.com/osresearch/heads/pull/1282/.