### PR TITLE
modules/flashtools : version bump back to osresearch/flashtools

### DIFF
--- a/modules/flashtools
+++ b/modules/flashtools
@@ -2,11 +2,11 @@ modules-$(CONFIG_FLASHTOOLS) += flashtools
 
 flashtools_depends := $(musl_dep)
 
-flashtools_version := 76bdfa21d65caeb7dbe9c2fa1a837369732f50af
+flashtools_version := d1e6f12568cb23387144a4b7a6535fe1bc1e79b1
 flashtools_dir := flashtools-$(flashtools_version)
 flashtools_tar := flashtools-$(flashtools_version).tar.gz
-flashtools_url := https://github.com/3mdeb/flashtools/archive/$(flashtools_version).tar.gz
-flashtools_hash := 81b3c1f12318bd2942b426a99638e23d24e85819227653cd3b9302fbfc43b220
+flashtools_url := https://github.com/osresearch/flashtools/archive/$(flashtools_version).tar.gz
+flashtools_hash := a68cdb4a2e312f96862119a6d829ac900b53d0cbc80caa5632efd43b5b7eed6c
 
 flashtools_target := \
 	$(CROSS_TOOLS) \


### PR DESCRIPTION
Changes to support ppc64 were merged upstream