### PR TITLE
Nitrokey 3 support

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -113,6 +113,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -111,6 +111,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -119,6 +119,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
@@ -118,6 +118,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -113,6 +113,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -111,6 +111,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -119,6 +119,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -118,6 +118,8 @@ QEMU_USB_FD_IMG := $(USB_FD_IMG)
 endif
 # To forward a USB token, set USB_TOKEN to one of the following:
 # - NitrokeyPro - forwards a Nitrokey Pro by VID:PID
+# - NitrokeyStorage - forwards a Nitrokey Storage by VID:PID
+# - Nitrokey3NFC - forwards a Nitrokey 3 by VID:PID
 # - LibremKey - forwards a Librem Key by VID:PID
 # - <other> - Provide the QEMU usb-host parameters, such as
 #   'hostbus=<#>,hostport=<#>' or 'vendorid=<#>,productid=<#>'

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -37,6 +37,7 @@ CUSTOM_PASS_AFFECTED_COMPONENTS=""
 
 RSA_KEY_LENGTH=3072
 
+GPG_ALGO="rsa"
 GPG_USER_NAME="OEM Key"
 GPG_KEY_NAME=`date +%Y%m%d%H%M%S`
 GPG_USER_MAIL="oem-${GPG_KEY_NAME}@example.com"
@@ -101,24 +102,47 @@ gpg_key_reset()
             whiptail_error_die "GPG Key forcesig toggle on failed!\n\n$ERROR"
         fi
     fi
-    # Set RSA key length
-    {
-        echo admin
-        echo key-attr
-        echo 1 # RSA
-        echo ${RSA_KEY_LENGTH} #Signing key size set to RSA_KEY_LENGTH
-        echo ${ADMIN_PIN_DEF}
-        echo 1 # RSA
-        echo ${RSA_KEY_LENGTH} #Encryption key size set to RSA_KEY_LENGTH
-        echo ${ADMIN_PIN_DEF}
-        echo 1 # RSA
-        echo ${RSA_KEY_LENGTH} #Authentication key size set to RSA_KEY_LENGTH
-        echo ${ADMIN_PIN_DEF}
-    } | gpg --command-fd=0 --status-fd=1 --pinentry-mode=loopback --card-edit \
-        > /tmp/gpg_card_edit_output 2>&1
-    if [ $? -ne 0 ]; then
-        ERROR=`cat /tmp/gpg_card_edit_output`
-        whiptail_error_die "Setting key attributed to RSA ${RSA_KEY_LENGTH} bits in USB security dongle failed."
+    # use p256 for key generation if requested
+    if [ "$GPG_ALGO" = "p256" ];then
+      {
+          echo admin
+          echo key-attr
+          echo 2 # ECC
+          echo 3 # P-256
+          echo ${ADMIN_PIN_DEF}
+          echo 2 # ECC
+          echo 3 # P-256
+          echo ${ADMIN_PIN_DEF}
+          echo 2 # ECC
+          echo 3 # P-256
+          echo ${ADMIN_PIN_DEF}
+      } | gpg --command-fd=0 --status-fd=1 --pinentry-mode=loopback --card-edit --expert \
+          > /tmp/gpg_card_edit_output 2>&1
+      if [ $? -ne 0 ]; then
+          ERROR=`cat /tmp/gpg_card_edit_output`
+          whiptail_error_die "Setting key to NIST-P256 in USB security dongle failed."
+      fi
+    # fallback to RSA key generation by default
+    else
+      # Set RSA key length
+      {
+          echo admin
+          echo key-attr
+          echo 1 # RSA
+          echo ${RSA_KEY_LENGTH} #Signing key size set to RSA_KEY_LENGTH
+          echo ${ADMIN_PIN_DEF}
+          echo 1 # RSA
+          echo ${RSA_KEY_LENGTH} #Encryption key size set to RSA_KEY_LENGTH
+          echo ${ADMIN_PIN_DEF}
+          echo 1 # RSA
+          echo ${RSA_KEY_LENGTH} #Authentication key size set to RSA_KEY_LENGTH
+          echo ${ADMIN_PIN_DEF}
+      } | gpg --command-fd=0 --status-fd=1 --pinentry-mode=loopback --card-edit \
+          > /tmp/gpg_card_edit_output 2>&1
+      if [ $? -ne 0 ]; then
+          ERROR=`cat /tmp/gpg_card_edit_output`
+          whiptail_error_die "Setting key attributed to RSA ${RSA_KEY_LENGTH} bits in USB security dongle failed."
+      fi
     fi
     # Generate OEM GPG keys
     {
@@ -354,6 +378,22 @@ report_integrity_measurements()
     fi
 }
 
+usb_security_token_capabilities_check()
+{
+    TRACE "Under /bin/oem-factory-reset:usb_security_token_capabilities_check"
+
+    enable_usb
+    # ... first set board config preference
+    if [ -n "$CONFIG_GPG_ALGO" ]; then
+        GPG_ALGO=$CONFIG_GPG_ALGO
+        DEBUG "Setting GPG_ALGO to (board-)configured: $CONFIG_GPG_ALGO"
+    fi
+    # ... overwrite with usb-token capability
+    if lsusb | grep -q "20a0:42b2"; then
+        GPG_ALGO="p256"
+        DEBUG "Nitrokey 3 detected: Setting GPG_ALGO to: $GPG_ALGO"
+    fi
+}
 
 ## main script start
 
@@ -391,6 +431,9 @@ fi
 
 # We show current integrity measurements status and time
 report_integrity_measurements
+
+# Determine gpg algorithm to be used, based on available usb-token
+usb_security_token_capabilities_check
 
 use_defaults=n
 if [ "$CONFIG_OEMRESET_OFFER_DEFAULTS" = y ]; then

--- a/modules/hotp-verification
+++ b/modules/hotp-verification
@@ -2,11 +2,12 @@ modules-$(CONFIG_HOTPKEY) += hotp-verification
 
 hotp-verification_depends := libusb $(musl_dep)
 
-hotp-verification_version := b2b924eabd4d713f73bfaa298cc4c759421caf8f
+# v1.4
+hotp-verification_version := b69bb20119d3cea5ec5c13d11b213dd80dfd8334
 hotp-verification_dir := hotp-verification-$(hotp-verification_version)
 hotp-verification_tar := nitrokey-hotp-verification-$(hotp-verification_version).tar.gz
 hotp-verification_url := https://github.com/Nitrokey/nitrokey-hotp-verification/archive/$(hotp-verification_version).tar.gz
-hotp-verification_hash := 424d3e0b0d35d3d9ce16d68fae7d19f23bc0d4317f5ccc879c04e18c3f9bdfc1
+hotp-verification_hash := ee6bcb7fc48bd5e7c290b2b344ce50713f4199425b1a6b324d0b27c80257241d
 
 hotp-verification_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
- Bumping version of  [hotp-verification to 1.4](https://github.com/Nitrokey/nitrokey-hotp-verification/releases/tag/v1.4) 
- Add support under oem-factory-reset to provision subkeys with p256
- move enable-usb earlier in oem-factory-reset
- Add USB Security dongle detction by USB ID
- If NK3, use p256 algo in oem-factory-reset

---

Originally first introduced in: #1417 
