### PR TITLE
usb-scan->media-scan: usb-init calling media-scan usb

### DIFF
--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -11,8 +11,19 @@ if grep -q /boot /proc/mounts ; then
 		|| die "Unable to unmount /boot"
 fi
 
-# Mount the USB boot device
-mount_usb || die "Unable to mount /media"
+available_partitions="$(blkid | while read line; do echo $line | awk -F ":" {'print $1'}; done )"
+
+if [ "$1" == "usb" ]; then
+	# Mount the USB boot device
+	mount_usb || die "Unable to mount /media"
+elif $(echo $available_partitions | grep -q "$1"); then
+	if grep -q /media /proc/mounts; then
+		umount /media \
+			|| die "Unable to unmount /media"
+	fi
+	mount "$1" /media \
+		|| die "Unable to mount $1 to /media"
+fi
 
 # Get USB boot device
 USB_BOOT_DEV=$(grep "/media" /etc/mtab | cut -f 1 -d' ')

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -9,5 +9,5 @@ if [ "$CONFIG_TPM" = "y" ]; then
 	tpm extend -ix 4 -ic usb
 fi
 
-usb-scan
+media-scan usb
 recovery "Something failed during USB boot"


### PR DESCRIPTION
media-scan accepts direct input of existing blkid and mount that passed device to /media