### PR TITLE
CircleCI: have sizes output kept in CircleCI forever just as hashes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,11 @@ commands:
       - run:
           name: Output hashes
           command: |
-            cat build/<<parameters.arch>>/<<parameters.target>>/hashes.txt || echo "No hashes for this build step..."\
+            cat build/<<parameters.arch>>/<<parameters.target>>/hashes.txt || echo "No hashes.txt for this build step..."
+      - run:
+          name: Output sizes
+          command: |
+            cat build/<<parameters.arch>>/<<parameters.target>>/sizes.txt || echo "No sizes.txt for this build step..."
       - run:
           name: Archiving build logs.
           command: |


### PR DESCRIPTION
CircleCI keeps steps output forever as opposed to artifacts.
This permits us to keep sizes.txt output as a step for a board forever, just like for hashes.

@JonathonHall-Purism 