### PR TITLE
`musl-cross-make` HTTP for Linux headers

### DIFF
--- a/patches/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c/0001-no-ssl-linux-headers.patch
+++ b/patches/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c/0001-no-ssl-linux-headers.patch
@@ -1,0 +1,11 @@
+--- ../orig/Makefile	2024-05-07 02:14:37.000000000 +0100
++++ ./Makefile	2025-10-27 00:11:38.045918046 +0000
+@@ -22,7 +22,7 @@
+ MUSL_REPO = https://git.musl-libc.org/git/musl
+ 
+ LINUX_SITE = https://cdn.kernel.org/pub/linux/kernel
+-LINUX_HEADERS_SITE = https://ftp.barfooze.de/pub/sabotage/tarballs/
++LINUX_HEADERS_SITE = http://ftp.barfooze.de/pub/sabotage/tarballs/
+ 
+ DL_CMD = wget -c -O
+ SHA1_CMD = sha1sum -c


### PR DESCRIPTION
Workaround for #2009

`musl-cross-make` checksum the download anyway, so no SSL shouldn't be too much of a concern.

Of-course, if the host updates their certificate, the issue goes away. A future-proof solution may be to patch a mirror into `musl-cross-make`.