### PR TITLE
Kexec cosmetic fixes

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -146,6 +146,17 @@ echo "$kexeccmd"
 eval "$kexeccmd" \
 || die "Failed to load the new kernel"
 
+if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
+	#Repeat kexec command that will be executed since in debug
+	DEBUG "kexeccmd= $kexeccmd"
+
+	read -n 1 -p "[DEBUG] Continue booting? [Y/n]: " debug_boot_confirm
+	if [ "${debug_boot_confirm^^}" = N ]; then
+		# abort
+		die "Boot aborted"
+	fi
+fi
+
 if [ "$CONFIG_TPM" = "y" ]; then
 	tpmr kexec_finalize
 fi

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -68,6 +68,7 @@ if [ "$unseal_failed" = "y" ]; then
 	fi
 fi
 
+echo 
 echo '+++ Building initrd'
 # pad the initramfs (dracut doesn't pad the last gz blob)
 # without this the kernel init/initramfs.c fails to read

--- a/patches/kexec-2.0.26.patch
+++ b/patches/kexec-2.0.26.patch
@@ -83,8 +83,8 @@ index 14263b0..55291d6 100644
 +                dbgprintf("%s: Reusing video type %d\n",
 +                    __func__, real_mode->orig_video_isVGA);
  	} else {
-+                dbgprintf("%s: Unknown driver %s, can't provide framebuffer\n",
-+                    __func__, fix.id);
++                fprintf(stderr, "Unknown driver %s, can't provide framebuffer\n kexec'ed OS will take over console only if %s is provided\n",
++                    fix.id, fix.id);
  		real_mode->orig_video_isVGA = 0;
  		close(fd);
  		return 0;
@@ -95,7 +95,7 @@ index 14263b0..55291d6 100644
 +            dbgprintf("%s: Kernel did not provide framebuffer address\n",
 +                __func__);
 +            dbgprintf("%s: Try enabling CONFIG_DRM_FBDEV_LEAK_PHYS_SMEM and "
-+                "drm_kms_helper.drm_leak_fbdev_smem\n",
++                "drm_kms_helper.drm_leak_fbdev_smem in kernel command-line options\n",
 +                __func__);
 +        }
 +


### PR DESCRIPTION
So that actual boards and future boards show that they might stay in the dark until OS loads the proper DRM/FB drivers if unsupported by kexec

Linux kernel changed since 4.19.
Since then, buffer addresses are generally hidden and cannot be directly passed to another kernel through kexec anymore.

Workarounds have been applied to linux kernel and kexec patch for i915drmfb, while others are currently unsupported out of the box.

Transition out of this is to have all boards rely on linux kernel's simplefb frambebuffer.
Meanwhile, other boards relying on kexec will show an error like the following that is shown for qemu boards as of today:

![2023-07-07-141414](https://github.com/osresearch/heads/assets/827570/49ad65de-df6a-4575-b63a-e0a84dc74460)

The `kexec -l` call outputs an error about virtio_gpudrmfb driver, which cannot expose its fb address to kexec and therefore, the user stays in the dark until the next kernel loads that driver and drives the console again.

@JonathonHall-Purism : please review