### PR TITLE
initrd/bin/unseal-hotp: Prevent script errors if unseal fails

### DIFF
--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -39,7 +39,7 @@ fi
 #counter_value=$(printf "%d" 0x${counter_value})
 if [ "$CONFIG_TPM" = "y" ]; then
 	DEBUG "Unsealing HOTP secret reuses TOTP sealed secret..."
-	tpmr unseal 4d47 0,1,2,3,4,7 312 "$HOTP_SECRET"
+	tpmr unseal 4d47 0,1,2,3,4,7 312 "$HOTP_SECRET" || die "Unable to unseal HOTP secret"
 else
 	# without a TPM, generate a secret based on the SHA-256 of the ROM
 	secret_from_rom_hash > "$HOTP_SECRET" || die "Reading ROM failed"


### PR DESCRIPTION
If the secret can't be unsealed, die immediately rather than continuing on to generate errors.