### PR TITLE
Bugfix: Fix TPM auth retry, counter error handling, and NV error surfacing

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -53,15 +53,15 @@ execution. Source lives in `initrd/`.
 
 | Subsystem | Key files | Purpose |
 | --- | --- | --- |
-| Init / boot flow | `initrd/init`, `initrd/bin/gui-init` | System initialization and main GUI loop |
-| TPM abstraction | `initrd/bin/tpmr` | Unified TPM 1.2 / TPM 2.0 wrapper |
-| Boot signing | `initrd/bin/kexec-sign-config` | GPG-sign /boot files, create checksums |
-| Boot verification | `initrd/bin/kexec-select-boot` | Verify checksums, select and kexec the OS |
-| LUKS key sealing | `initrd/bin/kexec-seal-key` | Seal disk encryption key to TPM |
-| TOTP/HOTP | `initrd/bin/seal-totp`, `seal-hotpkey` | Seal attestation secrets to TPM |
-| OEM reset | `initrd/bin/oem-factory-reset` | Full re-ownership: GPG, TPM, TOTP, checksums |
+| Init / boot flow | `initrd/init`, `initrd/bin/gui-init.sh` | System initialization and main GUI loop |
+| TPM abstraction | `initrd/bin/tpmr.sh` | Unified TPM 1.2 / TPM 2.0 wrapper |
+| Boot signing | `initrd/bin/kexec-sign-config.sh` | GPG-sign /boot files, create checksums |
+| Boot verification | `initrd/bin/kexec-select-boot.sh` | Verify checksums, select and kexec the OS |
+| LUKS key sealing | `initrd/bin/kexec-seal-key.sh` | Seal disk encryption key to TPM |
+| TOTP/HOTP | `initrd/bin/seal-totp.sh`, `initrd/bin/seal-hotpkey.sh` | Seal attestation secrets to TPM |
+| OEM reset | `initrd/bin/oem-factory-reset.sh` | Full re-ownership: GPG, TPM, TOTP, checksums |
 | Config GUI | `initrd/bin/config-gui.sh` | Runtime configuration menus |
-| Functions lib | `initrd/etc/functions` | Shared utilities: logging, INPUT, TPM helpers |
+| Functions lib | `initrd/etc/functions.sh` | Shared utilities: logging, INPUT, TPM helpers |
 | GUI lib | `initrd/etc/gui_functions` | Whiptail wrappers, integrity report |
 
 ---
@@ -74,7 +74,7 @@ Three-layer hierarchy:
 2. **`/etc/config.user`** — User overrides extracted from CBFS at runtime
 3. **`/tmp/config`** — Combined result, sourced during boot
 
-`combine_configs()` in `initrd/etc/functions` merges these by concatenating
+`combine_configs()` in `initrd/etc/functions.sh` merges these by concatenating
 `/etc/config*` into `/tmp/config`. User settings in CBFS take precedence
 because they appear last in the concatenation.
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -42,7 +42,7 @@ These are not intended to be changed in user config.
 
 | Variable | Purpose |
 |---|---|
-| CONFIG_BOARD | Internal name of the board being built.  Avoid testing this for specific boards in initrd/, instead add a customization point and override it with boards/<name>/initrd/bin/<file>.  (For example, boards/librem_mini_v2/initrd/bin/board-init.sh.) |
+| CONFIG_BOARD | Internal name of the board being built.  Avoid testing this for specific boards in initrd/, instead add a customization point and override it with boards/<name>/initrd/bin/<file>.sh.  (For example, boards/librem_mini_v2/initrd/bin/board-init.sh.) |
 | CONFIG_BOARD_NAME | Display name of the board being built.  Use this to show the board name to the user. |
 | CONFIG_BRAND_NAME | Brand name to use to refer to the firmware itself.  Upstream, this is "Heads".  For example, "Heads main menu", "Enable Heads debug tracing", etc.  Distributions can override this to their specific brand name (usually in site-local/config). |
 

--- a/doc/tpm.md
+++ b/doc/tpm.md
@@ -9,9 +9,9 @@ See also: [architecture.md](architecture.md), [boot-process.md](boot-process.md)
 
 ## tpmr — unified TPM abstraction
 
-`initrd/bin/tpmr` is a shell script wrapper that presents a single interface
+`initrd/bin/tpmr.sh` is a shell script wrapper that presents a single interface
 over both TPM 1.2 (`tpm` / `trousers`) and TPM 2.0 (`tpm2-tools`). All Heads
-scripts call `tpmr` rather than invoking `tpm` or `tpm2` directly.
+scripts call `tpmr.sh` rather than invoking `tpm` or `tpm2` directly.
 
 ### PCR sizes
 
@@ -155,11 +155,11 @@ unchanged; the TXT mechanism adds the DRTM capability on top of it.
 | 1 | unused | Zero; anchored in sealing policies |
 | 2 | coreboot SRTM | Boot block, ROM stage, RAM stage, Heads Linux kernel + initrd |
 | 3 | unused | Zero; anchored in sealing policies |
-| 4 | Heads (`usb-init`, `kexec-insert-key`, `functions`) | Boot mode tracking: `"usb"` during USB init, `"generic"` after DUK unsealed, `"recovery"` when recovery shell entered |
+| 4 | Heads (`usb-init.sh`, `kexec-insert-key.sh`, `initrd/etc/functions.sh`) | Boot mode tracking: `"usb"` during USB init, `"generic"` after DUK unsealed, `"recovery"` when recovery shell entered |
 | 5 | Heads `insmod` wrapper | Each loaded kernel module: parameters + binary content (default `MODULE_PCR=5`) |
-| 6 | Heads `qubes-measure-luks` | LUKS header dump for each encrypted drive |
-| 7 | Heads `cbfs-init`, `uefi-init` | Each CBFS/UEFI file: filename then content (default `CONFIG_PCR=7`) — covers `config.user`, GPG keyring, user CBFS files |
-| 16 | `tpmr calcfuturepcr` (scratch use only) | Resettable debug PCR used as scratch pad during pre-computation of future PCR values; not part of any sealing policy |
+| 6 | Heads `qubes-measure-luks.sh` | LUKS header dump for each encrypted drive |
+| 7 | Heads `cbfs-init.sh`, `uefi-init.sh` | Each CBFS/UEFI file: filename then content (default `CONFIG_PCR=7`) — covers `config.user`, GPG keyring, user CBFS files |
+| 16 | `tpmr.sh calcfuturepcr` (scratch use only) | Resettable debug PCR used as scratch pad during pre-computation of future PCR values; not part of any sealing policy |
 
 PCRs 0-3 are read at seal time and included in sealing policies. The zero
 state of PCRs 0, 1, and 3 is intentional — any unexpected extension of those
@@ -214,7 +214,7 @@ ROM configuration integrity, not disk state.
 
 ## PCR extension
 
-`tpmr extend -ix <pcr_num> -ic <string>` extends a PCR with the hash of a
+`tpmr.sh extend -ix <pcr_num> -ic <string>` extends a PCR with the hash of a
 string. `-if <file>` extends with the hash of a file.
 
 `calcfuturepcr` replays the expected extend sequence to compute what a PCR
@@ -224,7 +224,7 @@ after normal init, before any recovery shell entry).
 
 ### Recovery PCR extension
 
-When a recovery shell is entered, `initrd/etc/functions` extends PCR 4 with
+When a recovery shell is entered, `initrd/etc/functions.sh` extends PCR 4 with
 the string `"recovery"`. This permanently invalidates TOTP and LUKS DUK
 unsealing for the rest of the boot session — the TPM will refuse to unseal
 secrets that were sealed against the normal-boot PCR 4 value.
