### PR TITLE
fix broken OEM re-ownership process

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -187,7 +187,7 @@ generate_checksums()
     if [ "$CONFIG_TPM" = "y" ];then
 	    if [ "$CONFIG_IGNORE_ROLLBACK" != "y" ]; then
 		    tpmr counter_create \
-			 -pwdo "$TPM_PASS_DEF" \
+			 -pwdo "$TPM_PASS" \
 			 -pwdc '' \
 			 -la -3135106223 \
 			    | tee /tmp/counter \


### PR DESCRIPTION
Problem
When using a custom password for TPM, the OEM re-ownership process is broken

Impact 
The OEM re-ownership process breaks for any user setting a custom password and not just using 12345678 

First appeared
https://github.com/osresearch/heads/commit/6923fb5e20cfb662b76c1d1fa48e245ecd8d79fb

Detail
on line 498, if blank, the TPM custom password is overwritten with TPM_PASS_DEF (eg, when no custom password is set by the user installing)

```
if [ "$TPM_PASS" == "" ]; then TPM_PASS=$TPM_PASS_DEF; fi
```
so far so good.  $TPM_PASS should be used for all TPM interaction from this point. $TMP_PASS_DEF is now a disposed of variable.

we see that happens when resetting the TPM on line 712 (generate_checksums) is that $TPM_PASS is used (correctly)

```## reset TPM and set password
if [ "$CONFIG_TPM" = "y" ]; then
  echo -e "\nResetting TPM...\n"
  tpmr reset "$TPM_PASS" >/dev/null 2>/tmp/error
---SNIP
```
The TPM now has either the custom password of the user, or the default of 12345678 depending on user selection.

On line 712, we duck into the generate_checksums sub, which for some reason reverts to TPM_PASS_DEF

```
    # create Heads TPM counter
    if [ "$CONFIG_TPM" = "y" ];then
	    if [ "$CONFIG_IGNORE_ROLLBACK" != "y" ]; then
		    tpmr counter_create \
			 -pwdo "$TPM_PASS_DEF" \
--SNIP
```

This then, rightly, fails due to 
```
Authentication failed (Incorrect Password) (ox1) from TPM_CreateCounter
```