### PR TITLE
Bugfix oem-factory-reset: set HOTP counter to  0 on factory-reset/re-ownership

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -744,7 +744,7 @@ generate_checksums() {
 		fi
 
 		# If HOTP is enabled from board config, create HOTP counter
-		if [ -x /bin/hotp_verification]; then
+		if [ -x /bin/hotp_verification ]; then
 			## needs to exist for initial call to unseal-hotp
 			echo "0" >/boot/kexec_hotp_counter
 		fi


### PR DESCRIPTION
bugfix: check was missing space before closing [ brackets ].