@@ -283,11 +283,11 @@ validates the counter is readable from TPM, ensuring secrets can actually be
 unsealed.
 
 The counter is created during OEM Factory Reset by `check_tpm_counter` in
-`initrd/etc/functions`.
+`initrd/etc/functions.sh`.
 
 ### Counter state file
 
-`read_tpm_counter` in `initrd/etc/functions` reads the counter from the TPM
+`read_tpm_counter` in `initrd/etc/functions.sh` reads the counter from the TPM
 and writes the result to `/tmp/counter-<index>`. The format is
 `<hex_index>: <hex_value>`.
 
@@ -324,9 +324,9 @@ counter passes preflight or the user chooses to continue.
 
 ### Pipeline safety
 
-`tpmr counter_read` must be called with a direct redirect, not piped through
-`tee`. Piping through `tee` hides `tpmr` failures because `||` checks the
-exit status of `tee` (always 0), not `tpmr`. See
+`tpmr.sh counter_read` must be called with a direct redirect, not piped through
+`tee`. Piping through `tee` hides `tpmr.sh` failures because `||` checks the
+exit status of `tee` (always 0), not `tpmr.sh`. See
 [ux-patterns.md](ux-patterns.md#tpm-counter-patterns) for the correct pattern.
 
 ---
@@ -359,13 +359,13 @@ policy, or investigating why a seal/unseal operation fails.
 | --- | --- | --- |
 | Which coreboot PCRs are active on a board | `config/coreboot-<board>.config` | `CONFIG_PCR_SRTM`, `CONFIG_TPM_INIT_RAMSTAGE`, `CONFIG_TPM_MEASURED_BOOT_INIT_BOOTBLOCK`, `CONFIG_INTEL_TXT` |
 | Which coreboot version / fork a board uses | `modules/coreboot` + `boards/<board>/` | `CONFIG_COREBOOT_VERSION` in board config selects the coreboot source defined in `modules/coreboot` |
-| LUKS DUK sealing policy (which PCRs) | `initrd/bin/kexec-seal-key` | `tpmr seal` call and surrounding `pcrread` / `calcfuturepcr` calls; DEBUG comments explain each PCR |
-| TOTP/HOTP sealing policy (which PCRs) | `initrd/bin/seal-totp` | `tpmr seal` call; DEBUG messages explain why PCR 5 and PCR 6 are excluded |
-| PCR 4 (boot mode) tracking | `initrd/bin/usb-init`, `initrd/bin/kexec-insert-key`, `initrd/etc/functions` | `tpmr extend` calls with `"usb"`, `"generic"`, `"recovery"` |
+| LUKS DUK sealing policy (which PCRs) | `initrd/bin/kexec-seal-key.sh` | `tpmr.sh seal` call and surrounding `pcrread` / `calcfuturepcr` calls; DEBUG comments explain each PCR |
+| TOTP/HOTP sealing policy (which PCRs) | `initrd/bin/seal-totp.sh` | `tpmr.sh seal` call; DEBUG messages explain why PCR 5 and PCR 6 are excluded |
+| PCR 4 (boot mode) tracking | `initrd/bin/usb-init.sh`, `initrd/bin/kexec-insert-key.sh`, `initrd/etc/functions.sh` | `tpmr.sh extend` calls with `"usb"`, `"generic"`, `"recovery"` |
 | PCR 5 (kernel modules) | `initrd/sbin/insmod` | `MODULE_PCR` variable; default `MODULE_PCR=5`; each `insmod` extends PCR 5 |
-| PCR 6 (LUKS header) | `initrd/bin/qubes-measure-luks` | `tpmr extend` call against `/tmp/luksDump.txt` |
-| PCR 7 (CBFS / ROM files) | `initrd/bin/cbfs-init`, `initrd/bin/uefi-init` | `CONFIG_PCR` variable; default `CONFIG_PCR=7`; each extracted file extends PCR 7 |
-| Rollback counter logic | `initrd/etc/functions` | `check_tpm_counter`, `read_tpm_counter`, `counter_increment` |
+| PCR 6 (LUKS header) | `initrd/bin/qubes-measure-luks.sh` | `tpmr.sh extend` call against `/tmp/luksDump.txt` |
+| PCR 7 (CBFS / ROM files) | `initrd/bin/cbfs-init.sh`, `initrd/bin/uefi-init.sh` | `CONFIG_PCR` variable; default `CONFIG_PCR=7`; each extracted file extends PCR 7 |
+| Rollback counter logic | `initrd/etc/functions.sh` | `check_tpm_counter`, `read_tpm_counter`, `counter_increment` |
 
 ### Adding a new board
 

--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -980,9 +980,7 @@ force_unsafe_boot() {
 TRACE_FUNC
 
 if [ -x /bin/hotp_verification ]; then
-	enable_usb
-	# Detect dongle branding from USB VID:PID -- must run AFTER enable_usb so lsusb
-	# can see the dongle (NK3 enumerates ~1 second after USB module load).
+	# HOTP required by board config, always detect branding
 	detect_usb_security_dongle_branding
 fi
 

--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -981,11 +981,10 @@ TRACE_FUNC
 
 if [ -x /bin/hotp_verification ]; then
 	enable_usb
+	# Detect dongle branding from USB VID:PID -- must run AFTER enable_usb so lsusb
+	# can see the dongle (NK3 enumerates ~1 second after USB module load).
+	detect_usb_security_dongle_branding
 fi
-
-# Detect dongle branding from USB VID:PID -- must run AFTER enable_usb so lsusb
-# can see the dongle (NK3 enumerates ~1 second after USB module load).
-detect_usb_security_dongle_branding
 
 if detect_boot_device; then
 	# /boot device with installed OS found

--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -191,11 +191,19 @@ prompt_update_checksums() {
 		--yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that these files have not been tampered with.\n\nYou will need your GPG key available, and this change will modify your disk.\n\nDo you want to continue?" 0 80); then
 		if update_checksums; then
 			return 0
+		fi
+		# update_checksums may have set the TPM-reset-required marker
+		# during its execution (e.g. check_tpm_counter hit "out of
+		# resources").  Show the targeted TPM message instead of the
+		# generic failure so the user knows exactly what to do.
+		if tpm_reset_required; then
+			whiptail_error --title 'TPM Reset Required' \
+				--msgbox "Cannot sign /boot: TPM state is inconsistent.\n\nReset the TPM first (Options -> TPM/TOTP/HOTP Options -> Reset the TPM), then update checksums." 0 80
 		else
 			whiptail_error --title 'ERROR' \
 				--msgbox "Failed to update checksums / sign default config" 0 80
-			return 1
 		fi
+		return 1
 	fi
 	return 1
 }
@@ -411,8 +419,13 @@ EOF
 				skip_to_menu="true"
 				return 1
 				;;
+			# "Reset the TPM" from the TOTP failure whiptail menu.
+			# The gate runs first to verify /boot integrity.  If the gate
+			# fails *because* TPM reset is required (e.g. stale counters),
+			# the || tpm_reset_required bypass lets reset_tpm() proceed —
+			# it clears counters and creates a fresh one.
 			p)
-				if gate_reseal_with_integrity_report && reset_tpm && update_totp && BG_COLOR_MAIN_MENU="normal"; then
+				if { gate_reseal_with_integrity_report || tpm_reset_required; } && reset_tpm && update_totp && BG_COLOR_MAIN_MENU="normal"; then
 					reseal_tpm_disk_decryption_key || prompt_missing_gpg_key_action
 				fi
 				;;
@@ -806,8 +819,11 @@ show_tpm_totp_hotp_options_menu() {
 			update_totp && update_hotp || true
 		fi
 		;;
+	# "Reset the TPM" from the TPM/TOTP/HOTP options whiptail menu.
+	# Same gate-bypass pattern: if the gate fails because TPM
+	# reset is required, proceed to reset_tpm() anyway.
 	r)
-		if gate_reseal_with_integrity_report && reset_tpm; then
+		if { gate_reseal_with_integrity_report || tpm_reset_required; } && reset_tpm; then
 			reseal_tpm_disk_decryption_key || prompt_missing_gpg_key_action
 		fi
 		;;
@@ -837,7 +853,20 @@ reset_tpm() {
 				return 1
 			fi
 
-			tpmr.sh reset "$tpm_owner_passphrase"
+			# Verify TPM reset succeeded before proceeding to counter
+			# creation, signing, TOTP generation, and DUK resealing.
+			# A failed reset would leave the TPM in an inconsistent state
+			# (old passphrase with unknown PCRs), causing confusing errors
+			# downstream.  Show the actual error to the user and return
+			# to the menu.
+			local reset_err_file=$(mktemp)
+			if ! tpmr.sh reset "$tpm_owner_passphrase" >"$reset_err_file" 2>&1; then
+				ERROR=$(tail -n 1 "$reset_err_file" | fold -s)
+				rm -f "$reset_err_file"
+				whiptail_error --title 'ERROR' \
+					--msgbox "Error resetting TPM:\n\n${ERROR}" 0 80
+				return 1
+			fi
 
 			# now that the TPM is reset, remove invalid TPM counter files
 			mount_boot

--- a/initrd/bin/oem-factory-reset.sh
+++ b/initrd/bin/oem-factory-reset.sh
@@ -23,8 +23,8 @@ rm -f /tmp/hotpkey_fw_shown
 
 TRACE_FUNC
 
-# Enable USB and detect branding early — $DONGLE_BRAND is used throughout this script.
-enable_usb
+# Detect branding early — $DONGLE_BRAND is used throughout this script.
+# enable_usb is called internally by detect_usb_security_dongle_branding.
 detect_usb_security_dongle_branding
 
 # use TERM to exit on error
@@ -1005,9 +1005,8 @@ set_default_boot_option() {
 usb_security_token_capabilities_check() {
 	TRACE_FUNC
 
-	enable_usb
-
 	# Always detect dongle branding from USB VID:PID — never read a stored file.
+	# enable_usb is called internally by detect_usb_security_dongle_branding.
 	detect_usb_security_dongle_branding
 	DEBUG "USB Security dongle detected: $DONGLE_BRAND"
 	# Only show generic "Detected" if no specific brand was identified

--- a/initrd/bin/seal-hotpkey.sh
+++ b/initrd/bin/seal-hotpkey.sh
@@ -48,9 +48,7 @@ mount_boot || exit 1
 
 counter_value=1
 
-enable_usb
-
-# Detect branding after USB is up so lsusb can see the device.
+# Detect branding (enable_usb is called internally)
 detect_usb_security_dongle_branding
 DEBUG "$DONGLE_BRAND detected via USB VID:PID"
 

--- a/initrd/bin/tpmr.sh
+++ b/initrd/bin/tpmr.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # TPM Wrapper - to unify tpm and tpm2 subcommands
+#
+# NOTE: tpmtotp C code (counter_create.c, unsealfile.c, sealfile2.c, etc.)
+# prints ALL output (both success and error messages) via printf() to stdout,
+# NOT stderr.  This is a quirk of the tpmtotp toolkit.  When capturing
+# output or errors from tpm commands, we must capture stdout (not just stderr).
+#
+# TPM2 error codes caught by auth-retry grep patterns.
+# Reference: TCG TPM2 Part 2 (Structures), Table 18 — TPM_RC (Response Codes)
+# https://trustedcomputinggroup.org/resource/tpm-library-specification/
+#   0x98e  TPM_RC_AUTH_FAIL       — wrong password, retry allowed
+#   0x149  TPM_RC_AUTH_UNAVAILABLE — auth handle wrong for entity (e.g. owner
+#           hierarchy auth vs. NV index auth with authwrite attribute)
 
 . /etc/functions.sh
 
@@ -279,10 +291,21 @@ tpm2_counter_read() {
 	echo "$index: $hex_val"
 }
 
+# tpm2_counter_inc - Increment a TPM2 counter.
+#
+# Auth behaviour:
+#   -pwdc ""       : try bare nvincrement (index auth — counters created by
+#                    nvdefine have empty NV index auth).  On failure, prompt for
+#                    owner passphrase and retry with owner auth up to 3 times.
+#   -pwdc <pass>   : use owner auth — retry up to 3 times on auth failure,
+#                    re-prompting passphrase.
+#   (no -pwdc)     : try bare nvincrement first, then prompt and retry as above.
+#
+# Retry is consistent with tpm2_seal and tpm2_counter_create which also
+# re-prompt and retry on authorization failures.
 tpm2_counter_inc() {
 	TRACE_FUNC
-	local index pwd
-	local inc_args=()
+	local index pass=""
 	while true; do
 		case "$1" in
 		-ix)
@@ -290,7 +313,7 @@ tpm2_counter_inc() {
 			shift 2
 			;;
 		-pwdc)
-			pwd="$2"
+			pass="$2"
 			shift 2
 			;;
 		*)
@@ -298,100 +321,157 @@ tpm2_counter_inc() {
 			;;
 		esac
 	done
-	if [ -n "$pwd" ]; then
-		inc_args=(-C o -P "$(tpm2_password_hex "$pwd")")
+	# Try bare nvincrement first (index auth, no owner passphrase needed).
+	# This is a pre-check before the owner-auth retry loop and is not
+	# counted against the 3-attempt budget below.
+	if tpm2 nvincrement "0x$index" 2>/dev/null >/dev/console; then
+		local hex_val
+		hex_val="$(tpm2 nvread 0x$index | xxd -pc8)" || return 1
+		echo "$index: $hex_val"
+		return 0
 	fi
-	tpm2 nvincrement "${inc_args[@]}" "0x$index" >/dev/console || return 1
-	local hex_val
-	hex_val="$(tpm2 nvread 0x"$index" | xxd -pc8)" || return 1
-	echo "$index: $hex_val"
+
+	# Retry with owner auth (up to 3 attempts total).
+	# If -pwdc was provided, it's cached as tpm_owner_passphrase;
+	# otherwise prompt_tpm_owner_password will prompt and cache.
+	local attempt=0
+	while [ $attempt -lt 3 ]; do
+		attempt=$((attempt + 1))
+		if [ -n "$pass" ]; then
+			tpm_owner_passphrase="$pass"
+		else
+			prompt_tpm_owner_password
+		fi
+		local tmp_err_file=$(mktemp)
+		if tpm2 nvincrement -C o -P "$(tpm2_password_hex "$tpm_owner_passphrase")" "0x$index" 2>"$tmp_err_file" >/dev/console; then
+			rm -f "$tmp_err_file"
+			local hex_val
+			hex_val="$(tpm2 nvread 0x$index | xxd -pc8)" || return 1
+			echo "$index: $hex_val"
+			return 0
+		fi
+		local tmp_err_content="$(cat "$tmp_err_file")"
+		rm -f "$tmp_err_file"
+		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+		DEBUG "tpm2_counter_inc attempt $attempt failed. Stderr: $tmp_err_content"
+		if ! echo "$tmp_err_content" | grep -qiE 'authorization|auth|bad|permission|0x98e|0x149'; then
+			DIE "Can't increment TPM counter for $index, access denied."
+		fi
+		WARN "Authentication failed, retrying..."
+	done
+	DIE "Can't increment TPM counter for $index after 3 attempts, access denied."
 }
 
-tpm1_counter_create() {
-	TRACE_FUNC
+# _tpm_auth_retry - Shared retry helper for TPM commands needing owner auth.
+#
+# Handles both TPM1 (tpmtotp: errors to stdout, uses -pwdo/-pwdc flags)
+# and TPM2 (tpm2-tools: errors to stderr, uses -P parameter).
+#
+# Caching: prompt_tpm_owner_password reuses cached passphrase if available.
+# On auth failure the cache is shredded; next prompt will ask the user.
+#
+# Usage: _tpm_auth_retry <label> <error_stream> <tpm_type> <pw_flag> <cmd...>
+#   <label>:        short name for debug (e.g. "counter_create")
+#   <error_stream>: "stdout" (TPM1) or "stderr" (TPM2)
+#   <tpm_type>:    "tpm1" or "tpm2"
+#   <pw_flag>:     passphrase flag for TPM1 (-pwdo or -pwdc), ignored for TPM2
+#   <cmd...>:       the tpm command and its non-auth arguments
+#
+# Exit codes:
+#   0: success
+#   1: non-auth error (e.g., "out of resources" 0x15) — caller should check
+_tpm_auth_retry() {
+	local label="$1" error_stream="$2" tpm_type="$3" pw_flag="$4"
+	shift 4
+	local cmd=("$@")
+
 	local attempt=0
-	while true; do
+	while [ $attempt -lt 3 ]; do
 		attempt=$((attempt + 1))
 		prompt_tpm_owner_password
 		tpm_owner_passphrase="$(cat /tmp/secret/tpm_owner_passphrase)"
-		TMP_ERR_FILE=$(mktemp)
-		if tpm counter_create -pwdo "$tpm_owner_passphrase" "$@" 2>"$TMP_ERR_FILE"; then
-			rm -f "$TMP_ERR_FILE"
+
+		# Build auth args based on TPM type and flag
+		local auth_args=()
+		if [ "$tpm_type" = "tpm2" ]; then
+			auth_args=(-P "$(tpm2_password_hex "$tpm_owner_passphrase")")
+		else
+			# TPM1: use the provided flag (-pwdo or -pwdc)
+			auth_args=("$pw_flag" "$tpm_owner_passphrase")
+		fi
+
+		local tmp_file=$(mktemp)
+		local rc=0
+		if [ "$error_stream" = "stdout" ]; then
+			"${cmd[@]}" "${auth_args[@]}" >"$tmp_file" 2>&1 && rc=0 || rc=$?
+		else
+			"${cmd[@]}" "${auth_args[@]}" 2>"$tmp_file" >/dev/null && rc=0 || rc=$?
+		fi
+		if [ $rc -eq 0 ]; then
+			DEBUG "_tpm_auth_retry $label: success (attempt $attempt)"
+			cat "$tmp_file"
+			rm -f "$tmp_file"
 			return 0
 		fi
-		tmp_err_content="$(cat "$TMP_ERR_FILE")"
-		rm -f "$TMP_ERR_FILE"
-		DEBUG "Failed attempt $attempt to create counter from tpm1_counter_create. Stderr: $tmp_err_content"
-		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase
-		if echo "$tmp_err_content" | grep -qiE 'authorization|auth|bad|permission'; then
-			if [ "$attempt" -ge 3 ]; then
-				DIE "Unable to create counter from tpm1_counter_create after 3 attempts. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
-			fi
-			WARN "Counter creation failed (bad passphrase?). Retrying..."
+		local out_content="$(cat "$tmp_file")"
+		DEBUG "_tpm_auth_retry $label attempt $attempt failed: $out_content"
+		rm -f "$tmp_file"
+		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+		if echo "$out_content" | grep -qiE 'authorization|auth|bad|permission'; then
+			WARN "$label failed (bad passphrase?). Retrying..."
 		else
-			DIE "Unable to create counter from tpm1_counter_create. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
+			# Non-auth error (e.g., out of resources 0x15)
+			echo "$out_content"
+			return 1
 		fi
 	done
+	DIE "TPM $label failed after 3 attempts. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
+}
+
+# tpm1_counter_create - Create a TPM1 rollback counter.
+# Delegates to _tpm_auth_retry for passphrase-driven retry on auth failure.
+tpm1_counter_create() {
+	TRACE_FUNC
+	_tpm_auth_retry "counter_create" "stdout" "tpm1" "-pwdo" tpm counter_create "$@"
+}
+
+# tpm1_counter_read - Read a TPM1 counter value (no auth needed).
+tpm1_counter_read() {
+	TRACE_FUNC
+	tpm counter_read "$@"
+}
+
+# tpm1_counter_increment - Increment a TPM1 rollback counter.
+# Args: -ix <index> [ -pwdc <passphrase> ]
+tpm1_counter_increment() {
+	TRACE_FUNC
+	local counter_id=""
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			-ix) counter_id="$2"; shift 2 ;;
+			-pwdc) shift 2 ;;  # passphrase handled by _tpm_auth_retry
+			*) shift ;;
+		esac
+	done
+	_tpm_auth_retry "counter_increment" "stdout" "tpm1" "-pwdc" tpm counter_increment -ix "$counter_id"
 }
 
 tpm2_counter_create() {
 	TRACE_FUNC
-	pass=""  # owner passphrase from argument
-	label="" # label argument
-	while true; do
+	local pass="" label=""
+	while [ $# -gt 0 ]; do
 		case "$1" in
-		-pwdc)
-			pass="$2"
-			shift 2
-			;;
-		-la)
-			label="$2"
-			shift 2
-			;;
-		*)
-			break
-			;;
+		-pwdc) pass="$2"; shift 2 ;;
+		-la) label="$2"; shift 2 ;;
+		*) break ;;
 		esac
 	done
 
