### PR TITLE
BugFix: Pass debug call output to kmsg one line at a time

### DIFF
--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -24,7 +24,9 @@ warn() {
 
 DEBUG() {
 	if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
-		echo "DEBUG: $*" | tee -a /tmp/debug.log /dev/kmsg > /dev/null;
+		echo "DEBUG: $*" | while read line; do
+			echo "$line" | tee -a /tmp/debug.log /dev/kmsg >/dev/null
+		done
 	fi
 }
 


### PR DESCRIPTION
Fixes #1516

Otherwise TPM2 output for pcrs call under ash_fonctions pollutes kmsg and console output and prevents resealing of Disk Unlock Key with passphrase.

With this fix
![2023-10-21-143611](https://github.com/osresearch/heads/assets/827570/36e08d31-d025-43dc-a8e7-f9b34716b85f)
