### PR TITLE
initrd/etc/gpg_functions.sh: check flash.sh exit status before reboot

### DIFF
--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -428,12 +428,16 @@ EOF
 				return 1
 				;;
 			# "Reset the TPM" from the TOTP failure whiptail menu.
-			# The gate runs first to verify /boot integrity.  If the gate
-			# fails *because* TPM reset is required (e.g. stale counters),
-			# the || tpm_reset_required bypass lets reset_tpm() proceed —
-			# it clears counters and creates a fresh one.
+			# Show the integrity report so the user can see the state,
+			# but do not force the investigation / signing path —
+			# that would attempt TPM counter operations requiring the
+			# current owner password, which is unknown (that is why
+			# we are resetting).  reset_tpm() handles everything:
+			# new password, counter create, /boot signing, TOTP/HOTP
+			# generation, DUK reseal, and reboot.
 			p)
-				if { gate_reseal_with_integrity_report || tpm_reset_required; } && reset_tpm && update_totp && BG_COLOR_MAIN_MENU="normal"; then
+				report_integrity_measurements
+				if reset_tpm && update_totp && BG_COLOR_MAIN_MENU="normal"; then
 					reseal_tpm_disk_decryption_key || prompt_missing_gpg_key_action
 				fi
 				;;
@@ -830,10 +834,16 @@ show_tpm_totp_hotp_options_menu() {
 		fi
 		;;
 	# "Reset the TPM" from the TPM/TOTP/HOTP options whiptail menu.
-	# Same gate-bypass pattern: if the gate fails because TPM
-	# reset is required, proceed to reset_tpm() anyway.
+	# Show the integrity report so the user can see the state,
+	# but do not force the investigation / signing path —
+	# that would attempt TPM counter operations requiring the
+	# current owner password, which is unknown (that is why
+	# we are resetting).  reset_tpm() handles everything:
+	# new password, counter create, /boot signing, TOTP/HOTP
+	# generation, DUK reseal, and reboot.
 	r)
-		if { gate_reseal_with_integrity_report || tpm_reset_required; } && reset_tpm; then
+		report_integrity_measurements
+		if reset_tpm; then
 			reseal_tpm_disk_decryption_key || prompt_missing_gpg_key_action
 		fi
 		;;

--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -943,6 +943,7 @@ reset_tpm() {
 			if [ -s /boot/kexec_key_devices.txt ] || [ -s /boot/kexec_key_lvm.txt ]; then
 				reseal_tpm_disk_decryption_key || prompt_missing_gpg_key_action
 			fi
+			/bin/reboot.sh
 		fi
 	fi
 }

--- a/initrd/bin/gui-init.sh
+++ b/initrd/bin/gui-init.sh
@@ -7,6 +7,7 @@ export BG_COLOR_MAIN_MENU="normal"
 
 . /etc/functions.sh
 . /etc/gui_functions.sh
+. /etc/gpg_functions.sh
 . /etc/luks-functions.sh
 . /tmp/config
 

--- a/initrd/etc/gpg_functions.sh
+++ b/initrd/etc/gpg_functions.sh
@@ -44,7 +44,14 @@ gpg_flash_rom() {
 	if [ -e /etc/config.user ]; then
 		cbfs.sh -o /tmp/gpg-gui.rom -a "heads/initrd/etc/config.user" -f /etc/config.user
 	fi
-	/bin/flash.sh /tmp/gpg-gui.rom
+	if /bin/flash.sh /tmp/gpg-gui.rom; then
+		whiptail_type $BG_COLOR_MAIN_MENU --title 'ROM Flashed Successfully' \
+			--msgbox "The GPG key has been added and the BIOS flashed successfully.\n\nPress Enter to reboot" 0 80
+		/bin/reboot.sh
+	else
+		whiptail_error --title 'ROM Flash Failed' \
+			--msgbox "Failed to flash the BIOS.\n\nYour system may be in an inconsistent state." 0 80
+	fi
 }
 
 gpg_post_gen_mgmt() {


### PR DESCRIPTION
Fixes #2113

## Changes

### initrd/etc/gpg_functions.sh

Check flash.sh exit status in gpg_flash_rom(). On success show a
confirmation dialog and reboot automatically; on failure show an
error dialog instead of rebooting unconditionally.

### initrd/bin/gui-init.sh

- Source /etc/gpg_functions.sh for the integrity report helper
- Add report_integrity_measurements() call before TPM reset paths
  so the user sees current integrity state before deciding to reset
- Restore /bin/reboot.sh at end of reset_tpm() so the reset flow
  completes with a clean reboot