-	rand_index="1$(dd if=/dev/urandom bs=1 count=3 2>/dev/null | xxd -pc3)"
-
-	local attempt=0
-	while true; do
-		attempt=$((attempt + 1))
-		if [ -n "$pass" ]; then
-			tpm_owner_passphrase="$pass"
-			mkdir -p "$SECRET_DIR" || true
-			echo -n "$tpm_owner_passphrase" >/tmp/secret/tpm_owner_passphrase 2>/dev/null || true
-		else
-			prompt_tpm_owner_password
-			tpm_owner_passphrase="$tpm_owner_passphrase"
-		fi
-
-		TMP_ERR_FILE=$(mktemp)
-		if tpm2 nvdefine -C o -s 8 -a "ownerread|authread|authwrite|nt=1" \
-			-P "$(tpm2_password_hex "$tpm_owner_passphrase")" "0x$rand_index" \
-			2>"$TMP_ERR_FILE" >/dev/null; then
-			rm -f "$TMP_ERR_FILE"
-			echo "$rand_index: (valid after an increment)"
-			return 0
-		fi
-		tmp_err_content="$(cat "$TMP_ERR_FILE")"
-		rm -f "$TMP_ERR_FILE"
-		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase
-		DEBUG "tpm2_counter_create attempt $attempt failed. Stderr: $tmp_err_content"
-		if echo "$tmp_err_content" | grep -qiE 'authorization|auth|bad|permission'; then
-			if [ -n "$pass" ]; then
-				DIE "Counter creation failed with provided passphrase. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
-			fi
-			if [ "$attempt" -ge 3 ]; then
-				DIE "Unable to create counter from tpm2_counter_create after 3 attempts. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
-			fi
-			WARN "Counter creation failed (bad passphrase?). Retrying..."
-		else
-			DIE "Unable to create counter from tpm2_counter_create. Please reset the TPM using the GUI menu (Options -> TPM/TOTP/HOTP Options -> Reset the TPM) and try again."
-		fi
-	done
+	local rand_index="1$(dd if=/dev/urandom bs=1 count=3 2>/dev/null | xxd -pc3)"
+	_tpm_auth_retry "counter_create" "stderr" "tpm2" "-P" \
+	tpm2 nvdefine -C o -s 8 -a "ownerread|authread|authwrite|nt=1" "0x$rand_index"
+	# On success, output the index for the caller.
+	echo "$rand_index: (valid after an increment)"
 }
 
 tpm2_startsession() {
@@ -560,7 +640,7 @@ tpm2_seal() {
 		tmp_err_content="$(cat "$tmp_err_file")"
 		rm -f "$tmp_err_file"
 		DEBUG "Failed attempt $attempt to write sealed secret to NVRAM from tpm2_seal. Stderr: $tmp_err_content"
-		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase
+		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
 		if echo "$tmp_err_content" | grep -qiE 'authorization|auth|bad|permission'; then
 			if [ "$attempt" -ge 3 ]; then
 				DIE "Unable to write sealed secret to TPM NVRAM after 3 attempts. Reset the TPM and try again."
@@ -571,9 +651,25 @@ tpm2_seal() {
 		fi
 	done
 }
+# tpm1_seal - Seal a file to TPM1 NVRAM.
+#
+# NVRAM Flow:
+# 1. Create sealed blob from file + PCR policy (tpm sealfile2)
+# 2. Try to write blob to NVRAM index (tpm nv_writevalue)
+# 3. If write fails (index doesn't exist), create NVRAM space (tpm nv_definespace)
+# 4. Retry write after defining space
+#
+# Exit code handling:
+# - Script uses 'set -e', so we capture TPM exit codes in subshells to avoid
+#   premature exit. Some TPM implementations return exit code 2 (index doesn't
+#   exist) with empty stderr on first write - we handle this by defining NVRAM.
+# - Exit code 0: success
+# - Exit code 2: index doesn't exist (normal on first seal after TPM reset)
+# - Exit code 3+: other errors (permission denied, bad passphrase, etc.)
+#
+# PCR policy: At seal time, PCR5 is IGNORED (not measured) - only relevant for HOTP.
 tpm1_seal() {
 	TRACE_FUNC
-	local tmp_err_write tmp_err_define tmp_err_write_after_define
 	file="$1"
 	index="$2"
 	pcrl="$3" #0,1,2,3,4,5,6,7 (does not include algorithm prefix)
@@ -612,53 +708,87 @@ tpm1_seal() {
 		"${POLICY_ARGS[@]}"
 	DEBUG "tpm1_seal: sealed blob created at $sealed_file (size=$(wc -c <"$sealed_file" 2>/dev/null || echo 0) bytes), target nv index=$index"
 
+	tmp_out_write="$(mktemp)"
+	(
+		set +e
+		# Capture stdout+stderr: tpmtotp C code prints errors to stdout via printf
+		tpm nv_writevalue -in "$index" -if "$sealed_file" >"$tmp_out_write" 2>&1
+		echo $? > "$tmp_out_write.exit"
+	)
+	tpm_result=$(cat "$tmp_out_write.exit")
+	tmp_out_content="$(cat "$tmp_out_write")"
+	rm -f "$tmp_out_write" "$tmp_out_write.exit"
+	DEBUG "tpm1_seal: nv_writevalue result=$tpm_result, output='$tmp_out_content'"
+
+	if [ "$tpm_result" = "0" ]; then
+		DEBUG "tpm1_seal: nv_writevalue succeeded"
+		return 0
+	fi
+
+	# Continue if: exit code is 2 (index doesn't exist) OR output contains "illegal index".
+	# Otherwise: unexpected error, die.
+	if [ "$tpm_result" != "2" ] && ! echo "$tmp_out_content" | grep -qi 'illegal index'; then
+		DEBUG "tpm1_seal nv_writevalue(pre-define) output: $tmp_out_content"
+		DEBUG "Failed to write sealed secret to NVRAM from tpm1_seal (unexpected error). Wiping /tmp/secret/tpm_owner_passphrase"
+		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+		DIE "Unable to write sealed secret to TPM NVRAM"
+	fi
+	DEBUG "tpm1_seal: nv index $index is not defined yet (Illegal index); attempting nv_definespace"
+
+	tpm physicalpresence -s ||
+		{
+			WARN "Unable to assert physical presence"
+		}
+	# Physical presence only needs to be asserted once — it persists
+	# until the TPM is reset.  Asserting it inside the loop would be
+	# redundant.
+
+	# NVRAM define+write retry loop: if the passphrase is wrong (e.g. typo),
+	# re-prompt and retry up to 3 times, consistent with tpm1_counter_create
+	# and tpm2_seal.  This prevents a single mistyped TPM Owner Passphrase
+	# from killing the sealing flow.
 	local attempt=0
-	while true; do
+	while [ $attempt -lt 3 ]; do
 		attempt=$((attempt + 1))
-		tmp_err_write="$(mktemp)"
-		if tpm nv_writevalue -in "$index" -if "$sealed_file" 2>"$tmp_err_write"; then
-			rm -f "$tmp_err_write"
-			return 0
-		fi
-		tmp_err_content="$(cat "$tmp_err_write")"
-		rm -f "$tmp_err_write"
-		if ! echo "$tmp_err_content" | grep -qi 'illegal index'; then
-			DEBUG "tpm1_seal nv_writevalue(pre-define) stderr: $tmp_err_content"
-			DEBUG "Failed to write sealed secret to NVRAM from tpm1_seal (unexpected error). Wiping /tmp/secret/tpm_owner_passphrase"
-			shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase
-			DIE "Unable to write sealed secret to TPM NVRAM"
-		fi
-		DEBUG "tpm1_seal: nv index $index is not defined yet (Illegal index); attempting nv_definespace"
-
-		tpm physicalpresence -s ||
-			{
-				WARN "Unable to assert physical presence"
-			}
-
 		prompt_tpm_owner_password
 		tpm_owner_passphrase="$(cat /tmp/secret/tpm_owner_passphrase)"
-		tmp_err_define="$(mktemp)"
+		local tmp_def_out="$(mktemp)"
 		if ! DO_WITH_DEBUG --mask-position 7 tpm nv_definespace -in "$index" -sz "$sealed_size" \
-			-pwdo "$tpm_owner_passphrase" -per 0 2>"$tmp_err_define"; then
-			tmp_err_define_content="$(cat "$tmp_err_define")"
-			rm -f "$tmp_err_define"
-			DEBUG "tpm1_seal nv_definespace stderr: $tmp_err_define_content"
-			WARN "Unable to define TPM NVRAM space; trying anyway"
-		else
-			rm -f "$tmp_err_define"
+			-pwdo "$tpm_owner_passphrase" -per 0 >"$tmp_def_out" 2>&1; then
+			local def_out_content="$(cat "$tmp_def_out")"
+			rm -f "$tmp_def_out"
+			DEBUG "tpm1_seal nv_definespace failed (attempt $attempt): $def_out_content"
+			# If auth failure, retry after re-prompt; otherwise bail out.
+			if echo "$def_out_content" | grep -qiE 'authorization|auth|bad|permission'; then
+				shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+				WARN "nv_definespace failed (bad passphrase?). Retrying..."
+				continue
+			fi
+			# Non-auth error (e.g., NVRAM full) — surface it and die.
+			shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+			DIE "Failed to define NVRAM space for index $index: $def_out_content"
 		fi
+		rm -f "$tmp_def_out"
+		DEBUG "tpm1_seal: nv_definespace succeeded"
 
-		tmp_err_write_after_define="$(mktemp)"
-		if tpm nv_writevalue -in "$index" -if "$sealed_file" 2>"$tmp_err_write_after_define"; then
-			rm -f "$tmp_err_write_after_define"
+		tmp_out_write_after_define="$(mktemp)"
+		(
+			set +e
+			tpm nv_writevalue -in "$index" -if "$sealed_file" >"$tmp_out_write_after_define" 2>&1
+			echo $? > "$tmp_out_write_after_define.exit"
+		)
+		write_result=$(cat "$tmp_out_write_after_define.exit")
+		tmp_out_content="$(cat "$tmp_out_write_after_define")"
+		rm -f "$tmp_out_write_after_define" "$tmp_out_write_after_define.exit"
+		DEBUG "tpm1_seal: nv_writevalue(post-define) attempt $attempt result=$write_result, output='$tmp_out_content'"
+
+		if [ "$write_result" = "0" ]; then
+			DEBUG "tpm1_seal: nv_writevalue succeeded after define"
 			return 0
 		fi
-		tmp_err_content="$(cat "$tmp_err_write_after_define")"
-		rm -f "$tmp_err_write_after_define"
-		DEBUG "tpm1_seal nv_writevalue(post-define) stderr: $tmp_err_content"
-		DEBUG "Failed attempt $attempt to write sealed secret to NVRAM from tpm1_seal. Wiping /tmp/secret/tpm_owner_passphrase"
-		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase
-		if echo "$tmp_err_content" | grep -qiE 'authorization|auth|bad|permission'; then
+		DEBUG "tpm1_seal nv_writevalue(post-define) output: $tmp_out_content"
+		shred -n 10 -z -u /tmp/secret/tpm_owner_passphrase 2>/dev/null || true
+		if echo "$tmp_out_content" | grep -qiE 'authorization|auth|bad|permission'; then
 			if [ "$attempt" -ge 3 ]; then
 				DIE "Unable to write sealed secret to TPM NVRAM after 3 attempts"
 			fi
@@ -667,6 +797,7 @@ tpm1_seal() {
 			DIE "Unable to write sealed secret to TPM NVRAM"
 		fi
 	done
+	DIE "Unable to write sealed secret to TPM NVRAM after 3 attempts"
 }
 
 # Unseal a file sealed by tpm2_seal.  The PCR list must be provided, the
@@ -767,34 +898,56 @@ tpm1_unseal() {
 	rm -f "$tmp_err_read"
 
 	PASS_ARGS=()
-	if [ "$pass" ]; then
+
+	if [ -n "$pass" ]; then
 		PASS_ARGS=(-pwdd "$pass")
 	fi
 
+	# NOTE: tpmtotp C code (unsealfile.c, counter_create.c, etc.) prints
+	# ALL output (success and errors) via printf() to stdout, NOT stderr.
+	# This is a quirk of the tpmtotp toolkit.  We must capture stdout
+	# to detect failure messages like "Error Decryption failure from TPM_Unseal".
+	# Also: redirection order matters: >"$file" 2>&1 sends stdout to file, stderr follows.
+	# We use a tmp file + variable to avoid set -e killing the function on failure.
+	TMP_UNSEAL_OUT=$(mktemp)
+	at_exit cleanup_shred "$TMP_UNSEAL_OUT"
+	unseal_ok="n"
+
 	if [ -n "$pass" ]; then
-		if ! DO_WITH_DEBUG --mask-position 7 tpm unsealfile \
-			-if "$sealed_file" \
-			-of "$file" \
-			"${PASS_ARGS[@]}" \
-			-hk 40000000; then
-			if [ "$HEADS_NONFATAL_UNSEAL" = "y" ]; then
-				DEBUG "nonfatal tpm1_unseal failure: unable to unseal TPM NVRAM blob"
-				return 1
-			fi
-			DIE "Unable to unseal secret from TPM NVRAM. Use the GUI menu (Options -> TPM/TOTP/HOTP Options -> Generate new TOTP/HOTP secret) to reseal."
+		# Run in subshell with set +e to avoid set -e killing the script on failure.
+		# Capture stdout (tpmtotp prints errors via printf to stdout, not stderr).
+		if ( set +e
+			DO_WITH_DEBUG --mask-position 7 tpm unsealfile \
+				-if "$sealed_file" \
+				-of "$file" \
+				"${PASS_ARGS[@]}" \
+				-hk 40000000 >"$TMP_UNSEAL_OUT" 2>&1
+		); then
+			unseal_ok="y"
 		fi
 	else
-		if ! DO_WITH_DEBUG tpm unsealfile \
-			-if "$sealed_file" \
-			-of "$file" \
-			-hk 40000000; then
-			if [ "$HEADS_NONFATAL_UNSEAL" = "y" ]; then
-				DEBUG "nonfatal tpm1_unseal failure: unable to unseal TPM NVRAM blob"
-				return 1
-			fi
-			DIE "Unable to unseal secret from TPM NVRAM. Use the GUI menu (Options -> TPM/TOTP/HOTP Options -> Generate new TOTP/HOTP secret) to reseal."
+		# Run in subshell with set +e to avoid set -e killing the script on failure.
+		# Capture stdout (tpmtotp prints errors via printf to stdout, not stderr).
+		if ( set +e
+			DO_WITH_DEBUG tpm unsealfile \
+				-if "$sealed_file" \
+				-of "$file" \
+				-hk 40000000 >"$TMP_UNSEAL_OUT" 2>&1
+		); then
+			unseal_ok="y"
 		fi
 	fi
+
+	if [ "$unseal_ok" = "y" ]; then
+		DEBUG "tpm1_unseal: unseal succeeded"
+		return 0
+	fi
+	DEBUG "tpm1_unseal unsealfile output: $(cat "$TMP_UNSEAL_OUT")"
+	if [ "$HEADS_NONFATAL_UNSEAL" = "y" ]; then
+		DEBUG "nonfatal tpm1_unseal failure: unable to unseal TPM NVRAM blob"
+		return 1
+	fi
+	DIE "Unable to unseal secret from TPM NVRAM. Use the GUI menu (Options -> TPM/TOTP/HOTP Options -> Generate new TOTP/HOTP secret) to reseal."
 }
 
 # cache_owner_passphrase <passphrase>
@@ -984,6 +1137,14 @@ if [ "$CONFIG_TPM2_TOOLS" != "y" ]; then
 	calcfuturepcr)
 		shift
 		replay_pcr "sha1" "$@"
+		;;
+	counter_read)
+		shift
+		tpm1_counter_read "$@"
+		;;
+	counter_increment)
+		shift
+		tpm1_counter_increment "$@"
 		;;
 	counter_create)
 		shift

