### PR TITLE
Iso boot debugging and fixes

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -61,6 +61,11 @@ adjust_cmd_line() {
 	adjusted_cmd_line="y"
 }
 
+if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
+	#If expecting debug output, have kexec load (-l) output debug info
+	kexeccmd="$kexeccmd -d"
+fi
+
 module_number="1"
 while read line
 do
@@ -76,7 +81,14 @@ do
 		elif [ "$kexectype" = "multiboot" ]; then
 			kexeccmd="$kexeccmd -l $filepath"
 			kexeccmd="$kexeccmd --command-line \"$restval\""
+		elif [ "$kexectype" = "elf" ]; then
+			DEBUG "kexectype= $kexectype"
+			DEBUG "restval= $restval"
+			DEBUG "filepath= $filepath"
+			kexeccmd="$kexeccmd -l $filepath"
+			DEBUG "kexeccmd= $kexeccmd"
 		else
+			DEBUG "unknown kexectype!!!!"
 			kexeccmd="$kexeccmd -l $filepath"
 		fi
 	fi

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -27,7 +27,7 @@ mount -t iso9660 -o loop $MOUNTED_ISO_PATH /boot \
 	|| die '$MOUNTED_ISO_PATH: Unable to mount /boot'
 
 DEV_UUID=`blkid $DEV | tail -1 | tr " " "\n" | grep UUID | cut -d\" -f2`
-ADD="fromiso=/dev/disk/by-uuid/$DEV_UUID/$ISO_PATH img_dev=/dev/disk/by-uuid/$DEV_UUID iso-scan/filename=/${ISO_PATH} img_loop=$ISO_PATH"
+ADD="fromiso=/dev/disk/by-uuid/$DEV_UUID/$ISO_PATH img_dev=/dev/disk/by-uuid/$DEV_UUID iso-scan/filename=/${ISO_PATH} img_loop=$ISO_PATH iso=$DEV_UUID/$ISO_PATH"
 REMOVE=""
 
 paramsdir="/media/kexec_iso/$ISO_PATH"

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -47,7 +47,7 @@ if [ -r $REMOVE_FILE ]; then
 fi
 
 # Call kexec and indicate that hashes have been verified
-kexec-select-boot -b /boot -d /media -p "$paramsdir" \
+DO_WITH_DEBUG kexec-select-boot -b /boot -d /media -p "$paramsdir" \
 	-a "$ADD" -r "$REMOVE" -c "*.cfg" -u -i
 
 die "Something failed in selecting boot"

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -21,14 +21,20 @@ reset_entry() {
 }
 
 filedir=`dirname $file`
+DEBUG "filedir= $filedir"
 bootdir="${bootdir%%/}"
+DEBUG "bootdir= $bootdir"
 bootlen="${#bootdir}"
+DEBUG "bootlen= $bootlen"
 appenddir="${filedir:$bootlen}"
+DEBUG "appenddir= $appenddir"
 
 fix_path() {
 	path="$@"
 	if [ "${path:0:1}" != "/" ]; then
+		DEBUG "fix_path: path was $@"
 		path="$appenddir/$path"
+		DEBUG "fix_path: path is now $path"
 	fi
 }
 
@@ -38,7 +44,10 @@ check_path() {
 	local checkpath firstval
 	checkpath="$1"
 	firstval="$(echo "$checkpath" | cut -d\  -f1)"
-	if ! [ -r "$bootdir$firstval" ]; then return 1; fi
+	if ! [ -r "$bootdir$firstval" ]; then
+		DEBUG "$bootdir$firstval doesn't exist"
+		return 1; 
+	fi
 	return 0
 }
 
@@ -111,6 +120,7 @@ grub_entry() {
 			# TODO: differentiate between Xen and other multiboot kernels
 			kexectype="xen"
 			kernel="$val"
+			DEBUG " grub_entry multiboot kernel= $kernel"
 			;;
 		module*)
 			case $val in
@@ -118,6 +128,7 @@ grub_entry() {
 			esac
 			fix_path $val
 			modules="$modules|module $path"
+			DEBUG " grub_entry linux modules= $modules"
 			;;
 		linux*)
 			# Some configs have a device specification in the kernel
