### PR TITLE
ioport: changing url to debian, same hash. First need to go into #1198 direction

### DIFF
--- a/modules/ioport
+++ b/modules/ioport
@@ -1,9 +1,9 @@
 modules-$(CONFIG_IOPORT) += ioport
 
-ioport_version := 1.2
+ioport_version := 1.2.orig
 ioport_dir := ioport-$(ioport_version)
-ioport_tar := ioport-$(ioport_version).tar.gz
-ioport_url := https://people.redhat.com/rjones/ioport/files/$(ioport_tar)
+ioport_tar := ioport_$(ioport_version).tar.gz
+ioport_url := http://deb.debian.org/debian/pool/main/i/ioport/$(ioport_tar)
 ioport_hash := 7fac1c4b61eb9411275de0e1e7d7a8c3f34166f64f16413f50741e8fce2b8dc0
 
 ioport_configure := CFLAGS=-Os ./configure \


### PR DESCRIPTION
Annoying.

@JonathonHall-Purism will try to reach you to have this approved but otherwise will push without review, works locally and stops builds from succeeding in other PRs [otherwise](https://app.circleci.com/pipelines/github/tlaurion/heads/1901/workflows/ad521f6c-e272-4b13-8b8c-358b9e07f4da/jobs/29234?invite=true#step-103-26502_94):

```
2023-08-10 21:03:53-04:00 WGET https://people.redhat.com/rjones/ioport/files/ioport-1.2.tar.gz
if ! wget -O "/root/project/packages/x86/ioport-1.2.tar.gz.tmp" https://people.redhat.com/rjones/ioport/files/ioport-1.2.tar.gz ; then exit 1 ; fi ; mv "/root/project/packages/x86/ioport-1.2.tar.gz.tmp" "/root/project/packages/x86/ioport-1.2.tar.gz" 
--2023-08-10 21:03:53--  https://people.redhat.com/rjones/ioport/files/ioport-1.2.tar.gz
Resolving people.redhat.com (people.redhat.com)... 209.132.178.26
Connecting to people.redhat.com (people.redhat.com)|209.132.178.26|:443... connected.
ERROR: The certificate of 'people.redhat.com' is not trusted.
ERROR: The certificate of 'people.redhat.com' has expired.
The certificate has expired
```