### PR TITLE
qemu-coreboot-whiptail-tpm2-hotp : add missing HOTP board requirements

### DIFF
--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -31,7 +31,7 @@ CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
 CONFIG_DROPBEAR=y
 CONFIG_MSRTOOLS=y
-#CONFIG_HOTPKEY=y
+CONFIG_HOTPKEY=y
 
 #Uncomment only one of the following block
 #Required for graphical gui-init (FBWhiptail)


### PR DESCRIPTION
Otherwise, functional equivalent of qemu-coreboot-whiptail-tpm2