@@ -125,12 +136,14 @@ grub_entry() {
 			# it.  Keep the '/' following the device, since this
 			# path is relative to the device root, not the config
 			# location.
+			DEBUG " grub_entry : linux trimcmd prior of kernel/append parsing: $trimcmd"
 			kernel=`echo $trimcmd | sed "s/([^)]*)//g" | cut -d\  -f2`
 			append=`echo $trimcmd | cut -d\  -f3-`
 			;;
 		initrd*)
 			# Trim off device specification as above
 			initrd="$(echo "$val" | sed "s/([^)]*)//g")"
+			DEBUG " grub_entry: linux initrd= $initrd"
 			;;
 	esac
 }
@@ -206,16 +219,19 @@ syslinux_entry() {
 					;;
 				*)
 					kernel="${val#"$bootdir"}"
+					DEBUG "kernel= $kernel"
 			esac
 			;;
 		initrd* | INITRD* )
 			initrd="${val#"$bootdir"}"
+			DEBUG "initrd= $initrd"
 			;;
 		append* | APPEND* )
 			if [ "$kexectype" = "multiboot" -o "$kexectype" = "xen" ]; then
 				syslinux_multiboot_append
 			else
 				append="$val"
+				DEBUG "append= $append"
 			fi
 			;;
 	esac

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -218,12 +218,12 @@ syslinux_entry() {
 					state="search"
 					;;
 				*)
-					kernel="${val#"$bootdir"}"
+					kernel="$val"
 					DEBUG "kernel= $kernel"
 			esac
 			;;
 		initrd* | INITRD* )
-			initrd="${val#"$bootdir"}"
+			initrd="$val"
 			DEBUG "initrd= $initrd"
 			;;
 		append* | APPEND* )

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -182,7 +182,7 @@ scan_options() {
 	option_file="/tmp/kexec_options.txt"
 	if [ -r $option_file ]; then rm $option_file; fi
 	for i in `find $bootdir -name "$config"`; do
-		kexec-parse-boot "$bootdir" "$i" >> $option_file
+		DO_WITH_DEBUG kexec-parse-boot "$bootdir" "$i" >> $option_file
 	done
 	# FC29/30+ may use BLS format grub config files
 	# https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -86,7 +86,7 @@ if [ `cat /tmp/iso_menu.txt | wc -l` -gt 0 ]; then
 	if [ -n "$option" ]; then
 		MOUNTED_ISO=$option
 		ISO=${option:7} # remove /media/ to get device relative path
-		kexec-iso-init $MOUNTED_ISO $ISO $USB_BOOT_DEV
+		DO_WITH_DEBUG kexec-iso-init $MOUNTED_ISO $ISO $USB_BOOT_DEV
 
 		die "Something failed in iso init"
 	fi
@@ -95,9 +95,9 @@ fi
 echo "!!! Could not find any ISO, trying bootable USB"
 # Attempt to pull verified config from device
 if [ -x /bin/whiptail ]; then
-	kexec-select-boot -b /media -c "*.cfg" -u -g -s
+	DO_WITH_DEBUG kexec-select-boot -b /media -c "*.cfg" -u -g -s
 else
-	kexec-select-boot -b /media -c "*.cfg" -u -s
+	DO_WITH_DEBUG kexec-select-boot -b /media -c "*.cfg" -u -s
 fi
 
 die "Something failed in selecting boot"

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -11,5 +11,5 @@ if [ "$CONFIG_TPM" = "y" ]; then
 	tpmr extend -ix 4 -ic usb
 fi
 
-media-scan usb
+DO_WITH_DEBUG media-scan usb
 recovery "Something failed during USB boot"


### PR DESCRIPTION
- Add debug information from usb-init (or media-scan) up to kexec -e call
- Adds Tinycore iso magic (for Tinycore init to be able to find iso after successful kexec call)
- Adds the fix to isolinux parsing which was not dealing correctly with iso boot (where dd'ed iso was working)

Fixes #1347 
Fixes #1374 

@JonathonHall-Purism please review (this is different then #1351 which will be rebased on this when I have time to continue checking why we cannot have basic simple fb in absence of virtio fb under Tinycore's initrd)

@saper that should fix your issue under x230 with 4.x kernel which doen't suffer from 5.x-> Tinycore novga issue (like on qemu)