### PR TITLE
config-gui.sh: Add option to toggle DEBUG and TRACE output from Configuration Settings

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -65,6 +65,11 @@ while true; do
         'N' " $(get_config_display_action "$CONFIG_AUTOMATIC_POWERON") automatic power-on"
     )
 
+    # Debugging option always available
+    dynamic_config_options+=(
+        'Z' " $(get_config_display_action "$CONFIG_DEBUG_OUTPUT") $CONFIG_BRAND_NAME debug and function tracing output"
+    )
+
     [ "$CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE" = "y" ] && dynamic_config_options+=(
         't' ' Deactivate Platform Locking to permit OS write access to firmware'
     )
@@ -473,6 +478,30 @@ while true; do
         fi
       fi
     ;;
+    "Z" )
+      if [ "$CONFIG_DEBUG_OUTPUT" != "y" ]; then
+        if (whiptail --title 'Enable Debugging and Tracing output?' \
+             --yesno "This will enable DEBUG and TRACE output from scripts.
+                    \n\nDo you want to proceed?" 0 80) then
+
+          set_user_config "CONFIG_DEBUG_OUTPUT" "y"
+          set_user_config "CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT" "y"
+
+          whiptail --title 'Config change successful' \
+            --msgbox "Debugging and Tracing output enabled;\nsave the config change and reboot for it to go into effect." 0 80
+        fi
+      else
+        if (whiptail --title 'Disable Enable Debugging and Tracing output?' \
+             --yesno "This will disable DEBUG and TRACE output from scripts.
+                    \n\nDo you want to proceed?" 0 80) then
+          
+          set_user_config "CONFIG_DEBUG_OUTPUT" "n"
+          set_user_config "CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT" "n"
+
+          whiptail --title 'Config change successful' \
+            --msgbox "Debugging and Tracing output disabled;\nsave the config change and reboot for it to go into effect." 0 80
+        fi
+      fi
   esac
 
 done


### PR DESCRIPTION
This permits to toggle debug and tracing output which is pretty verbose and informative to anyone interested in developing or understanding Heads inner workings.


Now you can toggle it directly from within Heads, instead of toggling it up at compilation.
This PR also shows how to add additional configuration toggles under Heads.

-----
To activate it once this firmware update is flashed internally:
![signal-2023-08-25-135434](https://github.com/osresearch/heads/assets/827570/d32cc9aa-52b4-4756-9916-02a15003d852)
![signal-2023-08-25-135444](https://github.com/osresearch/heads/assets/827570/e5b23007-a134-41ce-ba77-5f6e2cec202b)
![signal-2023-08-25-135459](https://github.com/osresearch/heads/assets/827570/76a698dd-3e2a-47c0-9f8c-1616a4bd8bc4)
![signal-2023-08-25-135513](https://github.com/osresearch/heads/assets/827570/4fb4cef6-b7c7-4651-9bf2-a6f02569c803)
![signal-2023-08-25-135524](https://github.com/osresearch/heads/assets/827570/7638daa9-82d6-4124-a9fe-d877876e862a)
![signal-2023-08-25-135534](https://github.com/osresearch/heads/assets/827570/cf674d73-e31a-4c6d-9ad4-905b4a30b223)
![signal-2023-08-25-135545](https://github.com/osresearch/heads/assets/827570/79a98cb2-621f-4f6c-99c2-93244aa53460)
![signal-2023-08-25-135603](https://github.com/osresearch/heads/assets/827570/f18e2475-7d13-4754-a745-3aff61d4edbb)

And then, on boot: (See `TRACE` and `DEBUG` statements):
![signal-2023-08-25-135659](https://github.com/osresearch/heads/assets/827570/f6d4c6ff-c95d-446c-beae-0b8545f7def2)
![signal-2023-08-25-135746](https://github.com/osresearch/heads/assets/827570/9f829244-d54d-4202-8f77-7560bfb959d0)
![signal-2023-08-25-135847](https://github.com/osresearch/heads/assets/827570/5f9660ba-3fed-448c-b48d-5b762774fd30)


Happy learning of Heads internals and functioning!

----

@JonathonHall-Purism as discussed. Pretty trivial change, please review.
