### PR TITLE
modules/coreboot: Update Purism coreboot to 24e2f7e4

### DIFF
--- a/boards/librem_mini/initrd/bin/set_ec_poweron.sh
+++ b/boards/librem_mini/initrd/bin/set_ec_poweron.sh
@@ -7,10 +7,16 @@
 BRAMADDR=0x360
 BRAMDATA=0x361
 
-outb "$BRAMADDR" 0x29 # Select byte at offset 29h
 if [ "$1" = "y" ]; then
-	outb "$BRAMDATA" 0x00 # 0 -> automatic power-on
+	BRAM_VALUE="0x00" # 0 -> automatic power-on
 else
-	outb "$BRAMDATA" 0x01 # 1 -> stay off
+	BRAM_VALUE="0x01" # 1 -> stay off
 fi
 
+outb "$BRAMADDR" 0x29 # Select byte at offset 29h
+outb "$BRAMDATA" "$BRAM_VALUE"
+# There's also a 16-bit checksum at offset 3eh in bank 1.  The only byte
+# included in the checksum is the automatic power-on setting, so the value is
+# the same, and the upper 8 bits remain 0.
+outb "$BRAMADDR" 0x3e
+outb "$BRAMDATA" "$BRAM_VALUE"

--- a/boards/librem_mini_v2/initrd/bin/set_ec_poweron.sh
+++ b/boards/librem_mini_v2/initrd/bin/set_ec_poweron.sh
@@ -7,10 +7,16 @@
 BRAMADDR=0x360
 BRAMDATA=0x361
 
-outb "$BRAMADDR" 0x29 # Select byte at offset 29h
 if [ "$1" = "y" ]; then
-	outb "$BRAMDATA" 0x00 # 0 -> automatic power-on
+	BRAM_VALUE="0x00" # 0 -> automatic power-on
 else
-	outb "$BRAMDATA" 0x01 # 1 -> stay off
+	BRAM_VALUE="0x01" # 1 -> stay off
 fi
 
+outb "$BRAMADDR" 0x29 # Select byte at offset 29h
+outb "$BRAMDATA" "$BRAM_VALUE"
+# There's also a 16-bit checksum at offset 3eh in bank 1.  The only byte
+# included in the checksum is the automatic power-on setting, so the value is
+# the same, and the upper 8 bits remain 0.
+outb "$BRAMADDR" 0x3e
+outb "$BRAMDATA" "$BRAM_VALUE"

--- a/config/coreboot-librem_mini.config
+++ b/config/coreboot-librem_mini.config
@@ -1,10 +1,12 @@
-CONFIG_CBFS_SIZE=0xC00000
+CONFIG_USE_OPTION_TABLE=y
 CONFIG_VENDOR_PURISM=y
+CONFIG_CBFS_SIZE=0xC00000
 CONFIG_INTEL_GMA_VBT_FILE="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini/vbt.bin"
 CONFIG_IFD_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini/flashdescriptor.bin"
 CONFIG_ME_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini/me.bin"
 CONFIG_HAVE_IFD_BIN=y
 CONFIG_BOARD_PURISM_LIBREM_MINI=y
+CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=2 drm_kms_helper.drm_leak_fbdev_smem=1 i915.enable_fbc=0"
 CONFIG_CPU_MICROCODE_CBFS_EXTERNAL_BINS=y
 CONFIG_CPU_UCODE_BINARIES="3rdparty/purism-blobs/mainboard/purism/librem_cnl/cpu_microcode_blob.bin"
 CONFIG_HAVE_ME_BIN=y
@@ -12,4 +14,3 @@ CONFIG_NO_GFX_INIT=y
 CONFIG_PAYLOAD_LINUX=y
 CONFIG_PAYLOAD_FILE="@BOARD_BUILD_DIR@/bzImage"
 CONFIG_LINUX_INITRD="@BOARD_BUILD_DIR@/initrd.cpio.xz"
-CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=2 drm_kms_helper.drm_leak_fbdev_smem=1 i915.enable_fbc=0"

--- a/config/coreboot-librem_mini_v2.config
+++ b/config/coreboot-librem_mini_v2.config
@@ -1,9 +1,12 @@
+CONFIG_USE_OPTION_TABLE=y
 CONFIG_VENDOR_PURISM=y
+CONFIG_CBFS_SIZE=0xC00000
 CONFIG_INTEL_GMA_VBT_FILE="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini/vbt.bin"
 CONFIG_IFD_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini_v2/flashdescriptor.bin"
 CONFIG_ME_BIN_PATH="3rdparty/purism-blobs/mainboard/purism/librem_cnl/mini_v2/me.bin"
 CONFIG_HAVE_IFD_BIN=y
 CONFIG_BOARD_PURISM_LIBREM_MINI_V2=y
+CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=2 drm_kms_helper.drm_leak_fbdev_smem=1 i915.enable_fbc=0"
 CONFIG_CPU_MICROCODE_CBFS_EXTERNAL_BINS=y
 CONFIG_CPU_UCODE_BINARIES="3rdparty/purism-blobs/mainboard/purism/librem_cnl/cpu_microcode_blob.bin"
 CONFIG_HAVE_ME_BIN=y
@@ -11,5 +14,3 @@ CONFIG_NO_GFX_INIT=y
 CONFIG_PAYLOAD_LINUX=y
 CONFIG_PAYLOAD_FILE="@BOARD_BUILD_DIR@/bzImage"
 CONFIG_LINUX_INITRD="@BOARD_BUILD_DIR@/initrd.cpio.xz"
-CONFIG_LINUX_COMMAND_LINE="intel_iommu=igfx_off quiet loglevel=2 drm_kms_helper.drm_leak_fbdev_smem=1 i915.enable_fbc=0"
-CONFIG_CBFS_SIZE=0xC00000

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -79,10 +79,10 @@ coreboot-talos_2_repo := https://github.com/Dasharo/coreboot
 coreboot-talos_2_commit_hash := c8aed443c631042ad2b0326c35cd0b774752b924
 $(eval $(call coreboot_module,talos_2,))
 
-# Similarly, purism is based on 4.20.1, but nothing builds against 4.20.1 itself
+# Similarly, purism is based on 4.21, but nothing builds against 4.21 itself
 # or any other fork - no benefit to sharing the toolchain yet.
 coreboot-purism_repo := https://source.puri.sm/firmware/coreboot.git
-coreboot-purism_commit_hash := a899f08d2789db1dd9b02cff34179c4d38e6d0e3
+coreboot-purism_commit_hash := 24e2f7e46c933b0764b245f7f0b4c54554881950
 $(eval $(call coreboot_module,purism,))
 
 # Check that the board configured the coreboot version correctly


### PR DESCRIPTION
This is 4.21-Purism-1 plus a fix for native graphics init on Mini v1/v2: HDMI1 is enabled so passive DisplayPort to DVI/HDMI adapters will work.