### PR TITLE
Makefile: have sizes report output on screen and into sizes.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,13 @@ PACKAGES	:= $(shell mkdir -p "$(packages)")
 
 # record the build date / git hashes and other files here
 HASHES		:= $(board_build)/hashes.txt
+SIZES		:= $(board_build)/sizes.txt
 
 # Create the board output directory if it doesn't already exist
 BOARD_LOG	:= $(shell \
 	mkdir -p "$(board_build)" ; \
 	echo "$(DATE) $(GIT_HASH) $(GIT_STATUS)" > "$(HASHES)" ; \
+	echo "$(DATE) $(GIT_HASH) $(GIT_STATUS)" > "$(SIZES)" ; \
 )
 
 ifeq "y" "$(CONFIG_LINUX_BUNDLED)"
@@ -167,6 +169,7 @@ endif
 
 all payload:
 	@sha256sum $< | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $< | tee -a "$(SIZES)"
 
 # Disable all built in rules
 .INTERMEDIATE:
@@ -230,6 +233,7 @@ define do-cpio =
 		rm "$1.tmp" ; \
 	fi
 	@sha256sum "$1" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$1" | tee -a "$(SIZES)"
 	$(call do,HASHES   , $1,\
 		( cd "$2"; \
 		echo "-----" ; \
@@ -237,6 +241,14 @@ define do-cpio =
 		| xargs -0 sha256sum ; \
 		echo "-----" ; \
 		) >> "$(HASHES)" \
+	)
+	$(call do,SIZES    , $1,\
+		( cd "$2"; \
+		echo "-----" ; \
+		find . -type f -print0 \
+		| xargs -0 stat -c "%8s:%n" ; \
+		echo "-----" ; \
+		) >> "$(SIZES)" \
 	)
 endef
 
@@ -248,6 +260,7 @@ define do-copy =
 		cp -a --remove-destination "$1" "$2" ; \
 	)
 	@sha256sum "$(2:$(pwd)/%=%)"
+	@stat -c "%8s:%n" "$(2:$(pwd)/%=%)"
 endef
 
 
@@ -576,6 +589,7 @@ $(build)/$(initrd_dir)/initrd.cpio.xz: $(initrd-y)
 		rm "$@.tmp" ; \
 	fi
 	@sha256sum "$(@:$(pwd)/%=%)" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$(@:$(pwd)/%=%)" | tee -a "$(SIZES)"
 
 #
 # At the moment PowerPC can only load initrd bundled with the kernel.

--- a/modules/linux
+++ b/modules/linux
@@ -195,6 +195,7 @@ $(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build
 	$(call do-copy,$(dir $<)/$(linux_output),$@)
 	@touch $@ # force a timestamp update
 	@sha256sum "$@" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$@" | tee -a "$(SIZES)"
 
 # Build kernel second time, now that initrd is built.
 $(build)/$(BOARD)/$(LINUX_IMAGE_FILE).bundled: \


### PR DESCRIPTION
This adds an easy way to compare sizes of packed stripped built binaries and libs in cpios, compressed under initrd and the kernel bzImage and coreboot rom, both on screen and into sizes.txt.

This is basically a copy paste + `stat -c "%8s:%n"` under Makefile & modules/linux, reusing HASHES code but duplicating for SIZES.

Note that the sizes.txt can be sorted for human eyes through a simple `cat sizes.txt | sort -h`.

I would love to have this merged now so that master can be compared to branches that are rebased upon it.

---

@JonathonHall-Purism : can you review+approve asap please?