### PR TITLE
Makefile: adapt cleaning targets for arch directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,8 +609,8 @@ echo_modules:
 modules.clean:
 	for dir in $(module_dirs) \
 	; do \
-		$(MAKE) -C "build/$$dir" clean ; \
-		rm "build/$$dir/.configured" ; \
+		$(MAKE) -C "build/${CONFIG_TARGET_ARCH}/$$dir" clean ; \
+		rm -f "build/${CONFIG_TARGET_ARCH}/$$dir/.configured" ; \
 	done
 
 # Inject a GPG key into the image - this is most useful when testing in qemu,
@@ -631,7 +631,7 @@ real.clean:
 		$(kernel_headers) \
 	; do \
 		if [ ! -z "$$dir" ]; then \
-			rm -rf "build/$$dir"; \
+			rm -rf "build/${CONFIG_TARGET_ARCH}/$$dir"; \
 		fi; \
 	done
 	cd install && rm -rf -- *


### PR DESCRIPTION
Just a very minor fix for the `real.clean` and `modules.clean` Makefile targets - they haven't been adapted to the architecture hierarchy inside `build`.