### PR TITLE
bin/validate_cbfs_ifd_fit.sh: use /usr/bin/env bash for portable shebang

### DIFF
--- a/bin/validate_cbfs_ifd_fit.sh
+++ b/bin/validate_cbfs_ifd_fit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Validate that CBFS size fits within IFD BIOS region
 # and report space usage statistics


### PR DESCRIPTION
- Replace hard-coded /bin/bash with /usr/bin/env bash for better portability across systems