### PR TITLE
docker scripts: Use portable shebang

### DIFF
--- a/docker_latest.sh
+++ b/docker_latest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source shared docker helper functions
 # shellcheck source=docker/common.sh

--- a/docker_local_dev.sh
+++ b/docker_local_dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source shared docker helper functions
 # shellcheck source=docker/common.sh

--- a/docker_repro.sh
+++ b/docker_repro.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source shared docker helper functions (use the docker/ path where common.sh lives)
 # shellcheck source=docker/common.sh


### PR DESCRIPTION
Not all distros have /bin/bash, use env to get bash from the PATH