### PR TITLE
Permit unsafe usb boot of unsigned ISO (Ventoy-like)

### DIFF
--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -2,6 +2,7 @@
 # Boot from signed ISO
 set -e -o pipefail
 . /etc/functions
+. /etc/gui_functions
 . /tmp/config
 
 TRACE_FUNC
@@ -19,8 +20,32 @@ fi
 
 ISO_PATH="${ISO_PATH##/}"
 
-gpgv --homedir=/etc/distro/ "$ISOSIG" "$MOUNTED_ISO_PATH" \
-	|| die 'ISO signature failed'
+if [ -r "$ISOSIG" ]; then
+	# Signature found, verify it
+	gpgv --homedir=/etc/distro/ "$ISOSIG" "$MOUNTED_ISO_PATH" \
+		|| die 'ISO signature failed'
+	echo '+++ ISO signature verified'
+else
+	# No signature found, prompt user with warning
+	echo '+++ WARNING: No signature found for ISO'
+	if [ -x /bin/whiptail ]; then
+		if ! whiptail_warning --title 'UNSIGNED ISO WARNING' --yesno \
+			"WARNING: UNSIGNED ISO DETECTED\n\nThe selected ISO file:\n$MOUNTED_ISO_PATH\n\nDoes not have a detached signature (.sig or .asc file).\n\n\nThis means the integrity and authenticity of the ISO cannot be verified.\nBooting unsigned ISOs is potentially unsafe.\n\nDo you want to proceed with booting this unsigned ISO?" \
+			0 80; then
+			die "Unsigned ISO boot cancelled by user"
+		fi
+	else
+		echo "WARNING: The selected ISO file does not have a detached signature"
+		echo "This means the integrity and authenticity cannot be verified"
+		echo "Booting unsigned ISOs is potentially unsafe"
+		read -n1 -p "Do you want to proceed anyway? (y/N): " response
+		echo
+		if [ "$response" != "y" ] && [ "$response" != "Y" ]; then
+			die "Unsigned ISO boot cancelled by user"
+		fi
+	fi
+	echo '+++ Proceeding with unsigned ISO boot'
+fi
 
 echo '+++ Mounting ISO and booting'
 mount -t iso9660 -o loop $MOUNTED_ISO_PATH /boot \

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -79,8 +79,8 @@ get_menu_option() {
 	fi
 }
 
-# create ISO menu options
-ls -1r /media/*.iso 2>/dev/null > /tmp/iso_menu.txt || true
+# create ISO menu options - search recursively for ISO files
+find /media -name "*.iso" -type f 2>/dev/null | sort -r > /tmp/iso_menu.txt || true
 if [ `cat /tmp/iso_menu.txt | wc -l` -gt 0 ]; then
 	option_confirm=""
 	while [ -z "$option" -a "$option_index" != "s" ]


### PR DESCRIPTION
fixes
- Ventoy'ish boot of unsigned iso #1320  (ExFat: supported by Heads since https://github.com/linuxboot/heads/commit/f6eed4220861bece9c09b6fe8f3feef4f236364c)
- Not block user to boot unsigned ISO #1886 


Changes
- /media is mounted as usual
- /media is searched without limit for files matching name "*.iso"
- same code path for detached signed boot images.
- when sig/asc not found, warn prior of booting that unsigned iso image

Screenshot (old ISOs with detached signature removed for sake of these tests: irrelevant):
![2025-06-26-145547](https://github.com/user-attachments/assets/ae3d007f-93f4-4099-97c8-965a33d8419f)
![2025-06-26-151401](https://github.com/user-attachments/assets/13b999b4-a302-432e-a7b9-8a17bca6abea)

---

Todo:
- #1438
- cancelling anything on that boot path calls 'die' (which goes up to media-scan, landing into the recovery shell for now. PR welcome).