### PR TITLE
Add overrides for Makefile syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.config linguist-language=Makefile
+modules/* linguist-language=Makefile


### PR DESCRIPTION
Fix GitHub syntax highlighting for the Coreboot/Heads config files, and modules, which are all Makefiles.

See: https://github.com/github/linguist/blob/master/docs/overrides.md