### PR TITLE
Add DEBUG statements in code and fix "sh: argument expected"

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -8,6 +8,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.13
 export CONFIG_LINUX_VERSION=5.10.5
 
+#Enable DEBUG output
+export CONFIG_DEBUG_OUTPUT=y
+
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -10,6 +10,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
+export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -6,6 +6,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.13
 export CONFIG_LINUX_VERSION=5.10.5
 
+#Enable DEBUG output
+export CONFIG_DEBUG_OUTPUT=y
+
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -8,6 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
+export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -8,6 +8,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.13
 export CONFIG_LINUX_VERSION=5.10.5
 
+#Enable DEBUG output
+export CONFIG_DEBUG_OUTPUT=y
+
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -10,6 +10,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
+export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -6,6 +6,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.13
 export CONFIG_LINUX_VERSION=5.10.5
 
+#Enable DEBUG output
+export CONFIG_DEBUG_OUTPUT=y
+
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -8,6 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
+export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config

--- a/initrd/bin/cbfs-init
+++ b/initrd/bin/cbfs-init
@@ -2,6 +2,8 @@
 set -e -o pipefail
 . /etc/functions
 
+DEBUG "Under /bin/cbfs-init"
+
 # Update initrd with CBFS files
 if [ -z "$CONFIG_PCR" ]; then
 	CONFIG_PCR=7

--- a/initrd/bin/cbfs-init
+++ b/initrd/bin/cbfs-init
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-DEBUG "Under /bin/cbfs-init"
+TRACE "Under /bin/cbfs-init"
 
 # Update initrd with CBFS files
 if [ -z "$CONFIG_PCR" ]; then

--- a/initrd/bin/cbfs.sh
+++ b/initrd/bin/cbfs.sh
@@ -3,6 +3,8 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
+DEBUG "Under /bin/cbfs.sh"
+
 if pnor "$2" -r HBI > /tmp/pnor.part 2>/dev/null; then
     cbfs "$@" -o /tmp/pnor.part && pnor "$2" -w HBI < /tmp/pnor.part
 else

--- a/initrd/bin/cbfs.sh
+++ b/initrd/bin/cbfs.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
-DEBUG "Under /bin/cbfs.sh"
+TRACE "Under /bin/cbfs.sh"
 
 if pnor "$2" -r HBI > /tmp/pnor.part 2>/dev/null; then
     cbfs "$@" -o /tmp/pnor.part && pnor "$2" -w HBI < /tmp/pnor.part

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -5,6 +5,8 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
+DEBUG "Under /bin/config-gui.sh"
+
 param=$1
 
 while true; do

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-DEBUG "Under /bin/config-gui.sh"
+TRACE "Under /bin/config-gui.sh"
 
 param=$1
 

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -5,6 +5,8 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
+DEBUG "Under /bin/flash-gui.sh"
+
 while true; do
   unset menu_choice
   whiptail $BG_COLOR_MAIN_MENU --title "Firmware Management Menu" \

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-DEBUG "Under /bin/flash-gui.sh"
+TRACE "Under /bin/flash-gui.sh"
 
 while true; do
   unset menu_choice

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -6,6 +6,8 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
+DEBUG "Under /bin/flash.sh"
+
 case "$CONFIG_FLASHROM_OPTIONS" in
   -* )
     echo "Board $CONFIG_BOARD detected, continuing..."

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -6,7 +6,7 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
-DEBUG "Under /bin/flash.sh"
+TRACE "Under /bin/flash.sh"
 
 case "$CONFIG_FLASHROM_OPTIONS" in
   -* )

--- a/initrd/bin/flashrom-kgpe-d16-openbmc.sh
+++ b/initrd/bin/flashrom-kgpe-d16-openbmc.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 . /etc/functions
 
+DEBUG "Under /bin/flashrom-kgpe-d16-openbmc.sh"
+
 ROM="$1"
 if [ -z "$1" ]; then
 	die "Usage: $0 /media/kgpe-d16-openbmc.rom"

--- a/initrd/bin/flashrom-kgpe-d16-openbmc.sh
+++ b/initrd/bin/flashrom-kgpe-d16-openbmc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 . /etc/functions
 
-DEBUG "Under /bin/flashrom-kgpe-d16-openbmc.sh"
+TRACE "Under /bin/flashrom-kgpe-d16-openbmc.sh"
 
 ROM="$1"
 if [ -z "$1" ]; then

