### PR TITLE
qemu-coreboot-*whiptail-tpm2-* boards: move TPM2 debug PCAP variable to debug section for clarity

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -10,6 +10,8 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+export CONFIG_TPM2_CAPTURE_PCAP=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
@@ -63,7 +65,6 @@ export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 #TPM2 requirements
 export CONFIG_TPM2_TOOLS=y
 export CONFIG_PRIMARY_KEY_TYPE=ecc
-export CONFIG_TPM2_CAPTURE_PCAP=y
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
@@ -9,6 +9,8 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+export CONFIG_TPM2_CAPTURE_PCAP=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
@@ -62,7 +64,6 @@ export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 #TPM2 requirements
 export CONFIG_TPM2_TOOLS=y
 export CONFIG_PRIMARY_KEY_TYPE=ecc
-export CONFIG_TPM2_CAPTURE_PCAP=y
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -10,6 +10,8 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+export CONFIG_TPM2_CAPTURE_PCAP=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
@@ -63,7 +65,6 @@ export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 #TPM2 requirements
 export CONFIG_TPM2_TOOLS=y
 export CONFIG_PRIMARY_KEY_TYPE=ecc
-export CONFIG_TPM2_CAPTURE_PCAP=y
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 

--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -9,6 +9,8 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+export CONFIG_TPM2_CAPTURE_PCAP=y
 
 CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
@@ -62,7 +64,6 @@ export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 #TPM2 requirements
 export CONFIG_TPM2_TOOLS=y
 export CONFIG_PRIMARY_KEY_TYPE=ecc
-export CONFIG_TPM2_CAPTURE_PCAP=y
 CONFIG_TPM2_TSS=y
 CONFIG_OPENSSL=y
 


### PR DESCRIPTION
Since qemu boards are reference for TPM2 boards, it will remove a lot of future questions to have the PCAP debug related variable in board config under the debug section.

Changes it for the 4 current tpm2 boards in tree.

@JonathonHall-Purism : in link with questions already received https://matrix.to/#/!pAlHOfxQNPXOgFGTmo:matrix.org/$ZIbrfnsU668-yEzFoCyNGAOyg6mvtHwWAJkl26zukM0?via=matrix.org&via=nitro.chat&via=talk.puri.sm