### PR TITLE
initrd/*functions : add logic to show ec version under System Information and recovery shell, populated in init

### DIFF
--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -50,5 +50,14 @@ kernel=$(uname -s -r)
 
 FB_OPTIONS=""
 if whiptail --version | grep "fbwhiptail"; then FB_OPTIONS="--text-size 12"; fi
+# make sure we know the EC version too, populate if not already set
+if [ -z "$EC_VER" ]; then
+	EC_VER=$(ec_version)
+fi
+
+# build optional EC_VER line like gui_functions does
+ec_ver_line=""
+[ -n "$EC_VER" ] && ec_ver_line="\nEC_VER: ${EC_VER}"
+
 whiptail_type $BG_COLOR_MAIN_MENU $FB_OPTIONS --title 'System Info' \
-	--msgbox "${BOARD_NAME}\nFW_VER: ${FW_VER}\nKernel: ${kernel}\nCPU: ${cpustr}  RAM: ${memtotal} GB $battery_status\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')\n\n$(cat /tmp/devices_usb_pci)" 0 80
+	--msgbox "${BOARD_NAME}\nFW_VER: ${FW_VER}${ec_ver_line}\nKernel: ${kernel}\nCPU: ${cpustr}  RAM: ${memtotal} GB $battery_status\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')\n\n$(cat /tmp/devices_usb_pci)" 0 80

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -102,6 +102,14 @@ fw_version() {
 	echo "${FW_VER::-10}"
 }
 
+ec_version() {
+	# EC firmware version from DMI type 11 OEM Strings (if present).
+	# The raw sysfs entry has a 5-byte header followed by null-terminated strings.
+	local raw="/sys/firmware/dmi/tables/DMI"
+	[ -f "$raw" ] || return
+	tail -c +6 "$raw" | tr '\0' '\n' | sed -n 's/^EC firmware version: *//p'
+}
+
 preserve_rom() {
 	TRACE_FUNC
 	new_rom="$1"
@@ -313,7 +321,10 @@ recovery() {
 	touch /tmp/config
 	. /tmp/config
 
-	DEBUG "Board $CONFIG_BOARD - version $(fw_version)"
+	# Log board and firmware/EC versions in one go.  ec_version() will
+	# return an empty string if nothing is available, so the output is still
+	# well-formed even on systems without an EC version string.
+	DEBUG "Board $CONFIG_BOARD - version $(fw_version) EC_VER: $(ec_version)"
 
 	if [ "$CONFIG_TPM" = "y" ]; then
 		INFO "TPM: Extending PCR[4] to prevent any further secret unsealing"

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -165,6 +165,12 @@ file_selector() {
 
 show_system_info() {
 	TRACE_FUNC
+	# ensure EC_VER is populated; this mirrors the behaviour of the
+	# init script which exports EC_VER early, but calling the helper
+	# here makes the GUI menu self‑contained.
+	if [ -z "$EC_VER" ]; then
+		EC_VER=$(ec_version)
+	fi
 	battery_status="$(print_battery_state)"
 
 	memtotal=$(cat /proc/meminfo | grep 'MemTotal' | tr -s ' ' | cut -f2 -d ' ')
@@ -172,9 +178,13 @@ show_system_info() {
 	cpustr=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed -r 's/\(R\)//;s/\(TM\)//;s/CPU //;s/model name.*: //')
 	kernel=$(uname -s -r)
 
+	local ec_ver_line=""
+	[ -n "$EC_VER" ] && ec_ver_line="
+	EC_VER: ${EC_VER}"
+
 	local msgbox="${BOARD_NAME}
 
-	FW_VER: ${FW_VER}
+	FW_VER: ${FW_VER}${ec_ver_line}
 	Kernel: ${kernel}
 
 	CPU: ${cpustr}

--- a/initrd/init
+++ b/initrd/init
@@ -222,6 +222,9 @@ fi
 
 # export firmware version
 export FW_VER=$(fw_version)
+# export EC firmware version (DMI type 11 OEM string)
+# `ec_version` returns an empty string if the field is missing.
+export EC_VER=$(ec_version)
 
 # Add our boot devices into the /etc/fstab, if they are defined
 # in the configuration file.


### PR DESCRIPTION
repro from within Heads:
source /etc/functions
ec_version

v540tu:
2024-07-17_4ae73b9

v4x_adl:
1.07.02


- [x] Shows under /tmp/debug.log
- [x] Shows under System information


