### PR TITLE
seal-totp: better document inclusion of PCR4 measurements part of sealing op

### DIFF
--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -30,7 +30,7 @@ dd \
 
 secret="`base32 < $TOTP_SECRET`"
 pcrf="/tmp/secret/pcrf.bin"
-DEBUG "Sealing TOTP with actual state of PCR0-4)"
+DEBUG "Sealing TOTP with actual state of PCR0-4"
 tpmr pcrread 0 "$pcrf"
 tpmr pcrread -a 1 "$pcrf"
 tpmr pcrread -a 2 "$pcrf"
@@ -38,7 +38,7 @@ tpmr pcrread -a 3 "$pcrf"
 DEBUG "Sealing TOTP with actual state of PCR4 (Going to recovery shell extends PCR4)"
 # pcr 4 is expected to either: 
 #  zero on bare coreboot+linuxboot on x86 (boot mode: init)
-#  already extended on ppc64 per BOOTKERNEL (skiboot) which boots heads.
+#  already extended on ppc64 per BOOTKERNEL (skiboot) and seperators on PPC64.
 #We expect the PCR4 to be in the right state at unattended unseal operation
 tpmr pcrread -a 4 "$pcrf"
 # pcr 5 (kernel modules loaded) is not measured at sealing/unsealing of totp


### PR DESCRIPTION
commit https://github.com/osresearch/heads/commit/7b949a1a44eced0e90199eb6bd4e01513234f081 would have deserved a PR.

Here is a cbmem -L (tcpa log) on Talos II to explain why we need to include PCR4 measurements which now includes extends with BOOTKERNEL and seperators measurements.


Edit: Also why taking for granted that PCRs are zeroed on boot is not respecting TCG guidelines. Basically, PCRs boot values should be used as a base for tuturecalcpcr operations to determine to be sealed values for next boot unseal operations.

```
~ # cbmem -L
TPM2 log:
	Specification: 2.00
	Platform class: PC Client
TPM2 log entry 1:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: 27c4f1fa214480c8626397a15981ef3a9323717f
	Event data: 50 FMAP: FMAP
TPM2 log entry 2:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: 2d5f9d8abb287dc868a1b8505b11989f307d8cce
	Event data: 50 FMAP: BOOTBLOCK
TPM2 log entry 3:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: cba866ea5956334e5d1c7b58b21c28836cd25c95
	Event data: 50 CBFS: fallback/romstage
TPM2 log entry 4:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: 0447bd27531fcd0e293fca6f43e7ca6539de874e
	Event data: 50 CBFS: fallback/ramstage
TPM2 log entry 5:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: 567e5aa96274a685bf6ddda2599013e48bd346e2
	Event data: 50 CBFS: fallback/payload
TPM2 log entry 6:
	PCR: 2
	Event type: Action
	Digests:
		 SHA1: 11b04b24178f9c1f4dbe89a1b6e959dab6caf6c4
	Event data: 50 CBFS: 2-cpus.dtb
TPM2 log entry 7:
	PCR: 3
	Event type: Action
	Digests:
		 SHA256: 6e7b06693452d997ac534e823b1ea79e5bb8ed19ba8a7af878abf10199c3d515
		 SHA1: 6e7b06693452d997ac534e823b1ea79e5bb8ed19
	Event data: 7 VERSION
TPM2 log entry 8:
	PCR: 2
	Event type: Action
	Digests:
		 SHA256: de73053377e1ae5ba5d2b637a4f5bfaeb410137722f11ef135e7a1be524e3092
		 SHA1: de73053377e1ae5ba5d2b637a4f5bfaeb4101377
	Event data: 11 IMA_CATALOG
TPM2 log entry 9:
	PCR: 4
	Event type: Action
	Digests:
		 SHA256: c013f948107aa41f33a44ecdac691cd5d0fe9335584ae2476b2bc0fb7d866e87
		 SHA1: c013f948107aa41f33a44ecdac691cd5d0fe9335
	Event data: 10 BOOTKERNEL
TPM2 log entry 10:
	PCR: 0
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 11:
	PCR: 1
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 12:
	PCR: 2
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 13:
	PCR: 3
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 14:
	PCR: 4
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 15:
	PCR: 5
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 16:
	PCR: 6
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
TPM2 log entry 17:
	PCR: 7
	Event type: Separator
	Digests:
		 SHA256: ad95131bc0b799c0b1af477fb14fcf26a6a9f76079e48bf090acb7e8367bfd0e
		 SHA1: d9be6524a5f5047db5866813acf3277892a7a30a
	Event data: 4 ����
```

But PCR 5,6,7 are also touched.
Houston, we still have collision https://osresearch.net/Keys/#tpm-pcrs
