### PR TITLE
Qemu boards: typo correction in comment to manually enable Basic Boot mode

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -10,7 +10,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -8,7 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -9,7 +9,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
@@ -8,7 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -10,7 +10,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -8,7 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -9,7 +9,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y

--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -8,7 +8,7 @@ export CONFIG_LINUX_VERSION=5.10.5
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
-#export CONFIG_BASIC_BOOT=y
+#export CONFIG_BASIC=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y


### PR DESCRIPTION
 Was CONFIG_BASIC_BOOT instead of CONFIG_BASIC expected.

@3hhh I would recommend playing with this in the goal of #1441.
@JonathonHall-Purism simple review please.

Also some tweaks seem needed to enable autoboot on basic basic boot: current basic boot enablement thinks autoboot is configured because not negated?