--- a/initrd/bin/generic-init
+++ b/initrd/bin/generic-init
@@ -6,6 +6,7 @@
 
 mount_boot()
 {
+	DEBUG "Under /bin/generic-init:mount_boot"
 	# Mount local disk if it is not already mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \

--- a/initrd/bin/generic-init
+++ b/initrd/bin/generic-init
@@ -6,7 +6,7 @@
 
 mount_boot()
 {
-	DEBUG "Under /bin/generic-init:mount_boot"
+	TRACE "Under /bin/generic-init:mount_boot"
 	# Mount local disk if it is not already mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -5,6 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
+DEBUG "Under /bin/gpg-gui.sh"
 gpg_flash_rom() {
 
   if [ "$1" = "replace" ]; then

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-DEBUG "Under /bin/gpg-gui.sh"
+TRACE "Under /bin/gpg-gui.sh"
 gpg_flash_rom() {
 
   if [ "$1" = "replace" ]; then

--- a/initrd/bin/gpgv
+++ b/initrd/bin/gpgv
@@ -1,3 +1,6 @@
 #!/bin/sh
 # if we are using the full GPG we need a wrapper for the gpgv executable
+. /etc/functions
+
+DEBUG "Under /bin/gpgv"
 exec gpg --verify "$@"

--- a/initrd/bin/gpgv
+++ b/initrd/bin/gpgv
@@ -2,5 +2,5 @@
 # if we are using the full GPG we need a wrapper for the gpgv executable
 . /etc/functions
 
-DEBUG "Under /bin/gpgv"
+TRACE "Under /bin/gpgv"
 exec gpg --verify "$@"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -17,7 +17,7 @@ skip_to_menu="false"
 
 mount_boot()
 {
-  
+  DEBUG "Under /bin/gui-init:mount_boot"
   # Mount local disk if it is not already mounted
   while ! grep -q /boot /proc/mounts ; do
     # try to mount if CONFIG_BOOT_DEV exists
@@ -63,6 +63,7 @@ mount_boot()
 
 verify_global_hashes()
 {
+  DEBUG "Under /bin/gui-init:verify_global_hashes"
   # Check the hashes of all the files, ignoring signatures for now
   check_config /boot force
   TMP_HASH_FILE="/tmp/kexec/kexec_hashes.txt"
@@ -137,6 +138,7 @@ verify_global_hashes()
 
 prompt_update_checksums()
 {
+  DEBUG "Under /bin/gui-init:prompt_update_checksums"
   if (whiptail $BG_COLOR_WARNING --title 'Update Checksums and sign all files in /boot' \
       --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that these files have not been tampered with.\n\nYou will need your GPG key available, and this change will modify your disk.\n\nDo you want to continue?" 0 80) then
     if ! update_checksums ; then
@@ -148,6 +150,7 @@ prompt_update_checksums()
 
 generate_totp_htop()
 {
+  DEBUG "Under /bin/gui-init:generate_totp_htop"
   echo "Scan the QR code to add the new TOTP secret"
   if /bin/seal-totp "$BOARD_NAME"; then
     if [ -x /bin/hotp_verification ]; then
@@ -167,6 +170,7 @@ generate_totp_htop()
 
 update_totp()
 {
+  DEBUG "Under /bin/gui-init:update_totp"
   # update the TOTP code
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   if [ "$CONFIG_TPM" = n ]; then
@@ -217,6 +221,7 @@ update_totp()
 
 update_hotp()
 {
+  DEBUG "Under /bin/gui-init:update_hotp"
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
     if ! hotp_verification info ; then
@@ -255,6 +260,7 @@ update_hotp()
 
 clean_boot_check()
 {
+  DEBUG "Under /bin/gui-init:mount_boot"
   # assume /boot mounted
   if ! grep -q /boot /proc/mounts ; then
     return
@@ -283,6 +289,7 @@ clean_boot_check()
 
 check_gpg_key()
 {
+  DEBUG "Under /bin/gui-init:check_gpg_key"
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
@@ -319,6 +326,7 @@ check_gpg_key()
 
 prompt_auto_default_boot()
 {
+  DEBUG "Under /bin/gui-init:prompt_auto_default_boot"
   # save IFS before changing, restore after read
   IFS_DEF=$IFS
   IFS=''
@@ -335,6 +343,7 @@ prompt_auto_default_boot()
 
 show_main_menu()
 {
+  DEBUG "Under /bin/gui-init:show_main_menu"
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 0 80 10 \
@@ -368,6 +377,7 @@ show_main_menu()
 
 show_options_menu()
 {
+  DEBUG "Under /bin/gui-init:show_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "HEADS Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
@@ -424,6 +434,7 @@ show_options_menu()
 
 show_boot_options_menu()
 {
+  DEBUG "Under /bin/gui-init:show_boot_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
@@ -451,6 +462,7 @@ show_boot_options_menu()
 
 show_tpm_totp_hotp_options_menu()
 {
+  DEBUG "Under /bin/gui-init:show_tpm_totp_hotp_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
     --menu "Select An Option" 0 80 10 \
     'g' ' Generate new TOTP/HOTP secret' \
@@ -477,6 +489,7 @@ show_tpm_totp_hotp_options_menu()
 
 prompt_totp_mismatch()
 {
+  DEBUG "Under /bin/gui-init:prompt_totp_mismatch"
   if (whiptail $BG_COLOR_WARNING --title "TOTP/HOTP code mismatched" \
     --yesno "TOTP/HOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s yyyy-MM-DD hh:mm:ss' in UTC timezone\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 0 80) then
     echo ""
@@ -493,6 +506,7 @@ prompt_totp_mismatch()
 
 reset_tpm()
 {
+  DEBUG "Under /bin/gui-init:reset_tpm"
   if [ "$CONFIG_TPM" = "y" ]; then
     if (whiptail $BG_COLOR_WARNING --title 'Reset the TPM' \
         --yesno "This will clear the TPM and TPM password, replace them with new ones!\n\nDo you want to proceed?" 0 80) then
@@ -526,6 +540,7 @@ reset_tpm()
 
 show_system_info()
 {
+  DEBUG "Under /bin/gui-init:show_system_info"
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"
   if [ -n $battery_charge -a -n $battery_health ];then
@@ -543,6 +558,7 @@ show_system_info()
 
 select_os_boot_option()
 {
+  DEBUG "Under /bin/gui-init:select_os_boot_option"
   mount_boot
   if verify_global_hashes ; then
     kexec-select-boot -m -b /boot -c "grub.cfg" -g
@@ -551,6 +567,7 @@ select_os_boot_option()
 
 attempt_default_boot()
 {
+  DEBUG "Under /bin/gui-init:attempt_default_boot"
   mount_boot
     
   if ! verify_global_hashes; then
@@ -568,6 +585,7 @@ attempt_default_boot()
 
 force_unsafe_boot()
 {
+  DEBUG "Under /bin/gui-init:force_unsafe_boot"
   # Run the menu selection in "force" mode, bypassing hash checks
   if (whiptail $BG_COLOR_WARNING --title 'Unsafe Forced Boot Selected!' \
       --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 0 80) then
@@ -576,6 +594,7 @@ force_unsafe_boot()
 }
 
 # gui-init start
+DEBUG "Under /bin/gui-init, start"
 
 # Use stored HOTP key branding
 if [ -r /boot/kexec_hotp_key ]; then
@@ -609,6 +628,7 @@ if [[ "$HOTP" = "Success" && $CONFIG_AUTO_BOOT_TIMEOUT ]]; then
 fi
 
 while true; do
+  DEBUG "Under gui-init:while true loop"
   skip_to_menu="false"
   show_main_menu
 done

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -623,7 +623,7 @@ check_gpg_key
 update_totp
 update_hotp
 
-if [[ "$HOTP" = "Success" && $CONFIG_AUTO_BOOT_TIMEOUT ]]; then
+if [ "$HOTP" = "Success" -a -n "$CONFIG_AUTO_BOOT_TIMEOUT" ]; then
   prompt_auto_default_boot
 fi
 

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -17,7 +17,7 @@ skip_to_menu="false"
 
 mount_boot()
 {
-  DEBUG "Under /bin/gui-init:mount_boot"
+  TRACE "Under /bin/gui-init:mount_boot"
   # Mount local disk if it is not already mounted
   while ! grep -q /boot /proc/mounts ; do
     # try to mount if CONFIG_BOOT_DEV exists
@@ -63,7 +63,7 @@ mount_boot()
 
 verify_global_hashes()
 {
-  DEBUG "Under /bin/gui-init:verify_global_hashes"
+  TRACE "Under /bin/gui-init:verify_global_hashes"
   # Check the hashes of all the files, ignoring signatures for now
   check_config /boot force
   TMP_HASH_FILE="/tmp/kexec/kexec_hashes.txt"
@@ -138,7 +138,7 @@ verify_global_hashes()
 
 prompt_update_checksums()
 {
-  DEBUG "Under /bin/gui-init:prompt_update_checksums"
+  TRACE "Under /bin/gui-init:prompt_update_checksums"
   if (whiptail $BG_COLOR_WARNING --title 'Update Checksums and sign all files in /boot' \
       --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that these files have not been tampered with.\n\nYou will need your GPG key available, and this change will modify your disk.\n\nDo you want to continue?" 0 80) then
     if ! update_checksums ; then
@@ -150,7 +150,7 @@ prompt_update_checksums()
 
 generate_totp_htop()
 {
-  DEBUG "Under /bin/gui-init:generate_totp_htop"
+  TRACE "Under /bin/gui-init:generate_totp_htop"
   echo "Scan the QR code to add the new TOTP secret"
   if /bin/seal-totp "$BOARD_NAME"; then
     if [ -x /bin/hotp_verification ]; then
@@ -170,7 +170,7 @@ generate_totp_htop()
 
 update_totp()
 {
-  DEBUG "Under /bin/gui-init:update_totp"
+  TRACE "Under /bin/gui-init:update_totp"
   # update the TOTP code
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   if [ "$CONFIG_TPM" = n ]; then
@@ -221,7 +221,7 @@ update_totp()
 
 update_hotp()
 {
-  DEBUG "Under /bin/gui-init:update_hotp"
+  TRACE "Under /bin/gui-init:update_hotp"
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
     if ! hotp_verification info ; then
@@ -260,7 +260,7 @@ update_hotp()
 
 clean_boot_check()
 {
-  DEBUG "Under /bin/gui-init:mount_boot"
+  TRACE "Under /bin/gui-init:mount_boot"
   # assume /boot mounted
   if ! grep -q /boot /proc/mounts ; then
     return
@@ -289,7 +289,7 @@ clean_boot_check()
 
 check_gpg_key()
 {
-  DEBUG "Under /bin/gui-init:check_gpg_key"
+  TRACE "Under /bin/gui-init:check_gpg_key"
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
@@ -326,7 +326,7 @@ check_gpg_key()
 
 prompt_auto_default_boot()
 {
-  DEBUG "Under /bin/gui-init:prompt_auto_default_boot"
+  TRACE "Under /bin/gui-init:prompt_auto_default_boot"
   # save IFS before changing, restore after read
   IFS_DEF=$IFS
   IFS=''
@@ -343,7 +343,7 @@ prompt_auto_default_boot()
 
 show_main_menu()
 {
-  DEBUG "Under /bin/gui-init:show_main_menu"
+  TRACE "Under /bin/gui-init:show_main_menu"
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 0 80 10 \
@@ -377,7 +377,7 @@ show_main_menu()
 
 show_options_menu()
 {
-  DEBUG "Under /bin/gui-init:show_options_menu"
+  TRACE "Under /bin/gui-init:show_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "HEADS Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
@@ -434,7 +434,7 @@ show_options_menu()
 
 show_boot_options_menu()
 {
-  DEBUG "Under /bin/gui-init:show_boot_options_menu"
+  TRACE "Under /bin/gui-init:show_boot_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
@@ -462,7 +462,7 @@ show_boot_options_menu()
 
 show_tpm_totp_hotp_options_menu()
 {
-  DEBUG "Under /bin/gui-init:show_tpm_totp_hotp_options_menu"
+  TRACE "Under /bin/gui-init:show_tpm_totp_hotp_options_menu"
   whiptail $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
     --menu "Select An Option" 0 80 10 \
     'g' ' Generate new TOTP/HOTP secret' \
@@ -489,7 +489,7 @@ show_tpm_totp_hotp_options_menu()
 
 prompt_totp_mismatch()
 {
-  DEBUG "Under /bin/gui-init:prompt_totp_mismatch"
+  TRACE "Under /bin/gui-init:prompt_totp_mismatch"
   if (whiptail $BG_COLOR_WARNING --title "TOTP/HOTP code mismatched" \
     --yesno "TOTP/HOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s yyyy-MM-DD hh:mm:ss' in UTC timezone\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 0 80) then
     echo ""
@@ -506,7 +506,7 @@ prompt_totp_mismatch()
 
 reset_tpm()
 {
-  DEBUG "Under /bin/gui-init:reset_tpm"
+  TRACE "Under /bin/gui-init:reset_tpm"
   if [ "$CONFIG_TPM" = "y" ]; then
     if (whiptail $BG_COLOR_WARNING --title 'Reset the TPM' \
         --yesno "This will clear the TPM and TPM password, replace them with new ones!\n\nDo you want to proceed?" 0 80) then
@@ -540,7 +540,7 @@ reset_tpm()
 
 show_system_info()
 {
-  DEBUG "Under /bin/gui-init:show_system_info"
+  TRACE "Under /bin/gui-init:show_system_info"
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"
   if [ -n $battery_charge -a -n $battery_health ];then
@@ -558,7 +558,7 @@ show_system_info()
 
 select_os_boot_option()
 {
-  DEBUG "Under /bin/gui-init:select_os_boot_option"
+  TRACE "Under /bin/gui-init:select_os_boot_option"
   mount_boot
   if verify_global_hashes ; then
     kexec-select-boot -m -b /boot -c "grub.cfg" -g
@@ -567,7 +567,7 @@ select_os_boot_option()
 
 attempt_default_boot()
 {
-  DEBUG "Under /bin/gui-init:attempt_default_boot"
+  TRACE "Under /bin/gui-init:attempt_default_boot"
   mount_boot
     
   if ! verify_global_hashes; then
@@ -585,7 +585,7 @@ attempt_default_boot()
 
 force_unsafe_boot()
 {
-  DEBUG "Under /bin/gui-init:force_unsafe_boot"
+  TRACE "Under /bin/gui-init:force_unsafe_boot"
   # Run the menu selection in "force" mode, bypassing hash checks
   if (whiptail $BG_COLOR_WARNING --title 'Unsafe Forced Boot Selected!' \
       --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 0 80) then
@@ -594,7 +594,7 @@ force_unsafe_boot()
 }
 
 # gui-init start
-DEBUG "Under /bin/gui-init, start"
+TRACE "Under /bin/gui-init, start"
 
 # Use stored HOTP key branding
 if [ -r /boot/kexec_hotp_key ]; then
@@ -628,7 +628,7 @@ if [ "$HOTP" = "Success" -a -n "$CONFIG_AUTO_BOOT_TIMEOUT" ]; then
 fi
 
 while true; do
-  DEBUG "Under gui-init:while true loop"
+  TRACE "Under gui-init:while true loop"
   skip_to_menu="false"
   show_main_menu
 done

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -4,6 +4,8 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
+DEBUG "Under /bin/kexec-boot"
+
 dryrun="n"
 printfiles="n"
 printinitrd="n"

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-DEBUG "Under /bin/kexec-boot"
+TRACE "Under /bin/kexec-boot"
 
 dryrun="n"
 printfiles="n"

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -3,6 +3,8 @@
 set -e -o pipefail
 . /etc/functions
 
+DEBUG "Under /bin/kexec-insert-key"
+
 TMP_KEY_DEVICES="/tmp/kexec/kexec_key_devices.txt"
 TMP_KEY_LVM="/tmp/kexec/kexec_key_lvm.txt"
 

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -3,7 +3,7 @@
 set -e -o pipefail
 . /etc/functions
 
-DEBUG "Under /bin/kexec-insert-key"
+TRACE "Under /bin/kexec-insert-key"
 
 TMP_KEY_DEVICES="/tmp/kexec/kexec_key_devices.txt"
 TMP_KEY_LVM="/tmp/kexec/kexec_key_lvm.txt"

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -4,6 +4,8 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
+DEBUG "Under /bin/kexec-iso-init"
+
 MOUNTED_ISO_PATH="$1"
 ISO_PATH="$2"
 DEV="$3"

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
-DEBUG "Under /bin/kexec-iso-init"
+TRACE "Under /bin/kexec-iso-init"
 
 MOUNTED_ISO_PATH="$1"
 ISO_PATH="$2"

--- a/initrd/bin/kexec-parse-bls
+++ b/initrd/bin/kexec-parse-bls
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e -o pipefail
+. /etc/functions
+DEBUG "Under /bin/kexec-parse-bls"
+
 bootdir="$1"
 file="$2"
 blsdir="$3"

--- a/initrd/bin/kexec-parse-bls
+++ b/initrd/bin/kexec-parse-bls
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -o pipefail
 . /etc/functions
-DEBUG "Under /bin/kexec-parse-bls"
+TRACE "Under /bin/kexec-parse-bls"
 
 bootdir="$1"
 file="$2"

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e -o pipefail
+. /etc/functions
+
+DEBUG "Under /bin/kexec-parse-boot"
+
 bootdir="$1"
 file="$2"
 

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-DEBUG "Under /bin/kexec-parse-boot"
+TRACE "Under /bin/kexec-parse-boot"
 
 bootdir="$1"
 file="$2"

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -4,6 +4,8 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
+DEBUG "Under /bin/kexec-save-default"
+
 while getopts "b:d:p:i:" arg; do
 	case $arg in
 		b) bootdir="$OPTARG" ;;

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-DEBUG "Under /bin/kexec-save-default"
+TRACE "Under /bin/kexec-save-default"
 
 while getopts "b:d:p:i:" arg; do
 	case $arg in

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -3,6 +3,7 @@
 # with the current PCRs and then store it in the TPM NVRAM.
 # It will then need to be bundled into initrd that is booted.
 set -e -o pipefail
+. /etc/functions
 
 TPM_INDEX=3
 TPM_SIZE=312

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -4,6 +4,8 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
+DEBUG "Under /bin/kexec-select-boot"
+
 add=""
 remove=""
 config="*.cfg"

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-DEBUG "Under /bin/kexec-select-boot"
+TRACE "Under /bin/kexec-select-boot"
 
 add=""
 remove=""

--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -4,6 +4,8 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
+DEBUG "Under /bin/kexec-sign-config"
+
 rollback="n"
 update="n"
 while getopts "p:c:ur" arg; do

--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-DEBUG "Under /bin/kexec-sign-config"
+TRACE "Under /bin/kexec-sign-config"
 
 rollback="n"
 update="n"

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -3,6 +3,7 @@
 # The TOTP secret will be shown to the user on each encryption attempt.
 # It will then need to be bundled into initrd that is booted with Qubes.
 set -e -o pipefail
+. /etc/functions
 
 TPM_INDEX=3
 TPM_SIZE=312

--- a/initrd/bin/key-init
+++ b/initrd/bin/key-init
@@ -2,6 +2,8 @@
 set -e -o pipefail
 . /etc/functions
 
+DEBUG "Under /bin/key-init"
+
 # Post processing of keys
 
 # Import user's keys

--- a/initrd/bin/key-init
+++ b/initrd/bin/key-init
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-DEBUG "Under /bin/key-init"
+TRACE "Under /bin/key-init"
 
 # Post processing of keys
 

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -5,6 +5,8 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
+DEBUG "Under /bin/media-scan"
+
 # Unmount any previous boot device
 if grep -q /boot /proc/mounts ; then
 	umount /boot \

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-DEBUG "Under /bin/media-scan"
+TRACE "Under /bin/media-scan"
 
 # Unmount any previous boot device
 if grep -q /boot /proc/mounts ; then

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -2,6 +2,8 @@
 # Mount a USB device
 . /etc/functions
 
+DEBUG "Under /bin/mount-usb"
+
 enable_usb
 
 if ! lsmod | grep -q usb_storage; then

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -2,7 +2,7 @@
 # Mount a USB device
 . /etc/functions
 
-DEBUG "Under /bin/mount-usb"
+TRACE "Under /bin/mount-usb"
 
 enable_usb
 

--- a/initrd/bin/network-init-recovery
+++ b/initrd/bin/network-init-recovery
@@ -2,6 +2,8 @@
 
 . /etc/functions
 
+DEBUG "Under /bin/network-init-recovery"
+
 # bring up the ethernet; maybe should do DHCP?
 ifconfig lo 127.0.0.1
 

--- a/initrd/bin/network-init-recovery
+++ b/initrd/bin/network-init-recovery
@@ -2,7 +2,7 @@
 
 . /etc/functions
 
-DEBUG "Under /bin/network-init-recovery"
+TRACE "Under /bin/network-init-recovery"
 
 # bring up the ethernet; maybe should do DHCP?
 ifconfig lo 127.0.0.1

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1,7 +1,10 @@
 #!/bin/sh
 # Automated setup of TPM, GPG keys, and disk
 
+DEBUG "Under /bin/oem-factory-reset"
+
 set -o pipefail
+. /etc/functions
 
 # use TERM to exit on error
 trap "exit 1" TERM

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Automated setup of TPM, GPG keys, and disk
 
-DEBUG "Under /bin/oem-factory-reset"
+TRACE "Under /bin/oem-factory-reset"
 
 set -o pipefail
 . /etc/functions

--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -9,6 +9,8 @@ export BG_COLOR_MAIN_MENU=""
 . /etc/luks-functions
 . /tmp/config
 
+DEBUG "Under /bin/oem-system-info-xx30"
+
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"
   if [ -n $battery_charge -a -n $battery_health ];then

--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -9,7 +9,7 @@ export BG_COLOR_MAIN_MENU=""
 . /etc/luks-functions
 . /tmp/config
 
-DEBUG "Under /bin/oem-system-info-xx30"
+TRACE "Under /bin/oem-system-info-xx30"
 
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"

--- a/initrd/bin/poweroff
+++ b/initrd/bin/poweroff
@@ -1,4 +1,7 @@
 #!/bin/sh
+. /etc/functions
+
+DEBUG "Under /bin/poweroff"
 
 # Sync all mounted filesystems
 echo s > /proc/sysrq-trigger

--- a/initrd/bin/poweroff
+++ b/initrd/bin/poweroff
@@ -1,7 +1,7 @@
 #!/bin/sh
 . /etc/functions
 
-DEBUG "Under /bin/poweroff"
+TRACE "Under /bin/poweroff"
 
 # Sync all mounted filesystems
 echo s > /proc/sysrq-trigger

--- a/initrd/bin/qubes-measure-luks
+++ b/initrd/bin/qubes-measure-luks
@@ -3,7 +3,7 @@
 # a PCR so that we can detect disk swap attacks.
 . /etc/functions
 
-DEBUG "Under /bin/qubes-measure-luks"
+TRACE "Under /bin/qubes-measure-luks"
 
 die() { echo >&2 "$@"; exit 1; }
 

--- a/initrd/bin/qubes-measure-luks
+++ b/initrd/bin/qubes-measure-luks
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Measure all of the luks disk encryption headers into
 # a PCR so that we can detect disk swap attacks.
+. /etc/functions
+
+DEBUG "Under /bin/qubes-measure-luks"
 
 die() { echo >&2 "$@"; exit 1; }
 

--- a/initrd/bin/reboot
+++ b/initrd/bin/reboot
@@ -1,4 +1,7 @@
 #!/bin/sh
+. /etc/functions
+
+DEBUG "Under /bin/reboot"
 
 # Sync all mounted filesystems
 echo s > /proc/sysrq-trigger

--- a/initrd/bin/reboot
+++ b/initrd/bin/reboot
@@ -1,7 +1,7 @@
 #!/bin/sh
 . /etc/functions
 
-DEBUG "Under /bin/reboot"
+TRACE "Under /bin/reboot"
 
 # Sync all mounted filesystems
 echo s > /proc/sysrq-trigger

--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -10,12 +10,15 @@ HOTP_KEY="/boot/kexec_hotp_key"
 
 mount_boot()
 {
+  DEBUG "Under /bin/seal-htopkey:mount_boot"
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts ; then
     mount -o ro /boot \
       || recovery "Unable to mount /boot"
   fi
 }
+
+DEBUG "Under /bin/seal-hotpkey"
 
 # Use stored HOTP key branding (this might be useful after OEM reset)
 if [ -r /boot/kexec_hotp_key ]; then

--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -10,7 +10,7 @@ HOTP_KEY="/boot/kexec_hotp_key"
 
 mount_boot()
 {
-  DEBUG "Under /bin/seal-htopkey:mount_boot"
+  TRACE "Under /bin/seal-htopkey:mount_boot"
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts ; then
     mount -o ro /boot \
@@ -18,7 +18,7 @@ mount_boot()
   fi
 }
 
-DEBUG "Under /bin/seal-hotpkey"
+TRACE "Under /bin/seal-hotpkey"
 
 # Use stored HOTP key branding (this might be useful after OEM reset)
 if [ -r /boot/kexec_hotp_key ]; then

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -7,6 +7,8 @@
 
 . /etc/functions
 
+DEBUG "Under /bin/seal-totp"
+
 TPM_NVRAM_SPACE=4d47
 
 HOST="$1"

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -7,7 +7,7 @@
 
 . /etc/functions
 
-DEBUG "Under /bin/seal-totp"
+TRACE "Under /bin/seal-totp"
 
 TPM_NVRAM_SPACE=4d47
 

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -9,12 +9,15 @@ HOTP_COUNTER="/boot/kexec_hotp_counter"
 
 mount_boot_or_die()
 {
+  DEBUG "Under /bin/unseal-hotp:mount_boot_or_die"
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts ; then
     mount -o ro /boot \
       || die "Unable to mount /boot"
   fi
 }
+
+DEBUG "Under /bin/unseal-hotp"
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -9,7 +9,7 @@ HOTP_COUNTER="/boot/kexec_hotp_counter"
 
 mount_boot_or_die()
 {
-  DEBUG "Under /bin/unseal-hotp:mount_boot_or_die"
+  TRACE "Under /bin/unseal-hotp:mount_boot_or_die"
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts ; then
     mount -o ro /boot \
@@ -17,7 +17,7 @@ mount_boot_or_die()
   fi
 }
 
-DEBUG "Under /bin/unseal-hotp"
+TRACE "Under /bin/unseal-hotp"
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/unseal-totp
+++ b/initrd/bin/unseal-totp
@@ -6,6 +6,8 @@
 TOTP_SEALED="/tmp/secret/totp.sealed"
 TOTP_SECRET="/tmp/secret/totp.key"
 
+DEBUG "Under /bin/unseal-totp"
+
 tpm nv_readvalue \
 	-in 4d47 \
 	-sz 312 \

--- a/initrd/bin/unseal-totp
+++ b/initrd/bin/unseal-totp
@@ -6,7 +6,7 @@
 TOTP_SEALED="/tmp/secret/totp.sealed"
 TOTP_SECRET="/tmp/secret/totp.key"
 
-DEBUG "Under /bin/unseal-totp"
+TRACE "Under /bin/unseal-totp"
 
 tpm nv_readvalue \
 	-in 4d47 \

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -4,6 +4,8 @@
 . /etc/functions
 . /tmp/config
 
+DEBUG "Under /bin/usb-init"
+
 if [ "$CONFIG_TPM" = "y" ]; then
 	# Extend PCR4 as soon as possible
 	tpm extend -ix 4 -ic usb

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -4,7 +4,7 @@
 . /etc/functions
 . /tmp/config
 
-DEBUG "Under /bin/usb-init"
+TRACE "Under /bin/usb-init"
 
 if [ "$CONFIG_TPM" = "y" ]; then
 	# Extend PCR4 as soon as possible

--- a/initrd/bin/wget-measure.sh
+++ b/initrd/bin/wget-measure.sh
@@ -3,7 +3,7 @@
 . /etc/functions
 
 die() {
-	DEBUG "Under /bin/wget-measure.sh:die"
+	TRACE "Under /bin/wget-measure.sh:die"
         echo >&2 "$@"
         exit 1
 }

--- a/initrd/bin/wget-measure.sh
+++ b/initrd/bin/wget-measure.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 # get a file and extend a TPM PCR
+. /etc/functions
 
 die() {
+	DEBUG "Under /bin/wget-measure.sh:die"
         echo >&2 "$@"
         exit 1
 }

--- a/initrd/bin/x230-flash.init
+++ b/initrd/bin/x230-flash.init
@@ -5,6 +5,8 @@
 . /etc/functions
 . /tmp/config
 
+DEBUG "Under /bin/x230-flash.init"
+
 insmod /lib/modules/ehci-hcd.ko
 insmod /lib/modules/ehci-pci.ko
 insmod /lib/modules/xhci-hcd.ko

--- a/initrd/bin/x230-flash.init
+++ b/initrd/bin/x230-flash.init
@@ -5,7 +5,7 @@
 . /etc/functions
 . /tmp/config
 
-DEBUG "Under /bin/x230-flash.init"
+TRACE "Under /bin/x230-flash.init"
 
 insmod /lib/modules/ehci-hcd.ko
 insmod /lib/modules/ehci-pci.ko

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -12,7 +12,15 @@ warn() {
 	sleep 1;
 }
 
+DEBUG() {
+	if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
+		echo >&2 "DEBUG: $*";
+	fi
+}
+
+
 recovery() {
+	DEBUG "Under /etc/functions:recovery"
 	echo >&2 "!!!!! $*"
 
 	# Remove any temporary secret files that might be hanging around
@@ -44,6 +52,7 @@ recovery() {
 }
 
 pause_recovery() {
+	DEBUG "Under /etc/functions:pause_recovery"
 	read -p 'Hit enter to proceed to recovery shell:'
 	recovery $*
 }
@@ -54,6 +63,7 @@ pcrs() {
 
 confirm_totp()
 {
+	DEBUG "Under /etc/functions:confirm_totp"
 	prompt="$1"
 	last_half=X
 	unset totp_confirm
@@ -93,6 +103,7 @@ confirm_totp()
 
 enable_usb()
 {
+	DEBUG "Under /etc/functions:enable_usb"
 	#insmod ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning 
 	if ! lsmod | grep -q ehci_hcd; then
                 insmod /lib/modules/ehci-hcd.ko \
@@ -137,6 +148,7 @@ enable_usb()
 
 list_usb_storage()
 {
+	DEBUG "Under /etc/functions:list_usb_storage"
 	stat -c %N /sys/block/sd* 2>/dev/null | grep usb |
 		cut -f1 -d ' ' |
 		sed "s/[']//g" |
@@ -176,6 +188,7 @@ list_usb_storage()
 
 confirm_gpg_card()
 {
+	DEBUG "Under /etc/functions:confirm_gpg_card"
 	read \
 		-n 1 \
 		-p "Please confirm that your GPG card is inserted [Y/n]: " \
@@ -219,6 +232,7 @@ confirm_gpg_card()
 
 check_tpm_counter()
 {
+  DEBUG "Under /etc/functions:check_tpm_counter"
   LABEL=${2:-3135106223}
 	# if the /boot.hashes file already exists, read the TPM counter ID
 	# from it.
@@ -244,18 +258,21 @@ check_tpm_counter()
 
 read_tpm_counter()
 {
+	DEBUG "Under /etc/functions:read_tpm_counter"
 	tpm counter_read -ix "$1" | tee "/tmp/counter-$1" \
 	|| die "Counter read failed"
 }
 
 increment_tpm_counter()
 {
+	DEBUG "Under /etc/functions:increment_tpm_counter"
 	tpm counter_increment -ix "$1" -pwdc '' \
 		| tee /tmp/counter-$1 \
 	|| die "Counter increment failed"
 }
 
 check_config() {
+	DEBUG "Under /etc/functions:check_config"
 	if [ ! -d /tmp/kexec ]; then
 		mkdir /tmp/kexec \
 		|| die 'Failed to make kexec tmp dir'
@@ -284,6 +301,7 @@ check_config() {
 }
 
 preserve_rom() {
+	DEBUG "Under /etc/functions:preserve_rom"
 	new_rom="$1"
 	old_files=`cbfs -t 50 -l 2>/dev/null | grep "^heads/"`
 
@@ -299,6 +317,7 @@ preserve_rom() {
 	done
 }
 replace_config() {
+	DEBUG "Under /etc/functions:replace_config"
 	CONFIG_FILE=$1
 	CONFIG_OPTION=$2
 	NEW_SETTING=$3
@@ -314,11 +333,13 @@ replace_config() {
 	rm -f ${CONFIG_FILE}.tmp
 }
 combine_configs() {
+	DEBUG "Under /etc/functions:combine_configs"
 	cat /etc/config* > /tmp/config
 }
 
 update_checksums()
 {
+	DEBUG "Under /etc/functions:update_checksums"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \
@@ -346,6 +367,7 @@ update_checksums()
 }
 
 print_tree() {
+	DEBUG "Under /etc/functions:print_tree"
 	find ./ ! -path './kexec*' -print0 | sort -z
 }
 
@@ -413,6 +435,7 @@ escape_zero() {
 # due to https://bugs.busybox.net/show_bug.cgi?id=14226. Also, certain characters
 # may be intepreted by `whiptail`, `less` et al (e.g. \n, \b, ...).
 assert_signable() {
+	DEBUG "Under /etc/functions:assert_signable"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot || die "Unable to mount /boot"
@@ -432,6 +455,7 @@ assert_signable() {
 
 verify_checksums()
 {
+	DEBUG "Under /etc/functions:verify_checksums"
 	local boot_dir="$1"
 	local gui="${2:-y}"
 
@@ -465,6 +489,7 @@ verify_checksums()
 # mount /boot if successful
 detect_boot_device()
 {
+	DEBUG "Under /etc/functions:detect_boot_device"
 	# unmount /boot to be safe
 	cd / && umount /boot 2>/dev/null
 

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -18,9 +18,16 @@ DEBUG() {
 	fi
 }
 
+TRACE() {
+        if [ "$CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT" = "y" ];then
+                echo >&2 "TRACE: $*";
+        fi
+}
+
+
 
 recovery() {
-	DEBUG "Under /etc/functions:recovery"
+	TRACE "Under /etc/functions:recovery"
 	echo >&2 "!!!!! $*"
 
 	# Remove any temporary secret files that might be hanging around
@@ -52,7 +59,7 @@ recovery() {
 }
 
 pause_recovery() {
-	DEBUG "Under /etc/functions:pause_recovery"
+	TRACE "Under /etc/functions:pause_recovery"
 	read -p 'Hit enter to proceed to recovery shell:'
 	recovery $*
 }
@@ -63,7 +70,7 @@ pcrs() {
 
 confirm_totp()
 {
-	DEBUG "Under /etc/functions:confirm_totp"
+	TRACE "Under /etc/functions:confirm_totp"
 	prompt="$1"
 	last_half=X
 	unset totp_confirm
@@ -103,7 +110,7 @@ confirm_totp()
 
 enable_usb()
 {
-	DEBUG "Under /etc/functions:enable_usb"
+	TRACE "Under /etc/functions:enable_usb"
 	#insmod ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning 
 	if ! lsmod | grep -q ehci_hcd; then
                 insmod /lib/modules/ehci-hcd.ko \
@@ -148,7 +155,7 @@ enable_usb()
 
 list_usb_storage()
 {
-	DEBUG "Under /etc/functions:list_usb_storage"
+	TRACE "Under /etc/functions:list_usb_storage"
 	stat -c %N /sys/block/sd* 2>/dev/null | grep usb |
 		cut -f1 -d ' ' |
 		sed "s/[']//g" |
@@ -188,7 +195,7 @@ list_usb_storage()
 
 confirm_gpg_card()
 {
-	DEBUG "Under /etc/functions:confirm_gpg_card"
+	TRACE "Under /etc/functions:confirm_gpg_card"
 	read \
 		-n 1 \
 		-p "Please confirm that your GPG card is inserted [Y/n]: " \
@@ -232,7 +239,7 @@ confirm_gpg_card()
 
 check_tpm_counter()
 {
-  DEBUG "Under /etc/functions:check_tpm_counter"
+  TRACE "Under /etc/functions:check_tpm_counter"
   LABEL=${2:-3135106223}
 	# if the /boot.hashes file already exists, read the TPM counter ID
 	# from it.
@@ -258,21 +265,21 @@ check_tpm_counter()
 
 read_tpm_counter()
 {
-	DEBUG "Under /etc/functions:read_tpm_counter"
+	TRACE "Under /etc/functions:read_tpm_counter"
 	tpm counter_read -ix "$1" | tee "/tmp/counter-$1" \
 	|| die "Counter read failed"
 }
 
 increment_tpm_counter()
 {
-	DEBUG "Under /etc/functions:increment_tpm_counter"
+	TRACE "Under /etc/functions:increment_tpm_counter"
 	tpm counter_increment -ix "$1" -pwdc '' \
 		| tee /tmp/counter-$1 \
 	|| die "Counter increment failed"
 }
 
 check_config() {
-	DEBUG "Under /etc/functions:check_config"
+	TRACE "Under /etc/functions:check_config"
 	if [ ! -d /tmp/kexec ]; then
 		mkdir /tmp/kexec \
 		|| die 'Failed to make kexec tmp dir'
@@ -301,7 +308,7 @@ check_config() {
 }
 
 preserve_rom() {
-	DEBUG "Under /etc/functions:preserve_rom"
+	TRACE "Under /etc/functions:preserve_rom"
 	new_rom="$1"
 	old_files=`cbfs -t 50 -l 2>/dev/null | grep "^heads/"`
 
@@ -317,7 +324,7 @@ preserve_rom() {
 	done
 }
 replace_config() {
-	DEBUG "Under /etc/functions:replace_config"
+	TRACE "Under /etc/functions:replace_config"
 	CONFIG_FILE=$1
 	CONFIG_OPTION=$2
 	NEW_SETTING=$3
@@ -333,13 +340,13 @@ replace_config() {
 	rm -f ${CONFIG_FILE}.tmp
 }
 combine_configs() {
-	DEBUG "Under /etc/functions:combine_configs"
+	TRACE "Under /etc/functions:combine_configs"
 	cat /etc/config* > /tmp/config
 }
 
 update_checksums()
 {
-	DEBUG "Under /etc/functions:update_checksums"
+	TRACE "Under /etc/functions:update_checksums"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \
@@ -367,7 +374,7 @@ update_checksums()
 }
 
 print_tree() {
-	DEBUG "Under /etc/functions:print_tree"
+	TRACE "Under /etc/functions:print_tree"
 	find ./ ! -path './kexec*' -print0 | sort -z
 }
 
@@ -435,7 +442,7 @@ escape_zero() {
 # due to https://bugs.busybox.net/show_bug.cgi?id=14226. Also, certain characters
 # may be intepreted by `whiptail`, `less` et al (e.g. \n, \b, ...).
 assert_signable() {
-	DEBUG "Under /etc/functions:assert_signable"
+	TRACE "Under /etc/functions:assert_signable"
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot || die "Unable to mount /boot"
@@ -455,7 +462,7 @@ assert_signable() {
 
 verify_checksums()
 {
-	DEBUG "Under /etc/functions:verify_checksums"
+	TRACE "Under /etc/functions:verify_checksums"
 	local boot_dir="$1"
 	local gui="${2:-y}"
 
@@ -489,7 +496,7 @@ verify_checksums()
 # mount /boot if successful
 detect_boot_device()
 {
-	DEBUG "Under /etc/functions:detect_boot_device"
+	TRACE "Under /etc/functions:detect_boot_device"
 	# unmount /boot to be safe
 	cd / && umount /boot 2>/dev/null
 

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -4,7 +4,7 @@
 
 mount_usb()
 {
-  DEBUG "under gui_functions:mount_usb"
+  TRACE "under gui_functions:mount_usb"
   # Unmount any previous USB device
   if grep -q /media /proc/mounts ; then
     umount /media || die "Unable to unmount /media"
@@ -25,7 +25,7 @@ mount_usb()
 
 file_selector()
 {
-  DEBUG "under gui_functions:file_selector"
+  TRACE "under gui_functions:file_selector"
   FILE=""
   FILE_LIST=$1
   MENU_MSG=${2:-"Choose the file"}

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -1,8 +1,10 @@
 #!/bin/sh
 # Shell functions for common operations using fbwhiptail
+. /etc/functions
 
 mount_usb()
 {
+  DEBUG "under gui_functions:mount_usb"
   # Unmount any previous USB device
   if grep -q /media /proc/mounts ; then
     umount /media || die "Unable to unmount /media"
@@ -23,6 +25,7 @@ mount_usb()
 
 file_selector()
 {
+  DEBUG "under gui_functions:file_selector"
   FILE=""
   FILE_LIST=$1
   MENU_MSG=${2:-"Choose the file"}

--- a/initrd/init
+++ b/initrd/init
@@ -43,6 +43,8 @@ hwclock -l -s
 . /etc/functions
 . /etc/config
 
+DEBUG "Under init"
+
 # set CONFIG_TPM dynamically before init
 if [ -e /dev/tpm0 ]; then
 	CONFIG_TPM='y'

--- a/initrd/init
+++ b/initrd/init
@@ -43,7 +43,7 @@ hwclock -l -s
 . /etc/functions
 . /etc/config
 
-DEBUG "Under init"
+TRACE "Under init"
 
 # set CONFIG_TPM dynamically before init
 if [ -e /dev/tpm0 ]; then


### PR DESCRIPTION
As noted under #1316, it is sometimes difficult to isolate source of errors/diagnose problems.

This PR introduces:
- DEBUG and TRACE function under /etc/functions
- Adds TRACE statements under functions
- Adds 'export CONFIG_DEBUG_OUTPUT=y' and 'CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y' under board config to enable DEBUG and TRACE console output in code to trace source of error.
- DEBUG calls will be possible later on to provide more debugging as needed as we go (thinking of #1292)
- [ ] Fixes #1316 

---

In current debugging state, we can see that reported #1316 can be isolated under:
![2023-02-18-125731](https://user-images.githubusercontent.com/827570/219881370-fddbf29e-552b-45fe-8561-a9eab6b1ad39.png)
