### PR TITLE
modules/coreboot: do not rebuild version specific coreboot's builstack at each board's make

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -101,7 +101,7 @@ coreboot_output := $(CONFIG_COREBOOT_ROM)
 coreboot_output += $(CONFIG_COREBOOT_BOOTBLOCK)
 coreboot_depend += linux initrd $(musl_dep)
 
-COREBOOT_TOOLCHAIN="$(build)/$(coreboot_base_dir)/.xcompile"
+COREBOOT_TOOLCHAIN=$(build)/$(coreboot_base_dir)/.xcompile
 $(COREBOOT_TOOLCHAIN): $(build)/$(coreboot_base_dir)/.canary
 	$(MAKE) -C "$(build)/$(coreboot_base_dir)" CPUS=$(CPUS) "crossgcc-$(COREBOOT_TARGET)"
 


### PR DESCRIPTION
.xcompile was not found because it was quoted and shouldn't in coreboot module's makefile

Prior:
```
    stat("\"/home/user/heads/build/x86/coreboot-4.13/.xcompile\"", 0x7ffe56e6cfd0) = -1 ENOENT (No such file or directory)
    pipe([3, 4])                            = 0
    fcntl(4, F_GETFD)                       = 0
    fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
    fcntl(3, F_GETFD)                       = 0
    fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
    prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1024*1024}) = 0
    prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1024*1024}) = 0
    stat("/usr/bin/env", {st_mode=S_IFREG|0755, st_size=48480, ...}) = 0
    geteuid()                               = 1000
    getegid()                               = 1000
    getuid()                                = 1000
    getgid()                                = 1000
    access("/usr/bin/env", X_OK)            = 0
    mmap(NULL, 36864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK, -1, 0) = 0x7ce2be6fd000
    rt_sigprocmask(SIG_BLOCK, ~[], [CHLD], 8) = 0
    clone(child_stack=0x7ce2be705ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD) = 305342
    munmap(0x7ce2be6fd000, 36864)           = 0
    rt_sigprocmask(SIG_SETMASK, [CHLD], NULL, 8) = 0
    close(4)                                = 0
    read(3, "2\n", 200)                     = 2
    read(3, "", 198)                        = 0
    close(3)                                = 0
    wait4(-1, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 305342
    fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(0x88, 0), ...}) = 0
    write(1, "make -C \"/home/user/heads/build/"..., 74make -C "/home/user/heads/build/x86/coreboot-4.13" CPUS=2 "crossgcc-i386"
    ) = 74
    rt_sigprocmask(SIG_BLOCK, [HUP INT QUIT TERM XCPU XFSZ], NULL, 8) = 0
    stat("/usr/bin/env", {st_mode=S_IFREG|0755, st_size=48480, ...}) = 0
    geteuid()                               = 1000
    getegid()                               = 1000
    getuid()                                = 1000
    getgid()                                = 1000
    access("/usr/bin/env", X_OK)            = 0
    mmap(NULL, 36864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK, -1, 0) = 0x7ce2be6fd000
    rt_sigprocmask(SIG_BLOCK, ~[], [HUP INT QUIT TERM CHLD XCPU XFSZ], 8) = 0
    clone(child_stack=0x7ce2be705ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD) = 305343
    munmap(0x7ce2be6fd000, 36864)           = 0
    rt_sigprocmask(SIG_SETMASK, [HUP INT QUIT TERM CHLD XCPU XFSZ], NULL, 8) = 0
    rt_sigprocmask(SIG_UNBLOCK, [HUP INT QUIT TERM XCPU XFSZ], NULL, 8) = 0
    wait4(-1, make[1]: Entering directory '/home/user/heads/build/x86/coreboot-4.13'
    Welcome to the coreboot cross toolchain builder v ()

    Building toolchain using 2 thread(s).

    Target architecture is i386-elf

    Found compatible Ada compiler, enabling Ada support by default.

    Downloading and verifying tarballs ...
     * gmp-6.2.0.tar.xz (cached)... hash verified (052a5411dc74054240eec58132d2cf41211d0ff6)
     * mpfr-4.1.0.tar.xz (cached)... hash verified (159c3a58705662bfde4dc93f2617f3660855ead6) * mpc-1.2.0.tar.gz (cached)... hash verified (0abdc94acab0c9bfdaa391347cdfd7bbdb1cf017) * binutils-2.35.tar.xz (cached)... hash verified (6bdd090ce268b6d6c3442516021c4e4b5019e303) * gcc-8.3.0.tar.xz (cached)... hash verified (c27f4499dd263fe4fb01bcc5565917f3698583b2) Downloaded tarballs ... ok Unpacking and patching ... * gmp-6.2.0.tar.xz o gmp-6.2.0_generic-build.patch * mpfr-4.1.0.tar.xz
    ^C0x7ffe56e6ef40, 0, NULL)      = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
    strace: Process 305153 detached
```

