### PR TITLE
ci: enable automatic reruns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ jobs:
 workflows:
   version: 2
   build_and_test:
+    max_auto_reruns: 3
     jobs:
       - prep_env
 


### PR DESCRIPTION
CircleCI seems quite flaky. I've had to re-run from failed a few times to get a successful build.

This PR will automatically attempt to re-run the failed workflow 3 times before failing.

Eventually, issues causing the fails should be investigated and minimised.