### PR TITLE
bin/flash-gui.sh & initrd/bin/flash.sh: Show SHA256SUM for manual verification prior of flashing

### DIFF
--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -43,9 +43,11 @@ while true; do
 
         # is a .npf provided?
         if [ -z "${ROM##*.npf}" ]; then
+          #preventive cleanup
+          rm -rf /tmp/verified_rom >/dev/null 2>&1 || true
           # unzip to /tmp/verified_rom
-          mkdir /tmp/verified_rom
-          unzip $ROM -d /tmp/verified_rom
+          mkdir -p /tmp/verified_rom >/dev/null 2>&1 || true
+          unzip $ROM -d /tmp/verified_rom || die "Failed to unzip ROM file"
           # check file integrity
           if (cd /tmp/verified_rom/ && sha256sum -cs /tmp/verified_rom/sha256sum.txt); then
             ROM="$(head -n1 /tmp/verified_rom/sha256sum.txt | cut -d ' ' -f 3)"

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -25,67 +25,63 @@ while true; do
   menu_choice=$(cat /tmp/whiptail)
 
   case "$menu_choice" in
-    "x" )
-      exit 0
+  "x")
+    exit 0
     ;;
-    f|c )
-      if (whiptail $BG_COLOR_WARNING --title 'Flash the BIOS with a new ROM' \
-          --yesno "You will need to insert a USB drive containing your BIOS image (*.rom or *.tgz).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80) then
-        mount_usb
-        if grep -q /media /proc/mounts ; then
-          find /media ! -path '*/\.*' -type f \( -name '*.rom' -o -name '*.tgz' -o -type f -name '*.npf' \) | sort > /tmp/filelist.txt
-          file_selector "/tmp/filelist.txt" "Choose the ROM to flash"
-          if [ "$FILE" == "" ]; then
-            exit 1
-          else
-            ROM=$FILE
-          fi
+  f | c)
+    if (whiptail $BG_COLOR_WARNING --title 'Flash the BIOS with a new ROM' \
+      --yesno "You will need to insert a USB drive containing your BIOS image (*.rom, *.npf or *.tgz).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80); then
+      mount_usb
+      if grep -q /media /proc/mounts; then
+        find /media ! -path '*/\.*' -type f \( -name '*.rom' -o -name '*.tgz' -o -type f -name '*.npf' \) | sort >/tmp/filelist.txt
+        file_selector "/tmp/filelist.txt" "Choose the ROM to flash"
+        if [ "$FILE" == "" ]; then
+          exit 1
+        else
+          ROM=$FILE
+        fi
 
-          # is a .npf provided?
-          if [ -z "${ROM##*.npf}" ]; then
-            # unzip to /tmp/verified_rom
-            mkdir /tmp/verified_rom
-            unzip $ROM -d /tmp/verified_rom
-            # check file integrity
-            if (cd /tmp/verified_rom/ && sha256sum -cs /tmp/verified_rom/sha256sum.txt) ; then
-              ROM="$(head -n1 /tmp/verified_rom/sha256sum.txt | cut -d ' ' -f 3)"
-            else
-              whiptail --title 'ROM Integrity Check Failed! ' \
-                --msgbox "$ROM integrity check failed. Did not flash.\n\nPlease check your file (e.g. re-download).\n" 16 60
-              exit
-            fi
+        # is a .npf provided?
+        if [ -z "${ROM##*.npf}" ]; then
+          # unzip to /tmp/verified_rom
+          mkdir /tmp/verified_rom
+          unzip $ROM -d /tmp/verified_rom
+          # check file integrity
+          if (cd /tmp/verified_rom/ && sha256sum -cs /tmp/verified_rom/sha256sum.txt); then
+            ROM="$(head -n1 /tmp/verified_rom/sha256sum.txt | cut -d ' ' -f 3)"
           else
-            # exit if we shall not proceed
-            if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
-                --yesno "You have provided a *.rom file. The integrity of the file can not be\nchecked for this file.\nIf you do not know how to check the file integrity yourself,\nyou should use a *.npf file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 16 60) then
-              exit
-            fi
+            whiptail --title 'ROM Integrity Check Failed! ' \
+              --msgbox "$ROM integrity check failed. Did not flash.\n\nPlease check your file (e.g. re-download).\n" 16 60
+            exit
           fi
-
-          if (whiptail $BG_COLOR_WARNING --title 'Flash ROM?' \
-              --yesno "This will replace your current ROM with:\n\n${ROM#"/media/"}\n\nDo you want to proceed?" 0 80) then
-            if [ "$menu_choice" == "c" ]; then
-              /bin/flash.sh -c "$ROM"
-              # after flash, /boot signatures are now invalid so go ahead and clear them
-              if ls /boot/kexec* >/dev/null 2>&1 ; then
-                (
-                  mount -o remount,rw /boot 2>/dev/null
-                  rm /boot/kexec* 2>/dev/null
-                  mount -o remount,ro /boot 2>/dev/null
-                )
-              fi
-            else
-              /bin/flash.sh "$ROM"
-            fi
-            whiptail --title 'ROM Flashed Successfully' \
-              --msgbox "${ROM#"/media/"}\n\nhas been flashed successfully.\n\nPress Enter to reboot\n" 0 80
-            umount /media
-            /bin/reboot
-          else
+        else
+          # a rom file was provided. exit if we shall not proceed
+          ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}') || die "Failed to hash ROM file"
+          if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
+            --yesno "You have provided a *.rom file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.npf file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
             exit
           fi
         fi
+
+        if [ "$menu_choice" == "c" ]; then
+          /bin/flash.sh -c "$ROM"
+          # after flash, /boot signatures are now invalid so go ahead and clear them
+          if ls /boot/kexec* >/dev/null 2>&1; then
+            (
+              mount -o remount,rw /boot 2>/dev/null
+              rm /boot/kexec* 2>/dev/null
+              mount -o remount,ro /boot 2>/dev/null
+            )
+          fi
+        else
+          /bin/flash.sh "$ROM"
+        fi
+        whiptail --title 'ROM Flashed Successfully' \
+          --msgbox "${ROM#"/media/"}\n\nhas been flashed successfully.\n\nPress Enter to reboot\n" 0 80
+        umount /media
+        /bin/reboot
       fi
+    fi
     ;;
   esac
 


### PR DESCRIPTION
Add ROM and ROM hash when non-npf file is selected for flashing as per  https://github.com/osresearch/heads/pull/1514#issuecomment-1787258746

----
Old
- Refactoring of arguments parsing, so they are not positional.
- Internal usage of -i argument from flash-gui.sh to flash.sh to bypass hash validation prompt in case of npf
- Rewording of flash-gui.sh output in case of non-npf file
![signal-2023-10-18-174457](https://github.com/osresearch/heads/assets/827570/3e231a64-5459-4787-9b59-f0627d448ffc)
- Adds this validation prompt so the user can validate hash output from external source prior of accepting flashing
![signal-2023-10-18-174515](https://github.com/osresearch/heads/assets/827570/919946cb-7c46-4fd9-8b66-8f3b5f317a9f)


Notes:
- Talos II still only user of tgz archive which is similar to npf and doesn't show prompt either.