### PR TITLE
Use docker "immutable identifier" instead of tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
 jobs:
   prep_env:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.5
+      - image: tlaurion/heads-dev-env@sha256:50a9110cdfc6a74a383169d7c624139c3b3e05567b87203498118a8a33dd79f1   # v0.2.5
     resource_class: large
     working_directory: ~/heads
     steps:
@@ -122,7 +122,7 @@ jobs:
 
   build_and_persist:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.5
+      - image: tlaurion/heads-dev-env@sha256:50a9110cdfc6a74a383169d7c624139c3b3e05567b87203498118a8a33dd79f1   # v0.2.5
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -150,7 +150,7 @@ jobs:
 
   build:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.5
+      - image: tlaurion/heads-dev-env@sha256:50a9110cdfc6a74a383169d7c624139c3b3e05567b87203498118a8a33dd79f1   # v0.2.5
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -171,7 +171,7 @@ jobs:
 
   save_cache:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.5
+      - image: tlaurion/heads-dev-env@sha256:50a9110cdfc6a74a383169d7c624139c3b3e05567b87203498118a8a33dd79f1   # v0.2.5
     resource_class: large
     working_directory: ~/heads
     steps:

--- a/docker_repro.sh
+++ b/docker_repro.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Extract the Docker image version from the CircleCI config file
-DOCKER_IMAGE=$(grep -oP '^\s*-?\s*image:\s*\K(tlaurion/heads-dev-env:[^\s]+)' .circleci/config.yml | head -n 1)
+DOCKER_IMAGE=$(grep -oP '^\s*-?\s*image:\s*\K(tlaurion/heads-dev-env@[^\s]+)' .circleci/config.yml | head -n 1)
 
 # Check if the Docker image was found
 if [ -z "$DOCKER_IMAGE" ]; then


### PR DESCRIPTION
CircleCI and `docker_repro.sh` should use Docker's immutable identifier (sha256 digest of image) instead of tags.

Currently, using tags, the administrators of Docker Hub could be coerced into modifying `tlaurion/heads-dev-env` to produce malicious ROM's.

@tlaurion the safest way to ensure that CircleCI and local builds with `docker_repro.sh` are not tainted by a malicious images would be to use immutable identifiers instead of tags. Going forward, I would recommend you build your container locally, taking note of the sha256 digest, then pushing to docker hub before creating a signed commit replacing the checksums in `.circleci/config.yml`.