### PR TITLE
tpmr: change TPM DUK from policypassword for policyauthvalue

### DIFF
--- a/initrd/bin/tpmr
+++ b/initrd/bin/tpmr
@@ -463,7 +463,7 @@ tpm2_seal() {
 		# Add an object authorization policy (the object authorization
 		# will be the password).  Save the digest, this is the resulting
 		# policy.
-		tpm2 policypassword -Q -S "$TRIAL_SESSION" -L "$AUTH_POLICY"
+		tpm2 policyauthvalue -Q -S "$TRIAL_SESSION" -L "$AUTH_POLICY"
 		# Pass the password to create later.  Pass the sha256sum of the
 		# password to the TPM so the password is not limited to 32 chars
 		# in length.
@@ -605,7 +605,7 @@ tpm2_unseal() {
 		# Add the object authorization policy (the actual password is
 		# provided later, but we must include this so the policy we
 		# attempt to use is correct).
-		tpm2 policypassword -Q -S "$POLICY_SESSION"
+		tpm2 policyauthvalue -Q -S "$POLICY_SESSION"
 		# When unsealing, include the password with the auth session
 		UNSEAL_PASS_SUFFIX="+$(tpm2_password_hex "$pass")"
 	fi


### PR DESCRIPTION
Fixes #2053 


**History**

When TPM2 support was brought up under #893 #1292, it was made as a direct translation from TPM1 implementation + parameters encryption, which used policypassword to do PCR+passphrase on TPM Disk Unlock Key (DUK) sealing unsealing.

IT was discovered under #1658 #1663 attempt to port Heads to Chromeboxes having cr50 implementation of TPM2 that PolicyPassword was unavailable, and research stopped there. Recently, I checked the spec and what cr50 actually support...... To realize policypassword and policyauthvalue are swappable while policyauthvalue is actually better and policypassword was not supported by cr50 because considered legacy and less secure then policyauthvalue.


Tested under 
- [x] qemu-coreboot-fbwhiptail-tpm2 (`./docker_repro.sh make BOARD=qemu-coreboot-fbwhiptail-tpm2 PUBKEY_ASC=pubkey.asc inject_gpg run`)
- [x] novacustom-nv4x_adl

CC @JonathonHall-Purism 


---

@mdrobnak you might want to rebase #1663 on master once this is merged? Seems like this will bring direct porting support to other chromeboxes, since cr50 doesn't need to be extended and policyauthvalue is part of supported tpm2 workflows.



TODO:
- clean tpmr so errors are better logged, code more easy to understand and audit.