### PR TITLE
gui-init: warn the user when sealing measurements through TOTP/HOTP reset

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -149,17 +149,20 @@ prompt_update_checksums()
 generate_totp_htop()
 {
   echo "Scan the QR code to add the new TOTP secret"
-  /bin/seal-totp "$BOARD_NAME"
-  if [ -x /bin/hotp_verification ]; then
-    echo "Once you have scanned the QR code, hit Enter to configure your HOTP USB Security Dongle (e.g. Librem Key or Nitrokey)"
-    read
-    /bin/seal-hotpkey
+  if /bin/seal-totp "$BOARD_NAME"; then
+    if [ -x /bin/hotp_verification ]; then
+      echo "Once you have scanned the QR code, hit Enter to configure your HOTP USB Security Dongle (e.g. Librem Key or Nitrokey)"
+      read
+      /bin/seal-hotpkey
+    else
+      echo "Once you have scanned the QR code, hit Enter to continue"
+      read
+    fi
+    # clear screen
+    printf "\033c"
   else
-    echo "Once you have scanned the QR code, hit Enter to continue"
-    read
+    warn "Sealing of measurements inside of TPM failed. You might want to take ownership of TPM by resetting it."
   fi
-  # clear screen
-  printf "\033c"
 }
 
 update_totp()


### PR DESCRIPTION
Fixes #1290 by calling warn if sealing-totp failed (nvram/ownership invalid) to tell user he should reset TPM first.
This happens on non-reset TPM only where sealing/unsealing fails, see #1290 for details.

![2023-01-19-145713](https://user-images.githubusercontent.com/827570/213548912-b7cdd1ac-dc55-4ecb-ae48-ea4b3df1d7ca.png)


----

Note that all `die` calls gui-init will die (exiting init). 
Any other script called by gui-init calling die function as expected.

@JonathonHall-Purism 