### PR TITLE
Bash reproducibility

### DIFF
--- a/modules/bash
+++ b/modules/bash
@@ -7,7 +7,7 @@ bash_tar := bash-$(bash_version).tar.gz
 bash_url := https://ftpmirror.gnu.org/bash/$(bash_tar)
 bash_hash := 5bac17218d3911834520dad13cd1f85ab944e1c09ae1aba55906be1f8192f558
 
-bash_configure := CFLAGS=-Os ./configure \
+bash_configure := CFLAGS="-g0 -Os" LDFLAGS="-s" ./configure \
 	$(CROSS_TOOLS) \
 	--host $(target) \
 	--prefix="/usr" \

--- a/patches/bash-5.1.16.patch
+++ b/patches/bash-5.1.16.patch
@@ -1,0 +1,11 @@
+--- clean/bash-5.1.16/Makefile.in	2020-12-16 16:13:10.000000000 -0600
++++ bash-5.1.16/Makefile.in	2023-04-25 14:16:38.849618679 -0600
+@@ -626,7 +626,7 @@
+ 	@${MAKE} ${MFLAGS} tests TESTSCRIPT=run-gprof
+ 
+ version.h:  $(SOURCES) config.h Makefile patchlevel.h
+-	$(SHELL) $(SUPPORT_SRC)mkversion.sh -b -S ${topdir} -s $(RELSTATUS) -d $(Version) -o newversion.h \
++	$(SHELL) $(SUPPORT_SRC)mkversion.sh -S ${topdir} -s $(RELSTATUS) -d $(Version) -o newversion.h \
+ 		&& mv newversion.h version.h
+ 
+ bashversion$(EXEEXT): buildversion.o $(SUPPORT_SRC)bashversion.c


### PR DESCRIPTION
Removing debug info from bash.

Adding patch to disable bash auto increment of the build number that goes in the version string of the binary.
The increment is triggered when bash/configure is run and bash/.build file already exists.
Patch consists of removing the relevant flag from the call to helper script in makefile template.

Should fix bash reproducibility.