### PR TITLE
flashrom: bump flashrom to upstream 1.3 and fix flash.sh progress_bar

### DIFF
--- a/modules/flashrom
+++ b/modules/flashrom
@@ -2,17 +2,18 @@ modules-$(CONFIG_FLASHROM) += flashrom
 
 flashrom_depends := pciutils $(musl_dep)
 
-flashrom_version := b1f858f65b2abd276542650d8cb9e382da258967
+flashrom_version := 1776bb46ba6ea3d1ab2ec3f0cd88158aabed7400
 flashrom_dir := flashrom-$(flashrom_version)
 flashrom_tar := $(flashrom_dir).tar.gz
 flashrom_url := https://github.com/flashrom/flashrom/archive/$(flashrom_version).tar.gz
-flashrom_hash := 4873ad50f500629c244fc3fbee64b56403a82307d7f555dfa235336a200c336c
+flashrom_hash := 65e262ca4428a0ceddd73f481ed0d8444393b73a78469f266a4457dfc834ecb7
 
 # Default options for flashrom
 flashrom_cfg := \
 	WARNERROR=no \
 	CONFIG_NOTHING=yes \
 	CONFIG_INTERNAL=yes \
+	CONFIG_INTERNAL_X86=yes
 	CONFIG_DUMMY=yes \
 	CONFIG_AST1100=yes \
 
@@ -28,7 +29,8 @@ endif
 flashrom_target := \
 	$(MAKE_JOBS) \
 	$(CROSS_TOOLS) \
-	$(flashrom_cfg)
+	$(flashrom_cfg) \
+	flashrom
 
 flashrom_output := \
 	flashrom

--- a/modules/flashrom
+++ b/modules/flashrom
@@ -13,18 +13,21 @@ flashrom_cfg := \
 	WARNERROR=no \
 	CONFIG_NOTHING=yes \
 	CONFIG_INTERNAL=yes \
-	CONFIG_INTERNAL_X86=yes
-	CONFIG_DUMMY=yes \
-	CONFIG_AST1100=yes \
+	CONFIG_INTERNAL_X86=yes \
 
 ifeq "$(CONFIG_TARGET_ARCH)" "ppc64"
 flashrom_cfg := \
 	WARNERROR=no \
 	CONFIG_NOTHING=yes \
-	CONFIG_LINUX_MTD=yes \
-	CONFIG_DUMMY=yes \
-	CONFIG_AST1100=yes
+	CONFIG_LINUX_MTD=yes
 endif
+
+#Only enable AST1100 if requested per board configs
+ifeq "$(CONFIG_FLASHROM_AST1100)" "y"
+flashrom_cfg += CONFIG_AST1100=yes
+endif
+
+
 
 flashrom_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
Based on commit https://github.com/JonathonHall-Purism/heads/commit/2bb58f7f25bd55564132f48eaaa8ceb942f2b6ee

- Extended to not have the progress bar stuck at 99%. Progress bar drawing under Heads still needed until properly implemented upstream see https://ticket.coreboot.org/issues/390
- Removes flashrom DUMMY and AST1100 on both x86 and ppc64.
  - AST1100 can be added through board config option instead of bloating smaller SPI boards ROMs.

TODO: probably split flashrom into flashrom-stable/flashrom-upstream/flashrom-dasharo and have boards use the one needed. I suspect flashrom-stable will be even smaller.

---

Good news is that #1422  #1381 and this PR merged under #1398 can be compiled for legacy boards, dodging #1421 issue for the moment.