### PR TITLE
ioport: changing url to debian https server, same hash. First need to go into #1198 direction

### DIFF
--- a/modules/ioport
+++ b/modules/ioport
@@ -1,9 +1,9 @@
 modules-$(CONFIG_IOPORT) += ioport
 
-ioport_version := 1.2
+ioport_version := 1.2.orig
 ioport_dir := ioport-$(ioport_version)
-ioport_tar := ioport-$(ioport_version).tar.gz
-ioport_url := https://people.redhat.com/rjones/ioport/files/$(ioport_tar)
+ioport_tar := ioport_$(ioport_version).tar.gz
+ioport_url := https://deb.debian.org/debian/pool/main/i/ioport/$(ioport_tar)
 ioport_hash := 7fac1c4b61eb9411275de0e1e7d7a8c3f34166f64f16413f50741e8fce2b8dc0
 
 ioport_configure := CFLAGS=-Os ./configure \


### PR DESCRIPTION
Sorry for the noise.

Went to fast: https://github.com/osresearch/heads/commit/a276b05a445dc9cec03cd2e88d3e82e30e6a8556 was an http url, not https.

This is why reviewing is important :/

Supersedes #1463, pushing now.