### PR TITLE
initrd/bin/seal-hotpkey.sh: always query fresh PIN retry counter from hotp_verification info

### DIFF
--- a/doc/hotp.md
+++ b/doc/hotp.md
@@ -1,0 +1,78 @@
+# HOTP & USB Security Dongle
+
+This document covers how `seal-hotpkey.sh` interacts with `hotp_verification`
+and the NK3-specific behavior Heads scripts need to handle.
+
+See also: [security-model.md](security-model.md), [ux-patterns.md](ux-patterns.md),
+[tpm.md](tpm.md).  Return code definitions live in
+`build/x86/hotp-verification-*/src/return_codes.h`.
+
+---
+
+## NK3 `info` command output and exit codes
+
+`hotp_verification info` communicates over CCID (NK3) or HID (Pro/Storage/Librem
+Key).  stdout lines are tab-indented (`\t`).  The presence check in
+`seal-hotpkey.sh` looks for `Connected device status:` in the output, regardless
+of exit code.
+
+| Scenario | Exit code | `Connected device status:` | Counter line |
+|---|---|---|---|
+| Slot configured | 0 | yes | `Secrets app PIN counter: N` |
+| Slot unconfigured, OATH alive | 0 | yes | `PIN is not set - set PIN...` |
+| OATH SELECT fails (Path B) | 3 | no (returns early) | not printed |
+| No dongle connected | 1 | no | not printed |
+
+**Path A** (unconfigured slot, applet present): `status_ccid()` returns
+`RET_NO_PIN_ATTEMPTS` (31), `parse_cmd_and_run()` converts to exit 0.
+The counter line reads `"PIN is not set - set PIN before the first use"`.
+
+**Path B** (OATH SELECT fails): `send_select_ccid()` returns non-0x9000,
+`status_ccid()` returns `RET_COMM_ERROR` (29), `check_ret()` returns early.
+No `Connected device status:` is printed; exit code 3.
+
+## NK3 PIN counter mapping
+
+| PIN type | Source | Counter path | Factory default |
+|---|---|---|---|
+| Secrets App PIN | OATH applet (`Tag_PINCounter` TLV) | `Secrets app PIN counter:` | 8 |
+| GPG Admin PIN | PGP applet (ISO 7816 `0xCA`) | `GPG Card counters: Admin` | 3 |
+| GPG User PIN | PGP applet (same `0xCA`) | `GPG Card counters: User` | 3 |
+
+`seal-hotpkey.sh` uses the Secrets App PIN (called `admin_pin_retries` for
+historical reasons).
+
+## seal-hotpkey.sh retry logic
+
+All counter queries go through `query_pin_retries()` which retries
+`hotp_verification info` until a valid numeric counter is obtained.
+If the dongle is present but no numeric counter is found (unconfigured
+slot), `query_pin_retries` dies immediately.
+
+| Call site | Max retries | Purpose |
+|---|---|---|
+| Initial presence check | 1 (+ INPUT retry) | Get first counter, prompt reinsert on failure |
+| `show_pin_retries()` | 3 per PIN attempt | Display fresh count before each try |
+| `max_attempts` re-read | 1 | Seed attempt ceiling with current value |
+
+```
+NK3 (factory):      8 attempts  -> default-PIN skip at < 3, max_attempts = min(retries-1, 3)
+NK3 (decremented):  7 attempts  -> max_attempts = 3 (capped)
+NK3 (decremented):  2 attempts  -> max_attempts = 1 (min(2-1, 3))
+Pre-NK3 (factory):  3 attempts  -> max_attempts = min(3-1, 3) = 2
+Pre-NK3 (decrem.):  2 attempts  -> max_attempts = min(2-1, 3) = 1
+```
+
+## Pre-NK3 vs NK3 PIN behavior
+
+- **Pre-NK3** (Pro, Storage, Librem Key): Admin PIN counter starts at 3
+  (hardware-enforced), maps directly to OATH credential creation PIN.
+- **NK3**: Secrets App PIN counter starts at 8 (configurable), protects
+  OATH credential operations.
+
+## Firmware version display
+
+`hotpkey_fw_display` in `initrd/etc/functions.sh` parses `hotp_verification info`
+output to show the dongle firmware version with color coding.  Minimum-version
+thresholds are in `initrd/etc/dongle-versions`.
+See [ux-patterns.md](ux-patterns.md#color-coded-version-checks).

--- a/initrd/bin/seal-hotpkey.sh
+++ b/initrd/bin/seal-hotpkey.sh
@@ -65,15 +65,41 @@ TRACE_FUNC
 # Make sure no conflicting GPG related services are running, gpg-agent will respawn
 DO_WITH_DEBUG killall gpg-agent scdaemon >/dev/null 2>&1 || true
 
-# While making sure the key is inserted, capture the status so we can check how
-# many PIN attempts remain
+# Query hotp_verification info and extract numeric PIN retry counter.
+# Retries up to N times on communication failure.  Dies if the dongle
+# is present but no numeric counter can be extracted.
+query_pin_retries() {
+	local var_name="$1" dongle="$2" max="${3:-3}"
+	local attempt=0 info counter
+	while [ $attempt -lt "$max" ]; do
+		attempt=$((attempt + 1))
+		info="$(hotp_verification info 2>/dev/null)" || true
+		echo "$info" | grep -q "Connected device status:" || continue
+		HOTP_TOKEN_INFO="$info"
+		if [ "$dongle" = "Nitrokey 3" ]; then
+			counter=$(echo "$info" | grep "Secrets app PIN counter:" | grep -o '[0-9][0-9]*')
+		else
+			counter=$(echo "$info" | grep "Card counters: Admin" | grep -o 'Admin [0-9]*' | grep -o '[0-9]*')
+		fi
+		if [ -n "$counter" ]; then
+			eval "$var_name=\$counter"
+			return 0
+		fi
+		# Dongle is present but counter is missing — slot not configured.
+		DIE "$DONGLE_BRAND HOTP slot is not configured"
+	done
+	eval "$var_name="
+	return 1
+}
+
+# Initial query — if the dongle is not responding, prompt for reinsertion
+# and retry once.
 STATUS "Checking $DONGLE_BRAND presence for HOTP setup"
-if ! hotp_token_info="$(hotp_verification info)"; then
+if ! query_pin_retries admin_pin_retries "$DONGLE_BRAND" 1; then
 	INPUT "Insert your $DONGLE_BRAND and press Enter to configure it"
-	if ! hotp_token_info="$(hotp_verification info)"; then
-		# don't leak key on failure
+	if ! query_pin_retries admin_pin_retries "$DONGLE_BRAND" 1; then
 		shred -n 10 -z -u "$HOTP_SECRET" 2>/dev/null
-		DIE "Unable to find $DONGLE_BRAND"
+		DIE "Unable to communicate with $DONGLE_BRAND"
 	fi
 fi
 STATUS_OK "$DONGLE_BRAND is present for HOTP setup"
@@ -99,31 +125,18 @@ now_date="$(date '+%s')"
 # NK3 uses "Secrets app PIN counter" (factory default: 8 attempts);
 # all pre-NK3 devices use "Card counters: Admin" (factory default: 3 attempts).
 if [ "$DONGLE_BRAND" = "Nitrokey 3" ]; then
-	admin_pin_retries=$(echo "$hotp_token_info" | grep "Secrets app PIN counter:" | cut -d ':' -f 2 | tr -d ' ')
 	prompt_message="Secrets app"
 else
-	admin_pin_retries=$(echo "$hotp_token_info" | grep "Card counters: Admin" | grep -o 'Admin [0-9]*' | grep -o '[0-9]*')
 	prompt_message="GPG Admin"
 fi
-
-admin_pin_retries="${admin_pin_retries:-0}"
 DEBUG "HOTP related PIN retry counter is $admin_pin_retries"
 # Show dongle firmware version with color coding so users know when to upgrade
-hotpkey_fw_display "$hotp_token_info" "$DONGLE_BRAND"
+hotpkey_fw_display "$HOTP_TOKEN_INFO" "$DONGLE_BRAND"
 
 # Re-query and display the current PIN retry counter before each manual prompt.
-# Updates the global $admin_pin_retries (no local keyword) so callers can use
-# the fresh value for decisions (e.g. max_attempts calculation below).
 # prompt_message is already set for the device type (NK3 vs older), reuse it.
 show_pin_retries() {
-	local info
-	info="$(hotp_verification info 2>/dev/null)" || true
-	if [ "$DONGLE_BRAND" = "Nitrokey 3" ]; then
-		admin_pin_retries=$(echo "$info" | grep "Secrets app PIN counter:" | cut -d ':' -f 2 | tr -d ' ')
-	else
-		admin_pin_retries=$(echo "$info" | grep "Card counters: Admin" | grep -o 'Admin [0-9]*' | grep -o '[0-9]*')
-	fi
-	admin_pin_retries="${admin_pin_retries:-0}"
+	query_pin_retries admin_pin_retries "$DONGLE_BRAND" 3
 	STATUS "$DONGLE_BRAND ${prompt_message} PIN retries remaining: $(pin_color "$admin_pin_retries")${admin_pin_retries}\033[0m"
 }
 
@@ -182,15 +195,9 @@ if [ "$admin_pin_status" -ne 0 ]; then
 	#   Default PIN skipped (key >1 month old)        -> max_attempts = min(3-1, 3) = 2
 	#   Default PIN tried & failed (3 -> 2 remaining) -> max_attempts = min(2-1, 3) = 1
 	#   Counter read failed (0 or empty)              -> max_attempts = 3 (fallback, don't block)
-	# Re-read counter without displaying (loop will show it)
-	info="$(hotp_verification info 2>/dev/null)" || true
-	if [ "$DONGLE_BRAND" = "Nitrokey 3" ]; then
-		admin_pin_retries=$(echo "$info" | grep "Secrets app PIN counter:" | cut -d ':' -f 2 | tr -d ' ')
-	else
-		admin_pin_retries=$(echo "$info" | grep "Card counters: Admin" | grep -o 'Admin [0-9]*' | grep -o '[0-9]*')
-	fi
-	admin_pin_retries="${admin_pin_retries:-0}"
-	if [ "$admin_pin_retries" -ge 2 ]; then
+	# Re-read counter without displaying (loop will show it).
+	query_pin_retries admin_pin_retries "$DONGLE_BRAND" 1
+	if [ -n "$admin_pin_retries" ] && [ "$admin_pin_retries" -ge 2 ]; then
 		max_attempts=$((admin_pin_retries - 1))
 		[ "$max_attempts" -gt 3 ] && max_attempts=3
 	else


### PR DESCRIPTION
Fixes #2115

All counter queries centralized in `query_pin_retries()` which retries
`hotp_verification info` up to N times.  Extracts only digits via
`grep -o [0-9][0-9]*` — no non-numeric text leaks, no fabricated values.
DIE's if the dongle is present but no numeric counter is found (unconfigured
slot).  No caching, no ${var:-0} assignment — `admin_pin_retries` always
holds a fresh real value.