### PR TITLE
Set forcesig if "not forced" after reset

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -87,6 +87,19 @@ gpg_key_reset()
     if lsusb | grep -q "20a0:4109" &&  [ -x /bin/hotp_verification ] ; then
         /bin/hotp_verification regenerate ${ADMIN_PIN_DEF}
     fi
+    # Toggle forced sig (good security practice, forcing PIN request for each signature request)
+    if gpg --card-status | grep "Signature PIN" | grep -q "not forced"; then
+        {
+            echo admin
+            echo forcesig
+            echo ${ADMIN_PIN_DEF}
+        } | gpg --command-fd=0 --status-fd=1 --pinentry-mode=loopback --card-edit \
+            > /tmp/gpg_card_edit_output 2>/dev/null
+        if [ $? -ne 0 ]; then
+            ERROR=`cat /tmp/gpg_card_edit_output`
+            whiptail_error_die "GPG Key forcesig toggle on failed!\n\n$ERROR"
+        fi
+    fi
     # Set RSA key length
     {
         echo admin


### PR DESCRIPTION
Fixes  #1076 and closes [heads-wiki#102](https://github.com/osresearch/heads-wiki/issues/102)

Code is from https://github.com/osresearch/heads-wiki/issues/102#issuecomment-1255464870 but instead of making a function and call, it's incorporated into the `gpg_key_reset` function after the Nitrokey AES key reset.

**To-Do:**
- [x] Compile
- [x] Flash
- [x] Verify oem-factory-reset
  - [x] Yubikey
  - [x] Nitrokey (Don't have the hardware to verify)