After:
 ```
   stat("/home/user/heads/build/x86/coreboot-4.13/.xcompile", 0x7ffd0303c7f0) = -1 ENOENT (No such file or directory)
    pipe([3, 4])                            = 0
    fcntl(4, F_GETFD)                       = 0
    fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
    fcntl(3, F_GETFD)                       = 0
    fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
    prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1024*1024}) = 0
    prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1024*1024}) = 0
    stat("/usr/bin/env", {st_mode=S_IFREG|0755, st_size=48480, ...}) = 0
    geteuid()                               = 1000
    getegid()                               = 1000
    getuid()                                = 1000
    getgid()                                = 1000
    access("/usr/bin/env", X_OK)            = 0
    mmap(NULL, 36864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK, -1, 0) = 0x740f6e370000
    rt_sigprocmask(SIG_BLOCK, ~[], [CHLD], 8) = 0
    clone(child_stack=0x740f6e378ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD) = 306024
    munmap(0x740f6e370000, 36864)           = 0
    rt_sigprocmask(SIG_SETMASK, [CHLD], NULL, 8) = 0
    close(4)                                = 0
    read(3, "2\n", 200)                     = 2
    read(3, "", 198)                        = 0
    close(3)                                = 0
    wait4(-1, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 306024
    fstat(1, {st_mode=S_IFCHR|0620, st_rdev=makedev(0x88, 0), ...}) = 0
    write(1, "make -C \"/home/user/heads/build/"..., 74make -C "/home/user/heads/build/x86/coreboot-4.13" CPUS=2 "crossgcc-i386"
    ) = 74
    rt_sigprocmask(SIG_BLOCK, [HUP INT QUIT TERM XCPU XFSZ], NULL, 8) = 0
    stat("/usr/bin/env", {st_mode=S_IFREG|0755, st_size=48480, ...}) = 0
    geteuid()                               = 1000
    getegid()                               = 1000
    getuid()                                = 1000
    getgid()                                = 1000
    access("/usr/bin/env", X_OK)            = 0
    mmap(NULL, 36864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK, -1, 0) = 0x740f6e370000
    rt_sigprocmask(SIG_BLOCK, ~[], [HUP INT QUIT TERM CHLD XCPU XFSZ], 8) = 0
    clone(child_stack=0x740f6e378ff0, flags=CLONE_VM|CLONE_VFORK|SIGCHLD) = 306025
    munmap(0x740f6e370000, 36864)           = 0
    rt_sigprocmask(SIG_SETMASK, [HUP INT QUIT TERM CHLD XCPU XFSZ], NULL, 8) = 0
    rt_sigprocmask(SIG_UNBLOCK, [HUP INT QUIT TERM XCPU XFSZ], NULL, 8) = 0
    wait4(-1, make[1]: Entering directory '/home/user/heads/build/x86/coreboot-4.13'
    Welcome to the coreboot cross toolchain builder v ()

    Building toolchain using 2 thread(s).

    Target architecture is i386-elf

    Found compatible Ada compiler, enabling Ada support by default.

    Downloading and verifying tarballs ...
     * gmp-6.2.0.tar.xz (cached)... hash verified (052a5411dc74054240eec58132d2cf41211d0ff6)
     * mpfr-4.1.0.tar.xz (cached)... hash verified (159c3a58705662bfde4dc93f2617f3660855ead6) * mpc-1.2.0.tar.gz (cached)... hash verified (0abdc94acab0c9bfdaa391347cdfd7bbdb1cf017) * binutils-2.35.tar.xz (cached)... hash verified (6bdd090ce268b6d6c3442516021c4e4b5019e303) * gcc-8.3.0.tar.xz (cached)... hash verified (c27f4499dd263fe4fb01bcc5565917f3698583b2) Downloaded tarballs ... ok Unpacking and patching ... * mpfr-4.1.0.tar.xz * mpc-1.2.0.tar.gz * binutils-2.35.tar.xz
    ^C0x7ffd0303e760, 0, NULL)      = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
    strace: Process 305835 detached
```

So coreboot buildstack is built once per version and then reused on next board builds. Saves precious CI and local builds when developing with qemu/kvm.