### PR TITLE
/etc/functions: fix detection of virtual flash drive in qemu.

### DIFF
--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -155,7 +155,16 @@ list_usb_storage()
 			# never usable directly, and this allows the "wait for
 			# disks" loop in mount-usb to correctly wait for the
 			# partitions.
-			if fdisk -l "$b" | grep -q "doesn't contain a valid partition table"; then
+			# This check: [ $(fdisk -l "$b" | wc -l) -eq 5 ]
+			# covers the case of a device without partition table but
+			# formatted as fat32, which contains a sortof partition table.
+			# this causes fdisk to not print the invalid partition table
+			# message and instead it'll print an empty table with header.
+			# In both cases the output is 5 lines: 3 about device info,
+			# 1 empty line and the 5th will be the table header or the
+			# unvalid message.
+			DISK_DATA=$(fdisk -l "$b")
+			if echo "$DISK_DATA" | grep -q "doesn't contain a valid partition table" || [ $(echo "$DISK_DATA" | wc -l) -eq 5 ]; then
 				# No partition table, include this device
 				echo "$b"
 			else


### PR DESCRIPTION
Adds check to detect device formatted as fat32 without partition table.

With fat32 fdisk does not print message about invalid partition table and instead it'll print an empty table with header. In both cases total output has the same length of 5 lines: 3 about device info, 1 empty line and the 5th will be the table header or invalid partition message.

So the amount of lines fdisk outputs is used to detect if it's a formatted device without partition table.

This fixes #1274 

Sample image of the empty table fdisk outputs.
![Screenshot from 2023-01-17 12-28-39](https://user-images.githubusercontent.com/17953536/213252713-944bcf8f-0312-4f2d-bd4f-9af86dab918f.png)

Device format cases tested:
- Fat32 without partition table.
- Ext4 without partition table.
- MBR with single fat32 partition.
- GPT with single ext4 partition.
- USB drive with flashed live ISO
