### PR TITLE
coreboot: output xcompile into old shared location for all coreboot versions to prevent buildstack rebuild

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -92,6 +92,7 @@ coreboot_target := \
 	CROSS="$(COREBOOT_CROSS)" \
 	IASL="$(COREBOOT_IASL)" \
 	DOTCONFIG="$(build)/$(coreboot_dir)/.config" \
+	xcompile="$(build)/$(coreboot_base_dir)/.xcompile" \
 	BUILD_TIMELESS=1 \
 	CFLAGS_x86_32="$(EXTRA_FLAGS)" \
 	CFLAGS_x86_64="$(EXTRA_FLAGS)" \


### PR DESCRIPTION
Fixes https://github.com/osresearch/heads/issues/1370

Tested locally by doing two `make BOARD=t440-maximized`.  (coreboot 4.17 > 4.13)
Second build skips coreboot buildstack extraction, patching and building.

@JonathonHall-Purism please review (will check CircleCI output for different coreboot versions meanwhile. Second layer builds builds for same coreboot version should not build buildstack).

Addresses changeset https://review.coreboot.org/c/coreboot/+/28101