### PR TITLE
modules/* : remove unused configure options and review modules that were still compiled with -O2 as opposed to -Os

### DIFF
--- a/modules/busybox
+++ b/modules/busybox
@@ -12,6 +12,7 @@ busybox_configure := $(MAKE) CC="$(heads_cc)" oldconfig
 busybox_config := config/busybox.config
 busybox_output := busybox
 busybox_target := \
+	CFLAGS="-Os"  \
 	$(CROSS_TOOLS) \
 	$(MAKE_JOBS) \
 

--- a/modules/gpg2
+++ b/modules/gpg2
@@ -17,7 +17,6 @@ gpg2_configure := \
 	./configure \
 	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--host $(MUSL_ARCH)-linux-musl \
-	--with-libusb="$(INSTALL)" \
 	--with-gpg-error-prefix="$(INSTALL)" \
 	--with-libgcrypt-prefix="$(INSTALL)" \
 	--with-libassuan-prefix="$(INSTALL)" \
@@ -29,13 +28,11 @@ gpg2_configure := \
 	--enable-ccid-driver \
 	--disable-tofu \
 	--disable-rpath \
-        --disable-regex \
         --disable-doc \
 	--disable-bzip2 \
 	--disable-exec \
 	--disable-photo-viewers \
 	--disable-ldap \
-	--disable-regex \
 	--disable-nls \
 	--disable-all-tests \
 	--disable-wks-tools \

--- a/modules/kexec
+++ b/modules/kexec
@@ -7,7 +7,7 @@ kexec_url := https://kernel.org/pub/linux/utils/kernel/kexec/$(kexec_tar)
 kexec_hash := 89bdd941542c64fec16311858df304ed3a3908c1a60874d69df5d9bf1611e062
 
 kexec_configure := \
-	CFLAGS="-g -Os -fno-strict-aliasing -Wall -Wstrict-prototypes" \
+	CFLAGS="-Os -fno-strict-aliasing -Wall -Wstrict-prototypes" \
 	./configure \
 	$(CROSS_TOOLS) \
 	--host $(MUSL_ARCH)-elf-linux \

--- a/modules/linux
+++ b/modules/linux
@@ -59,7 +59,7 @@ $(build)/$(linux_dir)/.configured: $(linux_kconfig)
 linux_configure := \
 	mkdir -p "$(build)/$(linux_dir)" \
 	&& $(call install_config,$(pwd)/$(linux_kconfig),$(build)/$(linux_dir)/.config) \
-	&& $(MAKE) -C .. \
+	&& $CFLAGS="-Os" $(MAKE) -C .. \
 		ARCH="$(LINUX_ARCH)" \
 		CROSS_COMPILE="$(CROSS)" \
 		O="$(build)/$(linux_dir)" \

--- a/modules/npth
+++ b/modules/npth
@@ -8,6 +8,7 @@ npth_hash := 1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1
 
 npth_configure := ./configure \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
 	--host $(MUSL_ARCH)-linux-musl \
 	--prefix "/" \
 	--disable-static \

--- a/modules/slang
+++ b/modules/slang
@@ -6,8 +6,10 @@ slang_tar := slang-$(slang_version).tar.bz2
 slang_url := https://www.jedsoft.org/releases/slang/$(slang_tar)
 slang_hash := 54f0c3007fde918039c058965dffdfd6c5aec0bad0f4227192cc486021f08c36
 
-slang_configure := ./configure \
+slang_configure := \
 	$(CROSS_TOOLS) \
+	CFLAGS="-Os"  \
+	./configure \
 	ac_cv_path_nc5config=no \
 	--prefix "/" \
 	--host $(MUSL_ARCH)-elf-linux \


### PR DESCRIPTION
Note: is libusb still needed by anything? gpg2 doesn't require it anymore? Review

