### PR TITLE
modules/json-c: set cmake build type as minsizerel

### DIFF
--- a/modules/json-c
+++ b/modules/json-c
@@ -28,7 +28,7 @@ json-c_configure := \
 	echo -e "$(toolchain_file)" | sed 's/\\//g' > toolchain && \
 	mkdir -p build && \
 	cd build && \
-	cmake .. -DCMAKE_INSTALL_PREFIX="$(INSTALL)" -DCMAKE_TOOLCHAIN_FILE=../toolchain
+	cmake .. -DCMAKE_INSTALL_PREFIX="$(INSTALL)" -DCMAKE_TOOLCHAIN_FILE=../toolchain -DCMAKE_BUILD_TYPE=minsizerel
 
 json-c_target := \
 	$(CROSS_TOOLS) -C $(build)/$(json-c_dir)/build \


### PR DESCRIPTION
By default json-c builds as debug instead of release.

Adding `CMAKE_BUILD_TYPE=minsizerel` ensures it does not add debug info and optimizes for file size.

Fixes https://github.com/osresearch/heads/issues/1328