### PR TITLE
modules/linux: fix linux.*config targets for non-x86 architectures

### DIFF
--- a/modules/linux
+++ b/modules/linux
@@ -215,10 +215,12 @@ linux.modifydefconfig:
 	$(MAKE) \
 		-C "$(build)/$(linux_base_dir)" \
 		O="$(build)/$(linux_dir)" \
+		ARCH="$(LINUX_ARCH)" \
 		menuconfig && \
 	$(MAKE) \
 		-C "$(build)/$(linux_base_dir)" \
 		O="$(build)/$(linux_dir)" \
+		ARCH="$(LINUX_ARCH)" \
 		savedefconfig && \
 	mv "$(build)/$(linux_dir)/defconfig" "$(pwd)/$(linux_kconfig)"
 
@@ -231,6 +233,7 @@ linux.generateoldconfig:
 	&& cp "$(pwd)/$(linux_kconfig)" "$(build)/$(linux_dir)/.config" \
 	&& $(MAKE) -C "$(build)/$(linux_base_dir)" \
 		O="$(build)/$(linux_dir)" \
+		ARCH="$(LINUX_ARCH)" \
 		olddefconfig \
 	&& echo "" \
 	&& echo "You can now edit $(build)/$(linux_dir)/.config" \
@@ -247,6 +250,7 @@ linux.menuconfig:
 	$(MAKE) \
 		-C "$(build)/$(linux_base_dir)" \
 		O="$(build)/$(linux_dir)" \
+		ARCH="$(LINUX_ARCH)" \
 		menuconfig \
 
 # The config file in the repo is stored as a "defconfig" format
@@ -255,5 +259,6 @@ linux.saveconfig:
 	$(MAKE) \
 		-C "$(build)/$(linux_base_dir)" \
 		O="$(build)/$(linux_dir)" \
+		ARCH="$(LINUX_ARCH)" \
 		savedefconfig
 	mv "$(build)/$(linux_dir)/defconfig" "$(pwd)/$(linux_kconfig)"


### PR DESCRIPTION
This patch adds ARCH="$(LINUX_ARCH)" to Linux targets working on config files. Without it, the architecture defaults to that of host, which for cross-compilation isn't right.