--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -506,6 +506,7 @@ detect_usb_security_dongle_branding() {
 	if [ "$DONGLE_BRAND" != "USB Security dongle" ] \
 		&& [ -n "$DONGLE_BRAND" ] \
 		&& [ "$usb_was_enabled" = "y" ]; then
+		DEBUG "Fast path: DONGLE_BRAND='$DONGLE_BRAND' already known, USB was enabled"
 		return
 	fi
 
@@ -515,7 +516,10 @@ detect_usb_security_dongle_branding() {
 	[ "$usb_was_enabled" != "y" ] && wait_for_usb_devices
 
 	# If branding is already specific, USB is now ready and no re-scan is needed.
-	[ "$DONGLE_BRAND" != "USB Security dongle" ] && [ -n "$DONGLE_BRAND" ] && return
+	if [ "$DONGLE_BRAND" != "USB Security dongle" ] && [ -n "$DONGLE_BRAND" ]; then
+		DEBUG "Branding already specific ($DONGLE_BRAND), skipping lsusb scan"
+		return
+	fi
 	local lsusb_out
 	lsusb_out="$(lsusb)"
 	DEBUG "lsusb output: $lsusb_out"
@@ -757,8 +761,7 @@ cache_gpg_signing_pin() {
 		-name '*.key' -delete >/dev/null 2>&1 || true
 	DEBUG "Cleared private-keys-v1.d; agent will re-discover keys via scdaemon"
 
-	# setup the USB so we can reach the USB Security dongle's OpenPGP smartcard
-	enable_usb
+	# USB will be enabled by wait_for_gpg_card() and detect_usb_security_dongle_branding()
 	# Wait for USB enumeration before accessing GPG card to avoid race condition
 	wait_for_usb_devices
 
@@ -847,7 +850,7 @@ cache_gpg_signing_pin() {
 }
 
 confirm_gpg_card() {
-	enable_usb
+	# enable_usb is called internally by detect_usb_security_dongle_branding
 	detect_usb_security_dongle_branding
 	cache_gpg_signing_pin "$@"
 }
@@ -1034,7 +1037,7 @@ load_config_value() {
 
 enable_usb() {
 	TRACE_FUNC
-	[ "${_USB_ENABLED:-n}" = "y" ] && return
+	[ "${_USB_ENABLED:-n}" = "y" ] && { DEBUG "USB already enabled, skipping"; return; }
 	#insmod.sh ehci_hcd prior of uhdc_hcd and ohci_hcd to suppress dmesg warning
 	insmod.sh /lib/modules/ehci-hcd.ko || DIE "ehci_hcd: module load failed"
 
@@ -1046,7 +1049,8 @@ enable_usb() {
 	insmod.sh /lib/modules/ehci-pci.ko || DIE "ehci_pci: module load failed"
 	insmod.sh /lib/modules/xhci-hcd.ko || DIE "xhci_hcd: module load failed"
 	insmod.sh /lib/modules/xhci-pci.ko || DIE "xhci_pci: module load failed"
-	_USB_ENABLED="y"
+	export _USB_ENABLED="y"
+	DEBUG "USB modules loaded, _USB_ENABLED=y"
 }
 
 # Wait for USB bus enumeration to complete after enable_usb() loads modules.

--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -1693,13 +1693,30 @@ check_tpm_counter() {
 		DEBUG "Invoking tpmr.sh counter_create with label $LABEL"
 		# run it, then record the exit status explicitly; the '!' operator
 		# cannot be used because it would hide the real return code.
-		tpmr.sh counter_create \
-			-pwdc "${tpm_passphrase:-}" \
-			-la "$LABEL" \
-			>/tmp/counter 2> >(tee >(SINK_LOG "tpm counter_create stderr") >&2)
-		local rc=$?
+		# Capture stdout (TPM1 errors print to stdout via tpmtotp printf).
+		# Stderr (TPM2 errors) goes to SINK_LOG for debugging.
+		# Wrapped in subshell to avoid set -e killing the script on non-zero exit.
+		(
+			set +e
+			tpmr.sh counter_create \
+				-pwdc "${tpm_passphrase:-}" \
+				-la "$LABEL" \
+				>/tmp/counter 2> >(tee >(SINK_LOG "tpm counter_create stderr") >&2)
+			echo $? > /tmp/counter_create_rc
+		)
+		local rc=$(cat /tmp/counter_create_rc)
 		if [ $rc -ne 0 ]; then
 			DEBUG "tpmr.sh counter_create failed with status $rc"
+			# "out of resources" (TPM 1.2 error 0x15) is a generic resource
+			# exhaustion error (TPM_RESOURCES: "insufficient internal resources").
+			# The user must reset the TPM to release internal resources.
+			# Only set tpm_reset_required for this case, not for auth failures.
+			if grep -qiE 'out of resources|0x15' /tmp/counter 2>/dev/null; then
+				set_tpm_reset_required \
+					"TPM counter creation failed (exit $rc): $(head -c 200 /tmp/counter 2>/dev/null | tr '\n' ' ')" \
+					"check_tpm_counter"
+				DIE "TPM out of resources (0x15). Reset the TPM through the Heads menu: Options -> TPM/TOTP/HOTP Options -> Reset the TPM"
+			fi
 			# don't tell the user to reset again; the TPM was just reset
 			DIE "Unable to create TPM counter; TPM appears to be in a bad state. Perform OEM Factory Reset / re-ownership and try again."
 		fi
@@ -1854,6 +1871,12 @@ increment_tpm_counter() {
 	increment_ok="n"
 	local reset_required_marker="/tmp/secret/rollback_reset_required"
 
+	# Check if counter is readable; if so, mark it present so the
+	# "readable but not incrementable" branch below can set rollback_reset_required.
+	if tpmr.sh counter_read -ix "$counter_id" >/dev/null 2>&1; then
+		counter_present="y"
+	fi
+
 	# Prefer explicit passphrase, otherwise reuse cached TPM owner passphrase.
 	if [ -z "$tpm_passphrase" ] && [ -s /tmp/secret/tpm_owner_passphrase ]; then
 		tpm_passphrase="$(cat /tmp/secret/tpm_owner_passphrase)"
@@ -1872,16 +1895,6 @@ increment_tpm_counter() {
 		DEBUG "increment_tpm_counter: TPM1 owner passphrase obtained and cached"
 	fi
 
-	# Check if counter exists by reading it first
-	DEBUG "reading TPM counter $counter_id"
-	if ! DO_WITH_DEBUG tpmr.sh counter_read -ix "$counter_id" >/tmp/counter-check 2>/dev/null; then
-		DEBUG "TPM counter $counter_id could not be read before incrementing"
-		# Continue with increment attempt anyway to get detailed error messages
-	else
-		DEBUG "TPM counter $counter_id exists and was read successfully"
-		counter_present="y"
-	fi
-
 	# Try to increment the counter.  We normally hide the verbose
 	# output of tpmr.sh commands to avoid overwhelming the console, but we
 	# must *not* swallow any interactive prompts.  The previous implementation
@@ -1894,37 +1907,32 @@ increment_tpm_counter() {
 	DEBUG "incrementing TPM counter $counter_id"
 
 	if [ "$CONFIG_TPM2_TOOLS" = "y" ]; then
-		# TPM2 counters created with authwrite commonly require index auth (often
-		# empty auth) for nvincrement. Try that first, then owner auth fallback.
-		DEBUG "increment_tpm_counter: TPM2 trying index-auth nvincrement first"
-		if (
-			set -o pipefail
-			DO_WITH_DEBUG --mask-position 5 \
-				tpmr.sh counter_increment -ix "$counter_id" -pwdc "" \
-				2> >(SINK_LOG "tpm counter_increment stderr") |
-				tee /tmp/counter-"$counter_id" >/dev/null
-		); then
-			increment_ok="y"
-		elif [ -n "$tpm_passphrase" ]; then
-			DEBUG "increment_tpm_counter: TPM2 index-auth increment failed; trying owner-auth fallback"
-			if (
-				set -o pipefail
-				DO_WITH_DEBUG --mask-position 5 \
-					tpmr.sh counter_increment -ix "$counter_id" -pwdc "${tpm_passphrase}" \
-					2> >(SINK_LOG "tpm counter_increment stderr") |
-					tee /tmp/counter-"$counter_id" >/dev/null
-			); then
-				increment_ok="y"
-			fi
-		fi
-	else
-		# TPM1 path uses owner auth in practice.
+		# TPM2: counter_increment tries bare nvincrement (index auth) first,
+		# then retries with owner auth using -pwdc value if provided.
+		# One call suffices; the function handles both internally.
+		DEBUG "increment_tpm_counter: TPM2 incrementing counter $counter_id"
 		if (
 			set -o pipefail
 			DO_WITH_DEBUG --mask-position 5 \
 				tpmr.sh counter_increment -ix "$counter_id" -pwdc "${tpm_passphrase:-}" \
-				2> >(SINK_LOG "tpm counter_increment stderr") |
+				2>/dev/null |
 				tee /tmp/counter-"$counter_id" >/dev/null
+		); then
+			increment_ok="y"
+		fi
+	else
+		# TPM1 path uses owner auth in practice.
+		# NOTE: tpmtotp C code prints ALL output (success + errors) to stdout.
+		# We must capture stdout to detect failures properly.
+		# DO_WITH_DEBUG internally captures the command's stderr (tee /dev/stderr
+		# | SINK_LOG "$1 stderr") and stdout (tee >(SINK_LOG "$1 stdout")).
+		# Redirecting DO_WITH_DEBUG's own fd 2 to /dev/null is intentional: the
+		# actual command stderr is already handled inside DO_WITH_DEBUG.
+		if (
+			set -o pipefail
+			DO_WITH_DEBUG --mask-position 5 \
+				tpmr.sh counter_increment -ix "$counter_id" -pwdc "${tpm_passphrase:-}" \
+					2>/dev/null | tee /tmp/counter-"$counter_id" >/dev/null
 		); then
 			increment_ok="y"
 		fi

--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -1101,6 +1101,10 @@ wait_for_usb_devices() {
 # Sets global gpg_output with the last command output.
 wait_for_gpg_card() {
 	TRACE_FUNC
+
+	#make sure usb is enabled before trying to access the card
+	enable_usb
+
 	if [ ! -r /proc/uptime ]; then
 		gpg_output=$(gpg --card-status 2>&1)
 		local rc=$?

--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -765,7 +765,7 @@ cache_gpg_signing_pin() {
 	# Wait for USB enumeration before accessing GPG card to avoid race condition
 	wait_for_usb_devices
 
-	STATUS "Verifying presence of GPG card"
+	STATUS "Verifying presence of USB Security dongle"
 	# ensure we don't exit without retrying
 	errexit=$(set -o | grep errexit | awk '{print $2}')
 	set +e

--- a/initrd/etc/gui_functions.sh
+++ b/initrd/etc/gui_functions.sh
@@ -354,7 +354,7 @@ report_integrity_measurements() {
 	# Check signing key: try card immediately (USB already up); only prompt if not accessible.
 	# wait_for_gpg_card sets global gpg_output to the card-status output on success.
 	STATUS "Verifying signing key on $DONGLE_BRAND"
-	enable_usb
+	# enable_usb is called internally by wait_for_gpg_card
 	gpg_output=""
 	local _card_detected=0
 	if wait_for_gpg_card 2>/dev/null; then

--- a/initrd/etc/gui_functions.sh
+++ b/initrd/etc/gui_functions.sh
@@ -630,7 +630,15 @@ investigate_integrity_discrepancies() {
 			recovery "$msg"
 			;;
 		u)
+			# "Update checksums now" from the integrity investigation
+			# whiptail menu.  If update_checksums set tpm_reset_required
+			# (e.g. check_tpm_counter hit "out of resources"),
+			# return 1 to exit the investigation loop and return to
+			# the main menu instead of looping back here.
 			prompt_update_checksums && return 0
+			if tpm_reset_required; then
+				return 1
+			fi
 			;;
 		*)
 			return 0


### PR DESCRIPTION
This PR fixes regressions introduced by PR #2068, merged to origin/master on 2026-04-07.

## Regressions fixed (present in origin/master post-PR #2068):
- **PCR-5 extension causes DUK unseal failure**: Unconditional `enable_usb` and `detect_usb_security_dongle_branding` in `gui-init.sh` loaded USB modules (ehci-hcd, xhci-hcd, etc.) during early boot, extending PCR-5. `kexec-seal-key.sh` predicts PCR-5 = 0 for DUK seal, causing "Error PCR mismatch from TPM_Unseal" (exit code 24 = 0x18 = TPM_RC_PCR_MISMATCH).
- No "out of resources" (0x15) TPM counter error detection
- TPM2 counter increment had no auth retry on wrong passphrase
- TPM1 counter increment had no error handling
- tpm1_seal silenced NV define/write errors
- Duplicate TPM1/TPM2 retry loops (~100 lines of redundant code)
- counter_present dead code (now fixed with counter_read check)
- Comment mismatch (stdout vs console) now fixed
- set -e issue in check_tpm_counter (wrapped in subshell)

## Fixes implemented:
### PCR-5 / DUK unseal fix (commits 3-4):
- **Gate USB initialization**: Move `enable_usb` and `detect_usb_security_dongle_branding` inside `if [ -x /bin/hotp_verification ]` in `gui-init.sh` so non-HOTP boards don't load USB modules during early boot
  - Non-HOTP boards: PCR-5 stays at 0, DUK unseal works correctly
  - HOTP boards: USB still initialized early (required for dongle interaction), but only once (gated by `_USB_ENABLED` flag)
- **Export `_USB_ENABLED`**: Child processes (seal-hotpkey.sh, kexec-seal-key.sh, etc.) now inherit the flag and don't reload USB modules
- **Add DEBUG logging** to `enable_usb()` per `doc/logging.md` conventions
- Add `enable_usb` to `wait_for_gpg_card()` to ensure USB is ready before GPG card access

### TPM auth retry / counter error handling (commits 1-2):
- Add shared `_tpm_auth_retry` helper for TPM1/TPM2
- `check_tpm_counter` only triggers `tpm_reset_required` on 0x15 errors
- `tpm1_seal` surfaces NV errors with retry loop
- Simplify `reset_tpm` to verify `tpmr.sh reset` exit code
- Fix `tpmr.sh counter_create` to detect "out of resources" (0x15) and surface proper error

### Docs: unify script name references (commit 2):
- Update all `initrd/bin/*` and `initrd/etc/*` references in `doc/*` to use `.sh` extension

---

### Testing: (reseal TOTP+HOTP+DUK, TPM Reset + DUK sealing, OEM Factory Reset/Re-Ownership)
- [x] QEMU TPM1 with HOTP: firmware "upgrade" (reseal TOTP+HOTP+DUK) + reownership
- [x] QEMU TPM1 without HOTP: firmware "upgrade" (reseal TOTP+DUK)
- [x] QEMU TPM2 with HOTP: firmware "upgrade" (reseal TOTP+HOTP+DUK)
- [x] QEMU TPM2 without HOTP: firmware "upgrade" (reseal TOTP+DUK) + reownerhip
- [x] v540tu (tpm2 real hw)
- [x] x230 (tpm1 real hw) : hotp/non-hotp