### PR TITLE
fix USB keyboard initialization

### DIFF
--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -1151,12 +1151,12 @@ enable_usb_keyboard() {
 	# For resiliency, test CONFIG_USB_KEYBOARD_REQUIRED explicitly rather
 	# than having it imply CONFIG_USER_USB_KEYBOARD at build time.
 	# Otherwise, if a user got CONFIG_USER_USB_KEYBOARD=n in their
-	# config.user by mistake (say, by copying config.user from a laptop to a
-	# desktop/server), they could lock themselves out, only recoverable by
-	# hardware flash.
+	# config.user by mistake, they could lock themselves out.
 	if [ "$CONFIG_USB_KEYBOARD_REQUIRED" = y ] || [ "$CONFIG_USER_USB_KEYBOARD" = y ]; then
-		insmod.sh /lib/modules/usbhid.ko || DIE "usbhid: module load failed"
-	fi
+	enable_usb
+	wait_for_usb_devices
+	insmod.sh /lib/modules/usbhid.ko || DIE "usbhid: module load failed"
+fi
 }
 
 # ------- End of functions coming from /etc/ash_functions

--- a/initrd/init
+++ b/initrd/init
@@ -188,7 +188,7 @@ fi
 
 # load USB modules for boards using a USB keyboard
 if [ "$CONFIG_USB_KEYBOARD_REQUIRED" = y ] || [ "$CONFIG_USER_USB_KEYBOARD" = "y" ]; then
-	enable_usb
+	enable_usb_keyboard
 fi
 
 # Set the keyboard keymap if defined, file exists, and loadkeys is available


### PR DESCRIPTION
## Summary

This commit solves the issue with the usb keyboard initialization for some boards that needed it. Initially discovered during my wip  m900 port. Please see https://github.com/linuxboot/heads/issues/2101

## Initial Problem

Systems with `CONFIG_USB_KEYBOARD_REQUIRED=y` or `CONFIG_USER_USB_KEYBOARD=y` need USB keyboard support during initrd/early boot.

Previously, the `initrd/init` boot script only called:

```sh
enable_usb
```

This enabled USB support, but it did not load the `usbhid.ko` module required for USB keyboard input.

As a result, systems that depend on a USB keyboard during early boot could be left without keyboard input. This could prevent users from interacting with the system during initrd, including cases where keyboard input is needed to unlock or recover the system.

## Solution Description
The solution changes the USB keyboard initialization path so that `initrd/init` calls:

```sh
enable_usb_keyboard
```
instead of calling `enable_usb` directly.

The `enable_usb_keyboard` function in `initrd/etc/functions.sh` now performs the complete USB keyboard setup sequence:

```sh
enable_usb
wait_for_usb_devices
insmod.sh /lib/modules/usbhid.ko || DIE "usbhid: module load failed"
```

This ensures that when USB keyboard support is required or enabled, the system will:

1. Enable USB support.
2. Wait for USB devices to become available.
3. Load the `usbhid.ko` USB HID keyboard module.

## Changes

- Updated `initrd/init` to call `enable_usb_keyboard` for USB keyboard setup.
- Updated `enable_usb_keyboard` in `initrd/etc/functions.sh` to:
  - Call `enable_usb`
  - Call `wait_for_usb_devices`
  - Load `/lib/modules/usbhid.ko`

## Expected Result
USB keyboards are now properly initialized during early boot when `CONFIG_USB_KEYBOARD_REQUIRED=y` or `CONFIG_USER_USB_KEYBOARD=y`.

## Testing
- Verified that USB keyboard initialization now follows the full setup path.
- Confirmed that `usbhid.ko` is loaded through `enable_usb_keyboard` when USB keyboard support is enabled. 
