### PR TITLE
seed_package_mirror.sh: board renames

### DIFF
--- a/bin/seed_package_mirror.sh
+++ b/bin/seed_package_mirror.sh
@@ -56,8 +56,8 @@ echo "Downloading packages..."
 make packages BOARD=qemu-coreboot-fbwhiptail-tpm1-hotp
 make packages BOARD=UNTESTED_talos-2 # newt, PPC
 make packages BOARD=librem_l1um_v2 # TPM2
-make packages BOARD=librem_l1um # coreboot 4.11
-make packages BOARD=x230-maximized # io386
+make packages BOARD=EOL_librem_l1um # coreboot 4.11
+make packages BOARD=EOL_x230-maximized # io386
 echo
 echo "Copying to mirror directory..."
 mkdir -p "$ARG_MIRROR_DIR"


### PR DESCRIPTION
seed_package_mirror.sh fails as boards renamed:

`librem_l1um` -> `EOL_librem_l1um`
`x230-maximized` -> `EOL_x230-maximized`
