### PR TITLE
Bugfix to support unbound keyslot when sealing key

### DIFF
--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -143,8 +143,8 @@ for dev in $key_devices; do
 	if [ "$luks_version" == "2" ]; then
 		# LUKSv2 last key slot is 31
 		duk_keyslot=31
-		regex="^\s+([0-9]+):\s*luks2"
-		sed_command="s/^\s\+\([0-9]\+\):\s*luks2/\1/g"
+		regex="^\s+([0-9]+):\s*luks2$"
+		sed_command="s/^\s\+\([0-9]\+\):\s*luks2$/\1/g"
 		previous_luks_header_version=2
 		DEBUG "$dev: LUKSv2 device detected"
 	elif [ "$luks_version" == "1" ]; then


### PR DESCRIPTION
Fix for #2045

Changes introduced:
- unbound keyslots are now ignored (thanks to a new regex and sed command in kexec-seal-key)
- if by any chance luksDump parsing founds non-numeric keyslot numbers, they get ignored

It's the first time I change heads source code so I'm not sure I did everything as I should

I tested the new regex and sed command against some luksDump outputs with the following command:
```
cat luks.txt | grep -E "^\s+([0-9]+):\s*luks2$" | sed "s/^\s\+\([0-9]\+\):\s*luks2$/\1/g"
``` 