### PR TITLE
Fix usb keyboard at init

### DIFF
--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -27,7 +27,7 @@ TRACE() {
 }
 
 preserve_rom() {
-	TRACE "Under /etc/functions:preserve_rom"
+	TRACE "Under /etc/ash_functions:preserve_rom"
 	new_rom="$1"
 	old_files=`cbfs -t 50 -l 2>/dev/null | grep "^heads/"`
 
@@ -44,7 +44,7 @@ preserve_rom() {
 }
 
 recovery() {
-	TRACE "Under /etc/functions:recovery"
+	TRACE "Under /etc/ash_functions:recovery"
 	echo >&2 "!!!!! $*"
 
 	# Remove any temporary secret files that might be hanging around
@@ -76,19 +76,19 @@ recovery() {
 }
 
 pause_recovery() {
-	TRACE "Under /etc/functions:pause_recovery"
+	TRACE "Under /etc/ash_functions:pause_recovery"
 	read -p $'!!! Hit enter to proceed to recovery shell !!!\n'
 	recovery $*
 }
 
 combine_configs() {
-	TRACE "Under /etc/functions:combine_configs"
+	TRACE "Under /etc/ash_functions:combine_configs"
 	cat /etc/config* > /tmp/config
 }
 
 enable_usb()
 {
-	TRACE "Under /etc/functions:enable_usb"
+	TRACE "Under /etc/ash_functions:enable_usb"
 	#insmod ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning 
 	if ! lsmod | grep -q ehci_hcd; then
 		insmod /lib/modules/ehci-hcd.ko \

--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -85,3 +85,47 @@ combine_configs() {
 	TRACE "Under /etc/functions:combine_configs"
 	cat /etc/config* > /tmp/config
 }
+
+enable_usb()
+{
+	TRACE "Under /etc/functions:enable_usb"
+	#insmod ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning 
+	if ! lsmod | grep -q ehci_hcd; then
+		insmod /lib/modules/ehci-hcd.ko \
+			|| die "ehci_hcd: module load failed"
+	fi
+	if [ "$CONFIG_LINUX_USB_COMPANION_CONTROLLER" = y ]; then
+		if ! lsmod | grep -q uhci_hcd; then
+			insmod /lib/modules/uhci-hcd.ko \
+			|| die "uhci_hcd: module load failed"
+		fi
+		if ! lsmod | grep -q ohci_hcd; then
+			insmod /lib/modules/ohci-hcd.ko \
+			|| die "ohci_hcd: module load failed"
+		fi
+		if ! lsmod | grep -q ohci_pci; then
+			insmod /lib/modules/ohci-pci.ko \
+			|| die "ohci_pci: module load failed"
+		fi
+	fi
+	if ! lsmod | grep -q ehci_pci; then
+		insmod /lib/modules/ehci-pci.ko \
+		|| die "ehci_pci: module load failed"
+	fi
+	if ! lsmod | grep -q xhci_hcd; then
+		insmod /lib/modules/xhci-hcd.ko \
+		|| die "xhci_hcd: module load failed"
+	fi
+	if ! lsmod | grep -q xhci_pci; then
+		insmod /lib/modules/xhci-pci.ko \
+		|| die "xhci_pci: module load failed"
+		sleep 2
+	fi
+
+	if [ "$CONFIG_USB_KEYBOARD" = y ]; then
+		if ! lsmod | grep -q usbhid; then
+			insmod /lib/modules/usbhid.ko \
+			|| die "usbhid: module load failed"
+		fi
+	fi
+}

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -81,51 +81,6 @@ confirm_totp()
 	echo
 }
 
-enable_usb()
-{
-	TRACE "Under /etc/functions:enable_usb"
-	#insmod ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning 
-	if ! lsmod | grep -q ehci_hcd; then
-                insmod /lib/modules/ehci-hcd.ko \
-                || die "ehci_hcd: module load failed"
-        fi
-	if [ "$CONFIG_LINUX_USB_COMPANION_CONTROLLER" = y ]; then
-		if ! lsmod | grep -q uhci_hcd; then
-			insmod /lib/modules/uhci-hcd.ko \
-			|| die "uhci_hcd: module load failed"
-		fi
-		if ! lsmod | grep -q ohci_hcd; then
-			insmod /lib/modules/ohci-hcd.ko \
-			|| die "ohci_hcd: module load failed"
-		fi
-		if ! lsmod | grep -q ohci_pci; then
-			insmod /lib/modules/ohci-pci.ko \
-			|| die "ohci_pci: module load failed"
-		fi
-	fi
-	if ! lsmod | grep -q ehci_pci; then
-		insmod /lib/modules/ehci-pci.ko \
-		|| die "ehci_pci: module load failed"
-	fi
-	if ! lsmod | grep -q xhci_hcd; then
-		insmod /lib/modules/xhci-hcd.ko \
-		|| die "xhci_hcd: module load failed"
-	fi
-	if ! lsmod | grep -q xhci_pci; then
-		insmod /lib/modules/xhci-pci.ko \
-		|| die "xhci_pci: module load failed"
-		sleep 2
-	fi
-
-	if [ "$CONFIG_USB_KEYBOARD" = y ]; then
-		if ! lsmod | grep -q usbhid; then
-			insmod /lib/modules/usbhid.ko \
-			|| die "usbhid: module load failed"
-		fi
-	fi
-
-}
-
 list_usb_storage()
 {
 	TRACE "Under /etc/functions:list_usb_storage"


### PR DESCRIPTION
TPM2 board inclusion made bash required, and we missed early usb keyboard enablement+testing after moving some required init functions, but not all required ones, from functions to ash_functions, causing a regression on x230 usb-keyb and talos, requiring early usb keyboard support.

enable_usb function is moved /etc/ash_functions to be called from init, which otherwise don't find needed function, since init only sources the minimal ash_functions before switching to boot policy (gui-init or any other specified in board config)

That code is required to do measurements in PCR5 prior of actually loading the kernel modules drivers. 
/sbin/insmod is actually a wrapper script calling `busybox insmod` **after** having measured modules to be loaded.
This prevents unsealing secrets which requires runtime related PCRs to be consistent to be unsealed.

---

As a reminder, Heads doesn't enable USB stack unless needed.
On host like the Talos II without ps2, USB support is required to interact with the machine early at boot.
And to have usb HID (USB keyboard support) the USB controllers drivers needs to be loaded. All of which is provvided by enable_usb function.

@krystian-hebel this PR addresses https://github.com/osresearch/heads/pull/1313#issuecomment-1492178115

---

I will test talos rom on top of this, and then rebase my commit on master instead of #1313 to merge this alone as fix on master so that you can rebase on master only including current relevant commit [35c34f4](https://github.com/osresearch/heads/pull/1362/commits/35c34f4c9d4c5c1a60782dfe5ab29e35e8f95d93)