### PR TITLE
Use Intel mirror for acpi-unix2 20220331

### DIFF
--- a/patches/coreboot-4.17/0004-acpi-unix2-mirror.patch
+++ b/patches/coreboot-4.17/0004-acpi-unix2-mirror.patch
@@ -1,0 +1,32 @@
+From 8093bd4df682a49ab87845e4154e87885ad41734 Mon Sep 17 00:00:00 2001
+From: Jonathon Hall <jonathon.hall@puri.sm>
+Date: Tue, 11 Jul 2023 14:48:33 -0400
+Subject: [PATCH] util/crossgcc/buildgcc: Use different mirror
+
+acpica.org now redirects to Intel and all the links no longer work.
+
+Intel has a mirror of this archive, use it.
+
+Change-Id: I4fbfe33a4614aec97c631904d78ec391ed438bec
+Signed-off-by: Jonathon Hall <jonathon.hall@puri.sm>
+---
+ util/crossgcc/buildgcc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/util/crossgcc/buildgcc b/util/crossgcc/buildgcc
+index b25b260807..24916c5ab8 100755
+--- a/util/crossgcc/buildgcc
++++ b/util/crossgcc/buildgcc
+@@ -52,7 +52,8 @@ MPFR_ARCHIVE="https://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+ MPC_ARCHIVE="https://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
+ GCC_ARCHIVE="https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
+ BINUTILS_ARCHIVE="https://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
+-IASL_ARCHIVE="https://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
++# acpica.org links rotted, use Intel mirror for 20220331
++IASL_ARCHIVE="https://downloadmirror.intel.com/774879/acpica-unix2-${IASL_VERSION}.tar.gz"
+ # CLANG toolchain archive locations
+ LLVM_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
+ CLANG_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-${CLANG_VERSION}.src.tar.xz"
+-- 
+2.30.2
+

--- a/patches/coreboot-talos_2/0002-acpi-unix2-mirror.patch
+++ b/patches/coreboot-talos_2/0002-acpi-unix2-mirror.patch
@@ -1,0 +1,32 @@
+From 8093bd4df682a49ab87845e4154e87885ad41734 Mon Sep 17 00:00:00 2001
+From: Jonathon Hall <jonathon.hall@puri.sm>
+Date: Tue, 11 Jul 2023 14:48:33 -0400
+Subject: [PATCH] util/crossgcc/buildgcc: Use different mirror
+
+acpica.org now redirects to Intel and all the links no longer work.
+
+Intel has a mirror of this archive, use it.
+
+Change-Id: I4fbfe33a4614aec97c631904d78ec391ed438bec
+Signed-off-by: Jonathon Hall <jonathon.hall@puri.sm>
+---
+ util/crossgcc/buildgcc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/util/crossgcc/buildgcc b/util/crossgcc/buildgcc
+index b25b260807..24916c5ab8 100755
+--- a/util/crossgcc/buildgcc
++++ b/util/crossgcc/buildgcc
+@@ -52,7 +52,8 @@ MPFR_ARCHIVE="https://ftpmirror.gnu.org/mpfr/mpfr-${MPFR_VERSION}.tar.xz"
+ MPC_ARCHIVE="https://ftpmirror.gnu.org/mpc/mpc-${MPC_VERSION}.tar.gz"
+ GCC_ARCHIVE="https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz"
+ BINUTILS_ARCHIVE="https://ftpmirror.gnu.org/binutils/binutils-${BINUTILS_VERSION}.tar.xz"
+-IASL_ARCHIVE="https://acpica.org/sites/acpica/files/acpica-unix2-${IASL_VERSION}.tar.gz"
++# acpica.org links rotted, use Intel mirror for 20220331
++IASL_ARCHIVE="https://downloadmirror.intel.com/774879/acpica-unix2-${IASL_VERSION}.tar.gz"
+ # CLANG toolchain archive locations
+ LLVM_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz"
+ CLANG_ARCHIVE="https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang-${CLANG_VERSION}.src.tar.xz"
+-- 
+2.30.2
+


### PR DESCRIPTION
I built Librem 14 locally to verify the coreboot-4.17 patch.  Copied verbatim to coreboot-talos_2, will check CI build status.