### PR TITLE
circleci,modules/coreboot,doc: share crossgcc toolchain across Dasharo 24.12 forks; blobs: add lib.sh and unify hash pre-checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,12 @@ commands:
           command: |
             echo "Sourcing /devenv.sh since docker entrypoint doesn't do it as expected"
             source /devenv.sh
+            # Remove stale logs, .rom, and .zip from previous cache/workspace so
+            # store_artifacts only picks up files from this run (git-describe differs
+            # per commit, so old artifacts persist alongside new ones otherwise).
             rm -rf build/<< parameters.arch >>/log/*
+            rm -f build/<< parameters.arch >>/<< parameters.target >>/*.rom \
+                  build/<< parameters.arch >>/<< parameters.target >>/*.zip
             # Fresh checkout timestamps can make restored module stamp files look stale.
             # Refresh them first so restored musl-cross-make and dependency trees are reused.
             if [ -d "build/<< parameters.arch >>" ]; then
@@ -61,28 +66,24 @@ commands:
 jobs:
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Glossary
+  # Glossary (see doc/circleci.md for full cache model)
   # ═══════════════════════════════════════════════════════════════════════════
-  # fan-in: When multiple upstream jobs try to persist the same paths to the
-  #         same workspace. CircleCI throws an error if this happens.
-  #         Solution: Each job saves its own cache immediately, before persisting.
+  # fan-in: Error when a job depends on multiple upstreams that persisted
+  #         overlapping workspace paths.  Avoided here because each build
+  #         job depends on exactly one seed, so no downstream merges
+  #         workspaces from multiple seeds.
   #
-  # workspace chain: Linear dependency chain where only one job persists at a time.
-  #                  No fan-in possible since each job in the chain is unique.
+  # workspace chain: Linear dependency chain, one persist at a time.
   #
-  # cache layer: CircleCI caches are hierarchical for each architecture:
-  #              Cache key naming: {arch}-{layer}-nix-docker-heads-{hash}[-{fork}]
-  #              - {arch}-blobs-nix-docker-heads-{hash}                 (x86 only, ppc64 has no blobs)
-  #              - {arch}-musl-cross-make-nix-docker-heads-{hash}
-  #                └── Base toolchain (GCC + musl = musl-cross-make)
-  #              - {arch}-coreboot-musl-cross-make-nix-docker-heads-{hash}-{coreboot_dir}
-  #                └── Includes musl + coreboot toolstack
-  #              - {arch}-modules-coreboot-musl-cross-make-nix-docker-heads-{hash}-{coreboot_dir}
-  #                └── Includes coreboot + musl + all modules
-  #              Caches are reused across pipelines for the same repository.
-  #              They do NOT speed up sibling jobs in the same workflow run.
-  #              Each x86_coreboot job saves both coreboot and modules caches.
+  # cache layers (3): Modules(per-seed) -> Coreboot fork(per-seed) -> Musl(per-arch)
+  #   Seeds save caches (musl by musl-cross-make, modules+coreboot by x86_coreboot).
+  #   build jobs never save or restore cache.
+  #   Hashes are global (from create_hashes).  {coreboot_dir} suffix differentiates.
   #
+  # Dasharo: 4 forks share identical crossgcc (verified by diff).
+  #   Only novacustom-nv4x_adl [seed:coreboot-24.12] is a seed.
+  #   All other Dasharo boards are build jobs chaining behind via workspace.
+  #   See modules/coreboot and doc/circleci.md for details.
   # CACHE_VERSION: Environment variable used to invalidate all caches at once.
   #                Set as CircleCI project variable in project settings.
   #                Suggested format: YYYYMMDD (e.g., 20260420) for easy manual invalidation.
@@ -253,25 +254,12 @@ jobs:
             - install/x86
             - packages/x86
 
-  # x86_coreboot: builds a coreboot fork for x86 architecture.
-  # - Checks out code for build scripts
-  # - Attaches workspace from x86_musl_cross_make (has blobs + musl)
-  # - Restores cache with fallbacks:
-  #   (modules+coreboot+musl -> coreboot+musl -> musl)
-  #   Largest valid cache is first to maximize reuse when multiple keys exist.
-  #   Restored build stamps are refreshed before make so source checkout mtimes
-  #   do not force a redundant musl-cross-make rebuild.
-  #   Do not restore a generic coreboot cache across forks: that can inject
-  #   another fork's coreboot build tree (for example z790 into z690).
-  # - Builds coreboot firmware for this fork
-  # - Persists packages/x86, build/x86, crossgcc/x86, install/x86 to workspace
-  # - Saves fork-specific coreboot+toolchain cache, including install/x86 so
-  #   the restored cache still contains the musl sysroot used by modules
-  # - Optionally saves full modules cache (only on one fork)
-  #   This is kept as an escape hatch, but enabling it on the seed job would
-  #   extend that job's runtime and delay all downstream jobs that require it.
-  # Each distinct coreboot fork uses this: dasharo_nv4x, dasharo_v56, purism, 25.09, 4.11, dasharo_msi_*, etc.
+  # x86_coreboot: builds a coreboot fork and saves cache.
+  #   See doc/circleci.md for full documentation.
   # Workspace chain: create_hashes -> x86_blobs -> x86_musl_cross_make -> x86_coreboot
+  # Seeds (one per unique toolchain): coreboot-4.11, coreboot-25.09,
+  #   coreboot-dasharo_nv4x, coreboot-purism
+  # Dasharo v56/msi_z690/msi_z790 are build jobs, not x86_coreboot.
   x86_coreboot:
     executor: heads-docker
     parameters:
@@ -423,41 +411,43 @@ workflows:
   build_and_test:
     max_auto_reruns: 3
     jobs:
-      - create_hashes
+      - create_hashes:
+          name: create_hashes [cache keys]
 
       # ── x86 blobs ───────────────────────────────────────────────────────
       # Chain: create_hashes -> x86_blobs -> x86_musl_cross_make -> x86_coreboot
       - x86_blobs:
+          name: x86_blobs [ME GBE IFD]
           requires:
-            - create_hashes
+            - create_hashes [cache keys]
 
       # ── ppc64 talos-2 ──────────────────────────────────────────────────
-      # Chain: create_hashes -> ppc64_musl_cross_make -> ppc64_coreboot -> firmware
+      # Chain: create_hashes -> ppc64_musl_cross_make -> ppc64_coreboot
       - ppc64_musl_cross_make:
-          name: ppc64-musl-cross-make
+          name: ppc64-musl-cross-make [cross compiler]
           target: UNTESTED_talos-2
           subcommand: "musl-cross-make"
           requires:
-            - create_hashes
+            - create_hashes [cache keys]
 
       - ppc64_coreboot:
-          name: ppc64_talos_2
+          name: ppc64_talos_2 [seed:coreboot-talos-2]
           target: UNTESTED_talos-2
           subcommand: ""
           coreboot_dir: coreboot-talos_2
           requires:
-            - ppc64-musl-cross-make
+            - ppc64-musl-cross-make [cross compiler]
 
       # ── x86 musl-cross-make seed ──────────────────────────────────────────
       # Chain: x86_blobs -> x86_musl_cross_make -> x86_coreboot seeds
       - x86_musl_cross_make:
-          name: x86-musl-cross-make
+          name: x86-musl-cross-make [cross compiler]
           target: EOL_t480-hotp-maximized
           subcommand: "musl-cross-make"
           requires:
-            - x86_blobs
+            - x86_blobs [ME GBE IFD]
 
-      # ── x86 coreboot fork seeds (alphabetical by board target) ──────────────
+      # ── x86 coreboot fork seeds (alphabetical within each group) ────────────
       # Chain: x86_musl_cross_make -> x86_coreboot (linear per fork)
       # Each seed builds its coreboot fork and saves fork-specific cache.
       # No fan-in -> no workspace collision.
@@ -465,73 +455,73 @@ workflows:
       # 4.11 fork
       # Downstream boards: (none — standalone)
       - x86_coreboot:
-          name: EOL_librem_l1um
+          name: EOL_librem_l1um [seed:coreboot-4.11]
           target: EOL_librem_l1um
           subcommand: ""
           coreboot_dir: coreboot-4.11
           requires:
-            - x86-musl-cross-make
+            - x86-musl-cross-make [cross compiler]
 
       # 25.09 fork — builds coreboot-25.09 toolchain
       # Downstream boards: (all 28 board builds below)
       - x86_coreboot:
-          name: EOL_t480-hotp-maximized
+          name: EOL_t480-hotp-maximized [seed:coreboot-25.09]
           target: EOL_t480-hotp-maximized
           subcommand: ""
           coreboot_dir: coreboot-25.09
           requires:
-            - x86-musl-cross-make
+            - x86-musl-cross-make [cross compiler]
 
-      # dasharo_msi_z690 fork
-      # Downstream boards: UNTESTED_msi_z690a_ddr5
+      # ── Dasharo shared toolchain ──────────────────────────────────────────
+      # 4 forks share crossgcc (verified by sum-file diff).
+      # novacustom-nv4x_adl is the only seed; all other Dasharo boards are
+      # build jobs depending on it (see doc/circleci.md for cache model).
+      # If adding a Dasharo board, check modules/coreboot first: if its
+      # crossgcc sum files match dasharo_nv4x, add a build job here.
+      #
+      # dasharo_nv4x (seed for v56, z690, z790)
       - x86_coreboot:
-          name: UNTESTED_msi_z690a_ddr4
-          target: UNTESTED_msi_z690a_ddr4
-          subcommand: ""
-          coreboot_dir: coreboot-dasharo_msi_z690
-          requires:
-            - x86-musl-cross-make
-
-      # dasharo_msi_z790 fork
-      # Downstream boards: msi_z790p_ddr5
-      - x86_coreboot:
-          name: UNTESTED_msi_z790p_ddr4
-          target: UNTESTED_msi_z790p_ddr4
-          subcommand: ""
-          coreboot_dir: coreboot-dasharo_msi_z790
-          requires:
-            - x86-musl-cross-make
-
-      # dasharo_nv4x fork
-      # Downstream boards: UNTESTED_nitropad-ns50
-      - x86_coreboot:
-          name: novacustom-nv4x_adl
+          name: novacustom-nv4x_adl [seed:coreboot-24.12]
           target: novacustom-nv4x_adl
           subcommand: ""
           coreboot_dir: coreboot-dasharo_nv4x
           requires:
-            - x86-musl-cross-make
+            - x86-musl-cross-make [cross compiler]
 
-      # dasharo_v56 fork
-      # Downstream boards: novacustom-v540tu
-      - x86_coreboot:
+      # v56 (seeded by dasharo_nv4x)
+      - build:
           name: novacustom-v560tu
           target: novacustom-v560tu
           subcommand: ""
-          coreboot_dir: coreboot-dasharo_v56
           requires:
-            - x86-musl-cross-make
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
 
-      # purism fork — builds coreboot-purism toolchain
+      # msi_z690 (seeded by dasharo_nv4x)
+      - build:
+          name: UNTESTED_msi_z690a_ddr4
+          target: UNTESTED_msi_z690a_ddr4
+          subcommand: ""
+          requires:
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
+
+      # msi_z790 (seeded by dasharo_nv4x)
+      - build:
+          name: UNTESTED_msi_z790p_ddr4
+          target: UNTESTED_msi_z790p_ddr4
+          subcommand: ""
+          requires:
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
+
+      # purism fork -- builds coreboot-purism toolchain
       # Downstream boards: EOL_librem_13v2, EOL_librem_13v4, EOL_librem_15v3, EOL_librem_15v4,
       #   librem_11, librem_l1um_v2, librem_mini, librem_mini_v2
       - x86_coreboot:
-          name: librem_14
+          name: librem_14 [seed:coreboot-24.02.01]
           target: librem_14
           subcommand: ""
           coreboot_dir: coreboot-purism
           requires:
-            - x86-musl-cross-make
+            - x86-musl-cross-make [cross compiler]
 
       # ── coreboot 25.09 boards (alphabetical) ───────────────────────────────
       - build:
@@ -539,196 +529,196 @@ workflows:
           target: EOL_optiplex-7010_9010-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_optiplex-7010_9010-maximized
           target: EOL_optiplex-7010_9010-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_optiplex-7010_9010_TXT-hotp-maximized
           target: EOL_optiplex-7010_9010_TXT-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_optiplex-7010_9010_TXT-maximized
           target: EOL_optiplex-7010_9010_TXT-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t420-hotp-maximized
           target: EOL_t420-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t420-maximized
           target: EOL_t420-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t430-hotp-maximized
           target: EOL_t430-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t430-maximized
           target: EOL_t430-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t440p-hotp-maximized
           target: EOL_t440p-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t440p-maximized
           target: EOL_t440p-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t480-maximized
           target: EOL_t480-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t480s-hotp-maximized
           target: EOL_t480s-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_t480s-maximized
           target: EOL_t480s-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_UNTESTED_t530-hotp-maximized
           target: EOL_UNTESTED_t530-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_UNTESTED_t530-maximized
           target: EOL_UNTESTED_t530-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_w530-hotp-maximized
           target: EOL_w530-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_w530-maximized
           target: EOL_w530-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_w541-hotp-maximized
           target: EOL_w541-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_w541-maximized
           target: EOL_w541-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x220-hotp-maximized
           target: EOL_x220-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x220-maximized
           target: EOL_x220-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x230-hotp-maximized
           target: EOL_x230-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x230-hotp-maximized-fhd_edp
           target: EOL_x230-hotp-maximized-fhd_edp
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x230-maximized
           target: EOL_x230-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_x230-maximized-fhd_edp
           target: EOL_x230-maximized-fhd_edp
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_z220-cmt-hotp-maximized
           target: EOL_z220-cmt-hotp-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: EOL_z220-cmt-maximized
           target: EOL_z220-cmt-maximized
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       - build:
           name: qemu-coreboot-fbwhiptail-tpm2-hotp
           target: qemu-coreboot-fbwhiptail-tpm2-hotp
           subcommand: ""
           requires:
-            - EOL_t480-hotp-maximized
+            - EOL_t480-hotp-maximized [seed:coreboot-25.09]
 
       # ── purism boards (alphabetical) ──────────────────────────────────────
       - build:
@@ -736,85 +726,85 @@ workflows:
           target: EOL_librem_13v2
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: EOL_librem_13v4
           target: EOL_librem_13v4
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: EOL_librem_15v3
           target: EOL_librem_15v3
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: EOL_librem_15v4
           target: EOL_librem_15v4
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: librem_11
           target: librem_11
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: librem_l1um_v2
           target: librem_l1um_v2
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: librem_mini
           target: librem_mini
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
       - build:
           name: librem_mini_v2
           target: librem_mini_v2
           subcommand: ""
           requires:
-            - librem_14
+            - librem_14 [seed:coreboot-24.02.01]
 
-      # ── Dasharo nv4x ─────────────────────────────────────────────────────
+      # ── Dasharo nv4x (downstream boards seeded via nv4x_adl workspace) ─────
       - build:
           name: UNTESTED_nitropad-ns50
           target: UNTESTED_nitropad-ns50
           subcommand: ""
           requires:
-            - novacustom-nv4x_adl
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
 
-      # ── NovaCustom v56 ──────────────────────────────────────────────────
+      # ── NovaCustom v56 (seeded by nv4x_adl) ────────────────────────────────
       - build:
           name: novacustom-v540tu
           target: novacustom-v540tu
           subcommand: ""
           requires:
-            - novacustom-v560tu
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
 
-      # ── Dasharo msi_z690 ────────────────────────────────────────────────
+      # ── Dasharo msi_z690 (seeded by nv4x_adl) ──────────────────────────────
       - build:
           name: UNTESTED_msi_z690a_ddr5
           target: UNTESTED_msi_z690a_ddr5
           subcommand: ""
           requires:
-            - UNTESTED_msi_z690a_ddr4
+            - novacustom-nv4x_adl [seed:coreboot-24.12]
 
-      # ── Dasharo msi_z790 ────────────────────────────────────────────────
+      # ── Dasharo msi_z790 (seeded by nv4x_adl) ──────────────────────────────
       - build:
           name: msi_z790p_ddr5
           target: msi_z790p_ddr5
           subcommand: ""
           requires:
-            - UNTESTED_msi_z790p_ddr4
+            - novacustom-nv4x_adl [seed:coreboot-24.12]

--- a/blobs/lib.sh
+++ b/blobs/lib.sh
@@ -1,0 +1,43 @@
+# Common functions for blob download/processing scripts.
+# Source this file from individual blob scripts.
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+
+# Verify sha256sum for a file.  Exit with error on mismatch.
+chk_sha256sum() {
+	local sha256_hash="$1"
+	local filename="$2"
+	echo "$sha256_hash" "$filename" "$(pwd)"
+	sha256sum "$filename"
+	if ! echo "${sha256_hash} ${filename}" | sha256sum --check; then
+		echo "ERROR: SHA256 checksum for ${filename} doesn't match."
+		exit 1
+	fi
+}
+
+# Check that output files exist and match expected hashes.
+# Each arg is "<hash> <path>" (hash optionally followed by filename).
+# Returns 0 if all files exist AND hashes match.
+# Prints which files are missing and which have mismatched hashes.
+check_outputs() {
+	local all_ok=y
+	local pair hash path
+	for pair in "$@"; do
+		pair="$(echo "$pair" | tr -s ' ')"
+		hash="${pair%% *}"
+		path="${pair#* }"
+		echo -n "CHECKING: ${path}... "
+		if [[ ! -f "$path" ]]; then
+			echo "MISSING"
+			all_ok=
+		elif echo "${hash} ${path}" | sha256sum --check >/dev/null 2>&1; then
+			echo "OK"
+		else
+			echo "HASH MISMATCH"
+			all_ok=
+		fi
+	done
+	if [[ -n "$all_ok" ]]; then
+		return 0
+	fi
+	return 1
+}

--- a/blobs/p8z77-m_pro/download_BIOS_clean.sh
+++ b/blobs/p8z77-m_pro/download_BIOS_clean.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 # P7 ASUS
 
 function printusage {
@@ -44,12 +45,14 @@ fi
 
 CAP_ZIP_SHA256SUM="baf7f513227542c507e46735334663f63a0df5be9f6632d7b0f0cca5d3b9f980  P8Z77-M-PRO-ASUS-2203.zip"
 CAP_FILE_SHA256SUM="d9bf292778655d4e20f5db2154cd6a2229e42b60ce670a68d759f1dac757aaf0  P8Z77-M-PRO-ASUS-2203.CAP"
-FINAL_IFD_SHA256SUM="702570d59c11b9b70ab9d54b26ff0906a07edf15eebe63f40bcecb04b955969f  ifd.bin"
-FINAL_ME_SHA256SUM="8dda1e8360fbb2da05bfcd187f6e7b8a272a67d66bc0074bbfd1410eb35e3e17  me.bin"
+FINAL_IFD_SHA256SUM="702570d59c11b9b70ab9d54b26ff0906a07edf15eebe63f40bcecb04b955969f  $BLOB_DIR/ifd.bin"
+FINAL_ME_SHA256SUM="8dda1e8360fbb2da05bfcd187f6e7b8a272a67d66bc0074bbfd1410eb35e3e17  $BLOB_DIR/me.bin"
 ZIPURL="https://dlcdnets.asus.com/pub/ASUS/mb/LGA1155/P8Z77-M_PRO/P8Z77-M-PRO-ASUS-2203.zip"
 
 ZIPFILENAME=`echo $ZIPURL | sed 's/.*\///'`
 ROMFILENAME=`echo $ZIPFILENAME | sed 's/\.zip$/\.ROM/'`
+
+check_outputs "$FINAL_IFD_SHA256SUM" "$FINAL_ME_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
 
 extractdir=$(mktemp -d)
 echo "### Creating temp dir $extractdir "
@@ -73,18 +76,15 @@ echo "### Applying me_cleaner to neuter and truncate."
 $MECLEAN -S -r -t -d -O  /tmp/unneeded.bin -D "ifd.bin" -M "me.bin" P8Z77-M-PRO-ASUS-2203.ROM
 
 if [[ "${CONFIG_ZERO_IFD_VSCC}" =~ ^(Y|y)$ ]]; then
-	FINAL_IFD_SHA256SUM="092caeee117de27c0eb30587defcb6449a33c7c325b6f3c47b5a7a79670b5c3f  ifd.bin"
+	FINAL_IFD_SHA256SUM="092caeee117de27c0eb30587defcb6449a33c7c325b6f3c47b5a7a79670b5c3f  $BLOB_DIR/ifd.bin"
 	echo "### Modifying VSCC length and identifiers"
 	printf '\x00' | dd of=ifd.bin bs=1 seek=3837 count=1 conv=notrunc
 	printf '\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF' | dd of=ifd.bin bs=1 seek=3568 count=32 conv=notrunc
-	echo "### Verifying expected hashes"
-else
-	echo "###  Skipping VSCC modification by config"
 fi
-echo "$FINAL_IFD_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on generated IFD bin..." && exit 1; }
-mv ifd.bin $BLOB_DIR/ifd.bin
-echo "$FINAL_ME_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on generated ME binary..." && exit 1; }
-mv me.bin $BLOB_DIR/me.bin
+mv ifd.bin $BLOB_DIR/ifd.bin || { echo "ERROR: failed to move ifd.bin to $BLOB_DIR"; exit 1; }
+mv me.bin $BLOB_DIR/me.bin || { echo "ERROR: failed to move me.bin to $BLOB_DIR"; exit 1; }
+check_outputs "$FINAL_IFD_SHA256SUM" || exit 1
+check_outputs "$FINAL_ME_SHA256SUM" || exit 1
 
 echo "###Cleaning up..."
 cd -

--- a/blobs/xx20/download_parse_me.sh
+++ b/blobs/xx20/download_parse_me.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 BLOBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -6,16 +7,7 @@ FINAL_ME_BIN_SHA256SUM="1eef6716aa61dd844d58eca15a85faa1bf5f82715defd30bd3373e79
 ME_EXE_SHA256SUM="48f18d49f3c7c79fa549a980f14688bc27c18645f64d9b6827a15ef5c547d210  83rf46ww.exe"
 ME7_5M_UPD_PRODUCTION_SHA256SUM="760b0776b99ba94f56121d67c1f1226c77f48bd3b0799e1357a51842c79d3d36  app/ME7_5M_UPD_Production.bin"
 
-if [ -e "$BLOBDIR/me.bin" ]; then
-  echo "$BLOBDIR/me.bin found..."
-  if ! echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check; then
-    echo "$BLOBDIR/me.bin doesn't pass integrity validation. Continuing..."
-    rm -f "$BLOBDIR/me.bin"
-  else
-    echo "$BLOBDIR/me.bin already extracted and neutered outside of BUP"
-    exit 0
-  fi
-fi
+check_outputs "$FINAL_ME_BIN_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
 
 echo "### Creating temp dir"
 extractdir=$(mktemp -d)
@@ -36,8 +28,7 @@ echo "$ME7_5M_UPD_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sh
 echo "###Generating neuter+deactivate+maximize reduction of ME on app/ME7_5M_UPD_Production.bin, outputting minimized ME under $BLOBDIR/me.bin... "
 ( python3 "$BLOBDIR/me7_update_parser.py" -O "$BLOBDIR/me.bin" app/ME7_5M_UPD_Production.bin ) || { echo "Failed to generate ME binary..." && exit 1; }
 
-echo "### Verifying expected hash of me.bin"
-echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
+check_outputs "$FINAL_ME_BIN_SHA256SUM" || exit 1
 
 
 echo "###Cleaning up..."

--- a/blobs/xx30/download_clean_me.sh
+++ b/blobs/xx30/download_clean_me.sh
@@ -1,19 +1,11 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
-function printusage {
+function usage {
   echo "Usage: $0 -m <me_cleaner>(optional)"
 }
 
 ME_BIN_HASH="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4"
-
-if [ -e "${output_dir}/me.bin" ]; then
-  echo "me.bin already exists"
-  if echo "${ME_BIN_HASH} ${output_dir}/me.bin" | sha256sum --check; then
-    echo "SKIPPING: SHA256 checksum for me.bin matches."
-    exit 0
-  fi
-  echo "me.bin exists but checksum doesn't match. Continuing..."
-fi
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   if [[ "${1:-}" == "--help" ]]; then
@@ -26,34 +18,29 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
     output_dir="$(realpath "${1:-./}")"
 
-    if [[ ! -f "${output_dir}/me.bin" ]]; then
-      # Unpack Lenovo's Windows installer into a temporary directory and
-      # extract the Intel ME blob.
-      pushd "$(mktemp -d)" || exit
+    check_outputs "${ME_BIN_HASH} ${output_dir}/me.bin" && { echo "All outputs match. Nothing to do."; exit 0; }
 
-      curl -O https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe
-      innoextract g1rg24ww.exe
+    pushd "$(mktemp -d)" || exit
 
-      mv app/ME8_5M_Production.bin "${COREBOOT_DIR}/util/me_cleaner"
-      rm -rf ./*
-      popd || exit
+    curl -O https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe
+    innoextract g1rg24ww.exe
 
-      # Neutralize and shrink Intel ME. Note that this doesn't include
-      # --soft-disable to set the "ME Disable" or "ME Disable B" (e.g.,
-      # High Assurance Program) bits, as they are defined within the Flash
-      # Descriptor.
-      # https://github.com/corna/me_cleaner/wiki/External-flashing#neutralize-and-shrink-intel-me-useful-only-for-coreboot
-      pushd "${COREBOOT_DIR}/util/me_cleaner" || exit
+    mv app/ME8_5M_Production.bin "${COREBOOT_DIR}/util/me_cleaner"
+    rm -rf ./*
+    popd || exit
 
-      python me_cleaner.py -r -t -O me_shrinked.bin ME8_5M_Production.bin
-      rm -f ME8_5M_Production.bin
-      mv me_shrinked.bin "${output_dir}/me.bin"
-      popd || exit
-    fi
+    # Neutralize and shrink Intel ME. Note that this doesn't include
+    # --soft-disable to set the "ME Disable" or "ME Disable B" (e.g.,
+    # High Assurance Program) bits, as they are defined within the Flash
+    # Descriptor.
+    # https://github.com/corna/me_cleaner/wiki/External-flashing#neutralize-and-shrink-intel-me-useful-only-for-coreboot
+    pushd "${COREBOOT_DIR}/util/me_cleaner" || exit
 
-    if ! echo "${ME_BIN_HASH} ${output_dir}/me.bin" | sha256sum --check; then
-      echo "ERROR: SHA256 checksum for me.bin doesn't match."
-      exit 1
-    fi
+    python me_cleaner.py -r -t -O me_shrinked.bin ME8_5M_Production.bin
+    rm -f ME8_5M_Production.bin
+    mv me_shrinked.bin "${output_dir}/me.bin"
+    popd || exit
+
+    check_outputs "${ME_BIN_HASH} ${output_dir}/me.bin" || exit 1
   fi
 fi

--- a/blobs/xx30/download_clean_me_manually.sh
+++ b/blobs/xx30/download_clean_me_manually.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
-
-function printusage {
-  echo "Usage: $0 -m <me_cleaner>(optional)"
-}
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 BLOBDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FINAL_ME_BIN_SHA256SUM="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4  $BLOBDIR/me.bin"
 ME_EXE_SHA256SUM="f60e1990e2da2b7efa58a645502d22d50afd97b53a092781beee9b0322b61153  g1rg24ww.exe"
 ME8_5M_PRODUCTION_SHA256SUM="821c6fa16e62e15bc902ce2e958ffb61f63349a471685bed0dc78ce721a01bfa  app/ME8_5M_Production.bin"
 
-if [ "$#" -eq 0 ]; then printusage; fi
+if [ "$#" -eq 0 ]; then echo "Usage: $0 -m <me_cleaner>(optional)"; fi
 
 while getopts ":m:" opt; do
   case $opt in
@@ -23,16 +20,7 @@ while getopts ":m:" opt; do
   esac
 done
 
-if [ -e "$BLOBDIR/me.bin" ]; then
-  echo "$BLOBDIR/me.bin found..."
-  if ! echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check; then
-    echo "$BLOBDIR/me.bin doesn't pass integrity validation. Continuing..."
-    rm -f "$BLOBDIR/me.bin"
-  else
-    echo "$BLOBDIR/me.bin already extracted and neutered outside of ROMP and BUP"
-    exit 0
-  fi
-fi
+check_outputs "$FINAL_ME_BIN_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
 
 if [ -z "$MECLEAN" ]; then
   MECLEAN=$(command -v "$BLOBDIR/../../build/x86/coreboot-"*/util/me_cleaner/me_cleaner.py 2>&1 | head -n1)
@@ -56,12 +44,9 @@ innoextract ./g1rg24ww.exe || { echo "Failed calling innoextract. Tool installed
 echo "### Verifying expected hash of app/ME8_5M_Production.bin"
 echo "$ME8_5M_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
 
-bioscopy="some_value" # Assign a value to the bioscopy variable
-
-echo "### Applying me_cleaner to neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
+echo "### Applying me_cleaner to neuter+deactivate+maximize reduction of ME, outputting minimized ME under $BLOBDIR/me.bin... "
 "$MECLEAN" -r -t -O "$BLOBDIR/me.bin" app/ME8_5M_Production.bin
-echo "### Verifying expected hash of me.bin"
-echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
+check_outputs "$FINAL_ME_BIN_SHA256SUM" || exit 1
 
 echo "### Cleaning up..."
 cd - >/dev/null

--- a/blobs/xx30/optiplex_7010_9010.sh
+++ b/blobs/xx30/optiplex_7010_9010.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+
 EC_BLOB_HASH=20060eba91367b71a21c7757271ac642fa0376809f8c1b51066510246ac97bdb
 ACM_BLOB_HASH=b00d10f6615cf1b28f4fb4adac6631bf6e332db524e45dfafb92e539767d22a0
 SINIT_BLOB_HASH=1e888aebc78d637d119c489adffa95387b53429125dc3ad61f10a5cad0496834
 
 output_dir="$(realpath "${1:-./}")"
 
-if [[ ! -f "${output_dir}/IVB_BIOSAC_PRODUCTION.bin" ]] || [[ ! -f "${output_dir}/sch5545_ecfw.bin" ]] || [[ ! -f "${output_dir}/SNB_IVB_SINIT_20190708_PW.bin" ]] ; then
+check_outputs \
+	"${EC_BLOB_HASH} ${output_dir}/sch5545_ecfw.bin" \
+	"${ACM_BLOB_HASH} ${output_dir}/IVB_BIOSAC_PRODUCTION.bin" \
+	"${SINIT_BLOB_HASH} ${output_dir}/SNB_IVB_SINIT_20190708_PW.bin" && { echo "All outputs match. Nothing to do."; exit 0; }
+
     # Unpack Dell's Windows installer into a temporary directory and
     # extract the EC and ACM blobs
 
@@ -45,25 +51,9 @@ if [[ ! -f "${output_dir}/IVB_BIOSAC_PRODUCTION.bin" ]] || [[ ! -f "${output_dir
       echo "Can't download sinit blob, failing"
       exit 1
     fi
-fi
 
-if ! echo "${EC_BLOB_HASH} ${output_dir}/sch5545_ecfw.bin" | sha256sum --check; then
-      echo "ERROR: SHA256 checksum for sch5545_ecfw.bin doesn't match. Try again"
-      rm -f "${output_dir}/sch5545_ecfw.bin"
-      exit 1
-fi
-
-
-if ! echo "${ACM_BLOB_HASH} ${output_dir}/IVB_BIOSAC_PRODUCTION.bin" | sha256sum --check; then
-      echo "ERROR: SHA256 checksum for IVB_BIOSAC_PRODUCTION.bin doesn't match. Try again"
-      rm -f "${output_dir}/IVB_BIOSAC_PRODUCTION.bin"
-      exit 1
-fi
-
-
-if ! echo "${SINIT_BLOB_HASH} ${output_dir}/SNB_IVB_SINIT_20190708_PW.bin" | sha256sum --check; then
-      echo "ERROR: SHA256 checksum for SNB_IVB_SINIT_20190708_PW.bin doesn't match. Try again"
-      rm -f "${output_dir}/SNB_IVB_SINIT_20190708_PW.bin"
-      exit 1
-fi
+check_outputs \
+	"${EC_BLOB_HASH} ${output_dir}/sch5545_ecfw.bin" \
+	"${ACM_BLOB_HASH} ${output_dir}/IVB_BIOSAC_PRODUCTION.bin" \
+	"${SINIT_BLOB_HASH} ${output_dir}/SNB_IVB_SINIT_20190708_PW.bin" || exit 1
 

--- a/blobs/xx30/vbios_t530.sh
+++ b/blobs/xx30/vbios_t530.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 BLOBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROMPARSER="94a615302f89b94e70446270197e0f5138d678f3"
@@ -9,8 +10,10 @@ ROM_PARSER_SHA256SUM="f3db9e9b32c82fea00b839120e4f1c30b40902856ddc61a84bd3743996
 UEFI_EXTRACT_SHA256SUM="c9cf4066327bdf6976b0bd71f03c9e049ae39ed19ea3b3592bae3da8615d26d7  UEFIExtract_NE_A58_linux_x86_64.zip"
 VBIOS_FINDER_SHA256SUM="bd07f47fb53a844a69c609ff268249ffe7bf086519f3d20474087224a23d70c5  c2d764975115de466fdb4963d7773b5bc8468a06.zip"
 BIOS_UPDATE_SHA256SUM="6fc652b5fa10e5ea1ddc0e8477a2f1cfe56e00df76a94629f9b736faaee6199c  g4uj41us.exe"
-DGPU_ROM_SHA256SUM="3efe4886530086c0b612d1e669fbb4459ec93ec949b25a909e7ad273f4f01015  vbios_10de_0def_1.rom"
-IGPU_ROM_SHA256SUM="10b292c19322e7bb7db53350d2775d37b72a784292ea5686cd0f92af929f4916  vbios_8086_0106_1.rom"
+DGPU_ROM_SHA256SUM="3efe4886530086c0b612d1e669fbb4459ec93ec949b25a909e7ad273f4f01015  $BLOBDIR/10de,0def.rom"
+IGPU_ROM_SHA256SUM="10b292c19322e7bb7db53350d2775d37b72a784292ea5686cd0f92af929f4916  $BLOBDIR/8086,0106.rom"
+
+check_outputs "$DGPU_ROM_SHA256SUM" "$IGPU_ROM_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
 
 echo "### Creating temp dir"
 extractdir=$(mktemp -d)
@@ -63,14 +66,11 @@ innoextract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$B
 echo "### Finding, extracting and saving vbios"
 sudo ./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"app/G4ETB7WW/\$01D5100.FL1" || { echo "Failed to extract FL1" && exit 1; }
 
-echo "Verifying expected hash of extracted roms"
 cd output
-echo "$DGPU_ROM_SHA256SUM" | sha256sum --check || { echo "dGPU rom failed sha256sum verification..." && exit 1; }
-echo "$IGPU_ROM_SHA256SUM" | sha256sum --check || { echo "iGPU rom Failed sha256sum verification..." && exit 1; }
-
 echo "### Moving extracted roms to blobs directory"
 sudo mv vbios_10de_0def_1.rom $BLOBDIR/10de,0def.rom
 sudo mv vbios_8086_0106_1.rom $BLOBDIR/8086,0106.rom
+check_outputs "$DGPU_ROM_SHA256SUM" "$IGPU_ROM_SHA256SUM" || exit 1
 
 echo "### Cleaning Up"
 cd "$BLOBDIR"

--- a/blobs/xx30/vbios_w530.sh
+++ b/blobs/xx30/vbios_w530.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 BLOBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROMPARSER="94a615302f89b94e70446270197e0f5138d678f3"
@@ -9,9 +10,11 @@ ROM_PARSER_SHA256SUM="f3db9e9b32c82fea00b839120e4f1c30b40902856ddc61a84bd3743996
 UEFI_EXTRACT_SHA256SUM="c9cf4066327bdf6976b0bd71f03c9e049ae39ed19ea3b3592bae3da8615d26d7  UEFIExtract_NE_A58_linux_x86_64.zip"
 VBIOS_FINDER_SHA256SUM="bd07f47fb53a844a69c609ff268249ffe7bf086519f3d20474087224a23d70c5  c2d764975115de466fdb4963d7773b5bc8468a06.zip"
 BIOS_UPDATE_SHA256SUM="4769fdcfe34c40d285b8c7290305f04eb91d692f4bf25acd291d114353a958c2  g5uj39us.exe"
-K2000M_ROM_SHA256SUM="5005b582019b16d2073cec8cd384ec908d8ff38ab286a6dd65eadc0e89bfb4a8  vbios_10de_0ffb_1.rom"
-K1000M_ROM_SHA256SUM="6e28abb61cd4c69be7bd64e487681164cb487a48d77276f3108e3f192ceeee16  vbios_10de_0ffc_1.rom"
-IGPU_ROM_SHA256SUM="10b292c19322e7bb7db53350d2775d37b72a784292ea5686cd0f92af929f4916  vbios_8086_0106_1.rom"
+K2000M_ROM_SHA256SUM="5005b582019b16d2073cec8cd384ec908d8ff38ab286a6dd65eadc0e89bfb4a8  $BLOBDIR/10de,0ffb.rom"
+K1000M_ROM_SHA256SUM="6e28abb61cd4c69be7bd64e487681164cb487a48d77276f3108e3f192ceeee16  $BLOBDIR/10de,0ffc.rom"
+IGPU_ROM_SHA256SUM="10b292c19322e7bb7db53350d2775d37b72a784292ea5686cd0f92af929f4916  $BLOBDIR/8086,0106.rom"
+
+check_outputs "$K2000M_ROM_SHA256SUM" "$K1000M_ROM_SHA256SUM" "$IGPU_ROM_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
 
 echo "### Creating temp dir"
 extractdir=$(mktemp -d)
@@ -64,16 +67,12 @@ innoextract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"$B
 echo "### Finding, extracting and saving vbios"
 sudo ./vbiosfinder extract "$extractdir"/rom-parser-"$ROMPARSER"/VBiosFinder-"$VBIOSFINDER"/"app/G5ETB6WW/\$01D5200.FL1" || { echo "Failed to extract FL1" && exit 1; }
 
-echo "Verifying expected hash of extracted roms"
 cd output
-echo "$K2000M_ROM_SHA256SUM" | sha256sum --check || { echo "K2000M rom failed sha256sum verification..." && exit 1; }
-echo "$K1000M_ROM_SHA256SUM" | sha256sum --check || { echo "K1000M rom failed sha256sum verification..." && exit 1; }
-echo "$IGPU_ROM_SHA256SUM" | sha256sum --check || { echo "iGPU rom Failed sha256sum verification..." && exit 1; }
-
 echo "### Moving extracted roms to blobs directory"
 sudo mv vbios_10de_0ffb_1.rom "$BLOBDIR"/10de,0ffb.rom
 sudo mv vbios_10de_0ffc_1.rom "$BLOBDIR"/10de,0ffc.rom
 sudo mv vbios_8086_0106_1.rom "$BLOBDIR"/8086,0106.rom
+check_outputs "$K2000M_ROM_SHA256SUM" "$K1000M_ROM_SHA256SUM" "$IGPU_ROM_SHA256SUM" || exit 1
 
 echo "### Cleaning Up"
 cd "$BLOBDIR"

--- a/blobs/xx80/t480_download_clean_deguard_me_pad_tb.sh
+++ b/blobs/xx80/t480_download_clean_deguard_me_pad_tb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 # These variables are all for the deguard tool.
 # They would need to be changed if using the tool for other devices like the T480s or with a different ME version...
@@ -25,28 +26,6 @@ function usage() {
 Download Intel ME firmware from Dell, neutralize and shrink keeping the MFS.
 Download Thunderbolt firmware from Lenovo and pad it for flashing externally.
 "
-}
-
-function chk_sha256sum() {
-	sha256_hash="$1"
-	filename="$2"
-	echo "$sha256_hash" "$filename" "$(pwd)"
-	sha256sum "$filename"
-	if ! echo "${sha256_hash} ${filename}" | sha256sum --check; then
-		echo "ERROR: SHA256 checksum for ${filename} doesn't match."
-		exit 1
-	fi
-}
-
-function chk_exists_and_matches() {
-	if [[ -f "$1" ]]; then
-		if echo "${2} ${1}" | sha256sum --check; then
-			echo "SKIPPING: SHA256 checksum for $1 matches."
-			[[ "$3" = ME ]] && me_exists="y"
-			[[ "$3" = TB ]] && tb_exists="y"
-		fi
-		echo "$1 exists but checksum doesn't match. Continuing..."
-	fi
 }
 
 function download_and_clean() {
@@ -174,8 +153,6 @@ function parse_params() {
 	me_cleaned="${output_dir}/me_cleaned.bin"
 	me_deguarded="${output_dir}/t480_me.bin"
 	tb_flashable="${output_dir}/t480_tb.bin"
-	echo "Writing cleaned and deguarded ME to ${me_deguarded}"
-	echo "Writing flashable TB to ${tb_flashable}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
@@ -185,19 +162,22 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 	fi
 
 	parse_params "$@"
-	chk_exists_and_matches "$me_deguarded" "$DEGUARDED_ME_BIN_HASH" ME
-	chk_exists_and_matches "$tb_flashable" "$TB_BIN_HASH" TB
 
-	if [[ -z "$me_exists" ]]; then
+	check_outputs \
+		"${DEGUARDED_ME_BIN_HASH} ${me_deguarded}" \
+		"${TB_BIN_HASH} ${tb_flashable}" && { echo "All outputs match. Nothing to do."; exit 0; }
+
+	echo "Writing cleaned and deguarded ME to ${me_deguarded}"
+	if ! check_outputs "${DEGUARDED_ME_BIN_HASH} ${me_deguarded}"; then
 		download_and_clean "$me_cleaner" "$me_cleaned"
 		deguard "$me_cleaned" "$me_deguarded"
 		rm -f "$me_cleaned"
 	fi
-	
-	if [[ -z "$tb_exists" ]]; then
+	check_outputs "${DEGUARDED_ME_BIN_HASH} ${me_deguarded}" || exit 1
+
+	echo "Writing flashable TB to ${tb_flashable}"
+	if ! check_outputs "${TB_BIN_HASH} ${tb_flashable}"; then
 		download_and_pad_tb "$tb_flashable"
 	fi
-	
-	chk_sha256sum "$DEGUARDED_ME_BIN_HASH" "$me_deguarded"
-	chk_sha256sum "$TB_BIN_HASH" "$tb_flashable"
+	check_outputs "${TB_BIN_HASH} ${tb_flashable}" || exit 1
 fi

--- a/blobs/xx80/t480s_download_clean_deguard_me_pad_tb.sh
+++ b/blobs/xx80/t480s_download_clean_deguard_me_pad_tb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 # These variables are all for the deguard tool.
 # They would need to be changed if using the tool for other devices like the T480s or with a different ME version...
@@ -26,28 +27,6 @@ function usage() {
 Download Intel ME firmware from Dell, neutralize and shrink keeping the MFS.
 Download Thunderbolt firmware from Lenovo and pad it for flashing externally.
 "
-}
-
-function chk_sha256sum() {
-	sha256_hash="$1"
-	filename="$2"
-	echo "$sha256_hash" "$filename" "$(pwd)"
-	sha256sum "$filename"
-	if ! echo "${sha256_hash} ${filename}" | sha256sum --check; then
-		echo "ERROR: SHA256 checksum for ${filename} doesn't match."
-		exit 1
-	fi
-}
-
-function chk_exists_and_matches() {
-	if [[ -f "$1" ]]; then
-		if echo "${2} ${1}" | sha256sum --check; then
-			echo "SKIPPING: SHA256 checksum for $1 matches."
-			[[ "$3" = ME ]] && me_exists="y"
-			[[ "$3" = TB ]] && tb_exists="y"
-		fi
-		echo "$1 exists but checksum doesn't match. Continuing..."
-	fi
 }
 
 function download_and_clean() {
@@ -175,8 +154,6 @@ function parse_params() {
 	me_cleaned="${output_dir}/me_cleaned.bin"
 	me_deguarded="${output_dir}/t480s_me.bin"
 	tb_flashable="${output_dir}/t480s_tb.bin"
-	echo "Writing cleaned and deguarded ME to ${me_deguarded}"
-	echo "Writing flashable TB to ${tb_flashable}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
@@ -186,19 +163,22 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 	fi
 
 	parse_params "$@"
-	chk_exists_and_matches "$me_deguarded" "$DEGUARDED_ME_BIN_HASH" ME
-	chk_exists_and_matches "$tb_flashable" "$TB_BIN_HASH" TB
 
-	if [[ -z "$me_exists" ]]; then
+	check_outputs \
+		"${DEGUARDED_ME_BIN_HASH} ${me_deguarded}" \
+		"${TB_BIN_HASH} ${tb_flashable}" && { echo "All outputs match. Nothing to do."; exit 0; }
+
+	echo "Writing cleaned and deguarded ME to ${me_deguarded}"
+	if ! check_outputs "${DEGUARDED_ME_BIN_HASH} ${me_deguarded}"; then
 		download_and_clean "$me_cleaner" "$me_cleaned"
 		deguard "$me_cleaned" "$me_deguarded"
 		rm -f "$me_cleaned"
 	fi
-	
-	if [[ -z "$tb_exists" ]]; then
+	check_outputs "${DEGUARDED_ME_BIN_HASH} ${me_deguarded}" || exit 1
+
+	echo "Writing flashable TB to ${tb_flashable}"
+	if ! check_outputs "${TB_BIN_HASH} ${tb_flashable}"; then
 		download_and_pad_tb "$tb_flashable"
 	fi
-	
-	chk_sha256sum "$DEGUARDED_ME_BIN_HASH" "$me_deguarded"
-	chk_sha256sum "$TB_BIN_HASH" "$tb_flashable"
+	check_outputs "${TB_BIN_HASH} ${tb_flashable}" || exit 1
 fi

--- a/blobs/z220/download_BIOS_clean.sh
+++ b/blobs/z220/download_BIOS_clean.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
 
 # Z220 CMT HP
 
@@ -39,6 +40,8 @@ TGZURL="https://ftp.hp.com/pub/softpaq/sp97001-97500/sp97120.tgz"
 TGZFILENAME=`echo $TGZURL | sed 's/.*\///'`
 ROMFILENAME=`echo $TGZFILENAME | sed 's/\.zip$/\.ROM/'`
 
+check_outputs "$FINAL_IFD_SHA256SUM" "$FINAL_ME_SHA256SUM" && { echo "All outputs match. Nothing to do."; exit 0; }
+
 extractdir=$(mktemp -d)
 echo "### Creating temp dir $extractdir "
 cd "$extractdir"
@@ -60,9 +63,7 @@ $MECLEAN -S -r -t -d -O  /tmp/unneeded.bin -D "$BLOBDIR/ifd.bin" -M "$BLOBDIR/me
 printf '\x00' | dd of="$BLOBDIR/ifd.bin" bs=1 seek=3837 count=1 conv=notrunc
 printf '\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF' | dd of="$BLOBDIR/ifd.bin" bs=1 seek=3712 count=40 conv=notrunc
 
-echo "### Verifying expected hashes"
-echo "$FINAL_IFD_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on generated IFD bin..." && exit 1; }
-echo "$FINAL_ME_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on generated ME binary..." && exit 1; }
+check_outputs "$FINAL_IFD_SHA256SUM" "$FINAL_ME_SHA256SUM" || exit 1
 
 echo "###Cleaning up..."
 cd -

--- a/doc/circleci.md
+++ b/doc/circleci.md
@@ -1,23 +1,10 @@
 # CircleCI Pipeline and Cache Model
 
-This document explains how the CircleCI pipeline in Heads is structured,
-what the cache layers mean, and how each coreboot fork saves its own modules cache.
+This document explains the Heads CircleCI pipeline structure, cache
+layers, and job types.
 
 See also: [development.md](development.md), [docker.md](docker.md),
 [architecture.md](architecture.md).
-
----
-
-## Goals
-
-The CircleCI pipeline is optimized for two constraints:
-
-- Avoid CircleCI workspace fan-in errors.
-- Reuse expensive build outputs across pipelines without delaying unrelated
-  board builds more than necessary.
-
-The current layout favors a linear x86 seed chain followed by parallel board
-builds.
 
 ---
 
@@ -25,281 +12,324 @@ builds.
 
 ### Workspace
 
-A workspace is data passed from an upstream job to downstream jobs in the same
-workflow run.
+A workspace passes data from an upstream job to downstream jobs in the
+same workflow run.
 
-- Workspaces help sibling jobs in the current pipeline.
-- Workspaces are downloaded fresh by downstream jobs.
-- Persisting the same paths from multiple upstream jobs into one downstream job
-  causes fan-in problems in CircleCI.
+- Workspaces help downstream jobs in the current pipeline, not future ones.
+- Persisting the same paths from multiple upstream jobs into one
+  downstream job causes fan-in errors in CircleCI.
 
-### Cache
+### Cache vs workspace
 
-A CircleCI cache is stored for reuse by later pipeline runs in the same
-repository.
+| Type | Scope | Purpose |
+|---|---|---|
+| Workspace | Per-workflow | Share build outputs between jobs |
+| Cache | Cross-pipeline | Avoid redoing expensive operations (compiler builds, dependency downloads) |
 
-- Caches help future pipelines.
-- Caches do not speed up sibling jobs in the same workflow run.
-- Forks do not share caches with the upstream repository.
-- Each x86_coreboot job saves both modules and coreboot caches for its fork.
+### Job types
 
----
+Two job types exist for x86 board builds in `.circleci/config.yml`:
 
-## x86 pipeline shape
+**`x86_coreboot` (seed)**: One per unique toolchain.  Saves modules +
+coreboot fork caches.
+- `restore_cache` with 3-key fallback (Modules → Coreboot fork → Musl)
+- `build_board` — builds crossgcc (if `.heads-toolchain` stamp absent),
+  then builds the board ROM
+- `persist_to_workspace`: saves `packages/x86 build/x86 crossgcc/x86 install/x86`
+- `save_cache` ×2: Modules cache (full `build/x86`) + Coreboot fork
+  cache (`build/x86/{coreboot_dir}` + crossgcc + musl + packages)
 
-The x86 chain is intentionally linear until a seed board has produced a usable
-workspace:
-
-1. `create_hashes`
-2. `x86_blobs`
-3. `x86_musl_cross_make`
-4. `x86_coreboot` seed jobs, one per coreboot fork
-5. Downstream board builds for each fork, in parallel
-
-For the coreboot 25.09 branch, the seed board is `EOL_t480-hotp-maximized`.
-That job produces the workspace used by the other 25.09 boards in the same
-workflow.
-
-Other x86 forks follow the same pattern:
-
-- `novacustom-nv4x_adl` seeds the `coreboot-dasharo_nv4x` fork
-- `novacustom-v560tu` seeds the `coreboot-dasharo_v56` fork
-- `librem_14` seeds the `coreboot-purism` fork
-- `EOL_t480-hotp-maximized` seeds the `coreboot-25.09` fork
-- `EOL_librem_l1um` seeds the `coreboot-4.11` fork
-- `UNTESTED_msi_z690a_ddr4` seeds the `coreboot-dasharo_msi_z690` fork
-- `UNTESTED_msi_z790p_ddr4` seeds the `coreboot-dasharo_msi_z790` fork
-
-The downstream `build` jobs for each family consume the workspace from the
-relevant seed job instead of rebuilding the fork toolchain from scratch.
-
-The ppc64 chain mirrors x86:
-1. `create_hashes`
-2. `ppc64_musl_cross_make` - builds musl-cross-make toolchain, saves cache
-3. `ppc64_coreboot` - builds coreboot-talos_2 fork, saves cache
-4. (no downstream boards - only one ppc64 board exists)
+**`build` (downstream)**: Plain board builds.  No `restore_cache`/`save_cache`.
+All inputs come from the seed's workspace (including crossgcc, blobs, musl,
+and fork source for same-fork boards).  For Dasharo shared-toolchain boards
+where the seed uses a different fork (nv4x), fork source is cloned fresh
+during `make` (seconds).
 
 ---
 
-## Cache layers
+## Cache model
 
-The x86 pipeline uses hierarchical cache layers:
+All cache key hashes are computed once per pipeline by `create_hashes`
+and are global — every job gets the same hashes.  Per-seed
+differentiation comes solely from the `{coreboot_dir}` suffix.
 
-1. **`{arch}-musl-cross-make-nix-docker-heads-{hash}`**
-   - Base toolchain (GCC + musl = musl-cross-make)
-   - Paths: `build/{arch}/musl-cross-make-*`, `crossgcc/{arch}`, `install/{arch}`, `packages/{arch}`
+### Three layers (+ blobs)
 
-2. **`{arch}-coreboot-musl-cross-make-nix-docker-heads-{hash}-{coreboot_dir}`**
-   - Includes musl + coreboot toolstack
-   - Paths: `build/{arch}/{coreboot_dir}`, `build/{arch}/musl-cross-make-*`, `crossgcc/{arch}`, `install/{arch}`, `packages/{arch}`
+Restore order (first hit wins):
 
-3. **`{arch}-modules-coreboot-musl-cross-make-nix-docker-heads-{hash}-{coreboot_dir}`**
-   - Includes coreboot + musl + all built modules (FULL)
-   - Paths: `build/{arch}`, `install/{arch}`, `crossgcc/{arch}`, `packages/{arch}`
+| Priority | Layer | Key hash | Scope | Contents | Invalidates on |
+|---|---|---|---|---|---|
+| 1 | Modules | `all_modules_and_patches` | Per-seed | ALL of `build/{arch}` + crossgcc + install + packages | Any module/patches change |
+| 2 | Coreboot fork | `coreboot_musl-cross-make` | Per-seed | `build/{arch}/{coreboot_dir}` + crossgcc + musl + packages | Coreboot + musl-cross-make + coreboot patches + flake.lock |
+| 3 | Musl | `musl-cross-make` | Per-arch | `crossgcc/{arch}` + `build/{arch}/musl-cross-make-*` + install + packages | Musl-cross-make change (rare) |
 
-4. **`{arch}-blobs-nix-docker-heads`** are handled separately
+Blobs are handled separately as a 4th cache layer (`x86-blobs-...`), shared
+by all x86 jobs.  Restored before seeds run, persisted to workspace.
 
-Cache key naming: `{arch}-{layer}-nix-docker-heads-{hash}[-{fork}]`
+### Hit scenarios
 
-The cache key naming shows the dependency chain: each layer includes everything from the layers below it.
+- **Modules hits**: All fork source, crossgcc, and modules restored.
+  `make` finds `.heads-toolchain`, skips crossgcc rebuild.
+  Only changed artifacts rebuild.
+- **Coreboot fork hits, Modules misses** (e.g., non-coreboot module
+  changed): Fork source and crossgcc restored.  Modules rebuild.
+  Saves ~30-40 min of crossgcc build time.
+- **Musl only hits**: No coreboot fork source or coreboot crossgcc (`build/{arch}/{coreboot_dir}`).  The musl toolchain (`crossgcc/{arch}`) is present, but the coreboot fork tree -- including coreboot's own crossgcc under `util/crossgcc/` -- must be built from scratch.
+- **Nothing hits**: Everything from scratch.
 
-Restore order (most complete to least):
+### Why two saves per seed
+
+Each seed saves 2 caches: Modules (superset) and Coreboot fork (subset).
+The Coreboot fork cache is a narrow fallback — if only non-coreboot
+modules change, Modules misses but Coreboot fork hits, avoiding an
+unnecessary crossgcc rebuild.  Musl is arch-dependent, saved once per
+architecture (x86, ppc64), not per seed.
+
+### `build` jobs inherit cache through workspace
+
+`build` jobs have no `restore_cache` or `save_cache` steps.  They inherit
+cache results indirectly through the workspace chain:
+
+1. The seed runs `restore_cache` — on a warm run, the Modules or Coreboot
+   fork cache hits, restoring crossgcc (`.heads-toolchain` stamp) and
+   fork source into `build/{arch}/`.
+2. The seed runs `build_board` — `make` finds `.heads-toolchain`, skips
+   crossgcc rebuild.  Builds the ROM.
+3. The seed runs `persist_to_workspace` — saves everything under
+   `build/{arch}/`, including restored cache artifacts.
+4. The `build` job runs `attach_workspace` — gets the seed's full
+   `build/{arch}/` directory, including the crossgcc that was restored
+   from cache in step 1.
+
+The cache hit happens upstream, but the `build` job consumes the result.
+
+For same-fork `build` jobs (e.g. 25.09 downstream boards), the seed's
+fork source is inherited through the workspace -- no clone needed.
+
+For Dasharo shared-toolchain `build` jobs where the seed uses a different
+fork (nv4x), the fork source directory is not in the workspace.  Each
+such `build` job clones its own fork fresh during `make` (seconds).
+This prevents them from independently cache-missing under their own
+`{coreboot_dir}` suffix and triggering a redundant crossgcc rebuild.
+
+---
+
+## Pipeline shape
+
+Job names in CircleCI follow conventions to make their purpose clear
+in the UI:
+
+- Cache key creators include `[cache keys]`: `create_hashes [cache keys]`
+- Blob downloads include blob type: `x86_blobs [ME GBE IFD]`
+- Seeds include their upstream coreboot base: `[seed:coreboot-VERSION]`
+- Build jobs use their board target name (no suffix)
+
+The x86 chain:
+`create_hashes [cache keys]` → `x86_blobs [ME GBE IFD]` →
+`x86-musl-cross-make [cross compiler]` → `x86_coreboot` seeds →
+`build` jobs (parallel).
+
+The ppc64 chain (no blobs, single board):
+`create_hashes [cache keys]` → `ppc64-musl-cross-make [cross compiler]` →
+`ppc64_talos_2 [seed:coreboot-talos-2]`.
+
+### Step details
+
+All jobs run under the `heads-docker` executor (pinned Docker image at
+`tlaurion/heads-dev-env` with SHA256 hash — see [docker.md](docker.md)
+for the image definition and reproducibility details, and
+[flake.nix](../flake.nix) for the Nix-based build environment used to
+generate it).  The shared `build_board` command runs `make V=1 BOARD=<target>`,
+refreshes restored build stamps to prevent spurious rebuilds, and archives
+build logs on failure.
+
+1. **`create_hashes`**: Computes sha256 hashes (cache keys) from source
+   files and persists `tmpDir/` to workspace.  Four hash files are created:
+   - `all_modules_and_patches.sha256sums`: `Makefile`, `flake.lock`,
+     `patches/`, `modules/` — used by **Modules** cache layer
+   - `coreboot_musl-cross-make.sha256sums`: `flake.lock`,
+     `modules/coreboot`, `modules/musl-cross-make*`, `patches/coreboot*`
+     — used by **Coreboot fork** cache layer
+   - `musl-cross-make.sha256sums`: `flake.lock`,
+     `modules/musl-cross-make*` — used by **Musl** cache layer
+   - `blobs_listing.sha256sums`: `blobs/**/*.sh` — used by **Blobs** cache
+   All downstream jobs get the same global hashes (`tmpDir/` from workspace).
+   Per-seed differentiation comes from the `{coreboot_dir}` suffix on cache
+   keys, not from the hash.
+
+2. **`x86_blobs`**: Downloads x86 firmware blobs (ME, GBE, IFD).
+   Restores blob cache keyed on blob script listing hash (`x86-blobs-...`).
+   Persists `blobs/` to workspace.  Only for x86 (ppc64 has no blobs).
+
+3. **`x86-musl-cross-make [cross compiler]`**: Builds musl-cross-make arch-specific toolchain
+   (GCC + musl).  Restores/saves musl cache (`x86-musl-...`).
+   Persists `packages/x86 build/x86 crossgcc/x86 install/x86` to workspace.
+
+4. **`x86_coreboot` seeds** (one per unique toolchain): Build crossgcc + ROM.
+   Restores cache (Modules → Coreboot fork → Musl).  Saves 2 caches.
+   Persists workspace for downstream `build` jobs.
+
+5. **Downstream `build` jobs**: Attach workspace from seed, build ROM.
+   No cache operations.  Same-fork boards inherit fork source from workspace;
+   Dasharo shared-toolchain boards clone fork source fresh during `make`.
+
+### ppc64 chain
+
+- `ppc64-musl-cross-make [cross compiler]`: Same pattern as x86 but
+  ppc64-arch.  Restores/saves ppc64 musl cache.  No blobs step (ppc64
+  has no firmware blobs).
+- `ppc64_talos_2 [seed:coreboot-talos-2]`: Single seed for
+  `coreboot-talos_2`.  Restores/saves ppc64 modules + coreboot caches.
+  Only one ppc64 board exists, no downstream `build` jobs.
+- The ppc64 cache model mirrors x86 without the blobs layer.
+- See [architecture.md](architecture.md) and [config.md](config.md) for
+  ppc64 board and build details.
+
+### Seeds (5 total)
+
+Seed job names in CircleCI include their upstream coreboot base in
+`[seed:coreboot-VERSION]` format:
+
+| Job name in CircleCI | Seeds | Upstream base |
+|---|---|---|
+| `novacustom-nv4x_adl [seed:coreboot-24.12]` | 4 Dasharo families (8 boards) | coreboot 24.12 |
+| `librem_14 [seed:coreboot-24.02.01]` | 8 purism boards | coreboot 24.02.01 |
+| `EOL_t480-hotp-maximized [seed:coreboot-25.09]` | 28 x86 boards | coreboot 25.09 |
+| `EOL_librem_l1um [seed:coreboot-4.11]` | none (standalone) | coreboot 4.11 |
+| `ppc64_talos_2 [seed:coreboot-talos-2]` | none (standalone) | Dasharo fork for Talos 2 |
+
+### Downstream Dasharo boards (all `build` jobs)
+
+All depend on `novacustom-nv4x_adl [seed:coreboot-24.12]`, inherit its
+crossgcc via workspace:
+
+- `novacustom-v560tu`, `novacustom-v540tu`
+- `UNTESTED_msi_z690a_ddr4`, `UNTESTED_msi_z690a_ddr5`
+- `UNTESTED_msi_z790p_ddr4`, `msi_z790p_ddr5`
+- `UNTESTED_nitropad-ns50`
+
+---
+
+## Dasharo shared toolchain
+
+### Why the dasharo forks share a compiler
+
+Four Dasharo board families (nv4x, v56, msi_z690, msi_z790) all use
+the same `github.com/dasharo/coreboot` repository.  Their
+`util/crossgcc/sum/` files are byte-identical — verified by `diff -r`.
+They share identical packages: gcc-14.2.0, binutils-2.43.1,
+nasm-2.16.03, clang-18.1.8.
+
+In `modules/coreboot`, `dasharo_nv4x` is the toolchain provider (empty
+second arg to `coreboot_module()`).  `dasharo_v56`, `dasharo_msi_z690`,
+and `dasharo_msi_z790` pass `dasharo_nv4x` as their toolchain argument,
+consuming its crossgcc instead of building their own.
+
+**Why this works despite different FSP blobs**: The crossgcc is a
+compiler (GCC, binutils, assembler, linker).  It is independent of the
+code it compiles, just like `/usr/bin/gcc` can compile any C program
+regardless of which headers that program includes.  FSP blobs in
+`3rdparty/dasharo-blobs/` are inputs to the compiler (headers and
+binaries linked into the ROM), not part of the compiler itself.  Each
+board builds against its own fork's FSP blobs with its own `.config`;
+only the compiler binary is shared.  Each fork's `3rdparty/dasharo-blobs/`
+submodule commit differs (nv4x at 668d80d, v56/z690/z790 at 8dce760),
+but that only affects the ROM build, not the compiler.
+
+### CI structure
+
+Only `novacustom-nv4x_adl` is an `x86_coreboot` seed.  All other Dasharo
+boards are `build` jobs.  The cache key hash is global (from `modules/`
+and `patches/`).  If v56, z690, and z790 had their own seeds, each would
+have a different `{coreboot_dir}` suffix (`coreboot-dasharo_v56`,
+`coreboot-dasharo_msi_z690`, `coreboot-dasharo_msi_z790`) and would
+independently cache-miss and rebuild the same crossgcc on a cold cache.
+Making them `build` jobs eliminates that — they never try to restore
+cache, so they cannot cache-miss.  They get the crossgcc from
+`novacustom-nv4x_adl`'s workspace.
+
+### Re-verification after upstream rebase
+
+When a Dasharo fork rebases to a newer coreboot release, check that the
+shared toolchain is still compatible:
+
+```bash
+diff -r build/x86/coreboot-dasharo_nv4x/util/crossgcc/sum/ \
+       build/x86/coreboot-dasharo_NEW/util/crossgcc/sum/
 ```
-1. {arch}-modules-coreboot-musl-cross-make-nix-docker-heads-{modules_hash}-{coreboot_dir}
-2. {arch}-coreboot-musl-cross-make-nix-docker-heads-{coreboot_hash}-{coreboot_dir}
-3. {arch}-musl-cross-make-nix-docker-heads-{musl_hash}
-```
 
-Each `x86_coreboot` job saves both:
-- modules cache (full build state)
-- coreboot cache (fork-specific toolstack)
+If the diff is non-empty, the new fork needs its own toolchain module.
+The `{coreboot_dir}` suffix for its cache key would be the fork-specific
+directory name.
 
----
+### 24.02 cluster (not shared)
 
-## Current pipeline details
-
-The current pipeline behavior is:
-
-1. It uses explicit jobs for cache hashing, blob preparation, x86 musl seed,
-   x86 coreboot forks (each saves both modules and coreboot caches), generic board
-   builds, and the single ppc64 Talos II build.
-2. It uses a pinned `heads-docker` executor so the toolchain environment is
-   stable across jobs.
-3. It clears only `build/<arch>/log/*` before a build, not the restored build
-   trees themselves.
-4. It keeps x86 blob preparation separate from toolchain and firmware builds.
-5. It keys x86 coreboot caches by fork so one fork cannot restore another
-   fork's build tree.
-6. It restores the largest valid cache first, because CircleCI stops at the
-   first matching key.
-7. It stores `install/<arch>` together with the compiler and package trees so a
-   restored musl toolchain still has its sysroot.
-8. It refreshes restored `.configured` and `.build` stamps before invoking
-   `make`, so fresh checkout mtimes do not trigger a redundant rebuild of an
-   already restored musl-cross-make tree.
-9. It decouples ppc64 into musl-cross-make and coreboot jobs (like x86) so each
-   saves its cache immediately rather than at the end of a long combined build.
+`coreboot-24.02.01` (upstream tarball), `coreboot-purism` (Purism git
+fork), and a stale `build/x86/coreboot-dasharo` checkout (no active
+boards, no module definition) share identical sum files (gcc-13.2.0,
+binutils-2.41, nasm-2.16.01, clang-16.0.6).  `purism` is the only
+maintained/CI consumer of this toolchain -- sharing would not save any
+crossgcc builds since purism is the sole consumer, and would add
+complexity (different source types: tarball vs git fork).
+(Unmaintained boards that reference 24.02.01 exist under
+`unmaintained_boards/` but are not built in CI.)
 
 ---
 
-## Maintainer checklist
+## Maintainer edit map
 
-When changing `.circleci/config.yml`, update this document by answering these
-questions in order:
+When changing `.circleci/config.yml`, update this document:
 
-1. Did the job graph change?
-   Update the `x86 pipeline shape` section and the seed-board list.
-2. Did a cache key, restore order, or saved path change?
-Update `Cache layers` and `Why musl could rebuild after a cache hit`.
-3. Did the change alter current runtime behavior or restore/build semantics?
-   Update `Current pipeline details`.
-4. Did the change affect the maintenance workflow itself?
-   Update this section too.
-
-If you cannot summarize the change in one of those sections, the document is
-missing a section and should be extended rather than worked around.
-
----
-
-## Edit map
-
-Use this map when modifying the pipeline:
-
-- Add or remove a cache hash input:
-  edit `create_hashes` in `.circleci/config.yml` and update `Cache layers` here.
-- Add or remove x86 blob preparation:
-  edit `x86_blobs` and update `x86 pipeline shape` plus `Cache layers`.
-- Add or remove an x86 coreboot fork seed:
-  edit the `x86_coreboot` workflow entries and update the seed-board list in
-  `x86 pipeline shape`.
-- Add or remove downstream boards for a fork:
-  edit the `build` workflow entries and verify the seed dependency still points
-  to the correct fork seed.
-- Change what makes musl reusable:
-  update the save/restore paths in `.circleci/config.yml` and re-check the
-  explanation in `Why musl could rebuild after a cache hit`.
-- Change ppc64 behavior:
-  edit `ppc64_musl_cross_make` and/or `ppc64_coreboot` and re-check both
-  `Cache layers` and the ppc64 chain description.
-
----
-
-## Invariants
-
-These are the current rules worth preserving unless a deliberate design change:
-
-- Only one job at a time should persist a given workspace chain.
-- Blob download is separate from x86 toolchain and coreboot builds.
-- Each fork saves both modules and coreboot caches.
-- x86 and ppc64 restore lists should prefer the largest valid cache first.
-- Same-workflow cache misses can be expected when the broad key is being published during that workflow; this should improve on the next pipeline.
-- Musl reuse requires both `crossgcc/<arch>` and `install/<arch>`.
-- Each coreboot fork has its own cache keyed by `{coreboot_dir}` to prevent cross-fork contamination.
-- ppc64 now uses decoupled musl-cross-make + coreboot jobs, each saving cache immediately.
-
-## How each fork saves its cache
-
-Each `x86_coreboot` job (the first board for each coreboot fork) saves both:
-1. **modules cache** - full build state including all built modules
-2. **coreboot cache** - fork-specific coreboot toolstack
-
-This means every fork is self-sufficient:
-- First board of fork builds everything and saves both caches
-- Downstream boards in same fork restore full modules cache
-- No separate cache publication job needed
+- **Job graph changed**: Update Pipeline shape and seed list.
+- **Cache key, restore order, or saved path changed**: Update Cache
+  model and `Why musl could rebuild`.
+- **Runtime or rebuild semantics changed**: Update Pipeline details.
+- **New Dasharo fork added**: In `modules/coreboot`, set its toolchain
+  to `dasharo_nv4x` if crossgcc sum files match; add a `build` job in
+  `.circleci/config.yml` depending on `novacustom-nv4x_adl`.  If sum
+  files differ, add a new `x86_coreboot` seed.
+- **New non-Dasharo fork added**: Add an `x86_coreboot` seed in
+  `.circleci/config.yml`.
 
 ---
 
 ## Why musl could rebuild after a cache hit
 
-**Original problem**: Even when cache is restored, musl-cross-make was rebuilt
-because the Makefile only checked if `CROSS` env var was set, not if the
-compiler actually existed on disk.
+**Problem**: Even when cache is restored, musl-cross-make was rebuilt
+because the Makefile only checked if `CROSS` env var was set, not if
+the compiler actually existed on disk.
 
-**Fix**: The musl-cross-make module now uses `wildcard` to auto-detect if
-`crossgcc/<arch>/bin/<triplet>-gcc` exists. If found, it sets CROSS and uses
-the `--version` path (no rebuild). If not found, it builds from scratch.
+**Fix**: The musl-cross-make module uses `wildcard` to auto-detect if
+`crossgcc/<arch>/bin/<triplet>-gcc` exists.  If found, it sets CROSS
+and uses the `--version` path (no rebuild).  If not found, it builds
+from scratch.
 
 The build logic also requires both:
 - the compiler binaries under `crossgcc/<arch>`
 - the installed sysroot under `install/<arch>`
 
-If the cache only restores the compiler tree but not the installed headers and
-libraries, the generic module build rules still have missing outputs and musl
-is rebuilt.
+If the cache only restores the compiler tree but not the installed
+headers and libraries, the generic module build rules still have
+missing outputs and musl is rebuilt.  That is why `install/{arch}` is
+stored alongside the compiler in every cache layer.
 
-That is why the current branch stores `install/x86` and `install/ppc64` in the
-musl and coreboot cache layers, not only in the broad modules cache.
-
-There is a second reuse problem to watch for: restored stamp files can be older
-than freshly checked-out source files in CI. When that happens, GNU Make can
-decide that `.configured` and then `.build` are stale even though the restored
-outputs are complete. The current CI job refreshes restored `.configured` and
-`.build` timestamps before invoking `make` so restored musl-cross-make trees are
-reused instead of spending several minutes rebuilding for timestamp reasons
-alone.
+A second reuse problem: restored stamp files can be older than freshly
+checked-out source files in CI.  When that happens, GNU Make can decide
+that `.configured` and then `.build` are stale even though the restored
+outputs are complete.  The CI job refreshes restored stamps before
+invoking `make` so restored musl-cross-make trees are reused.
 
 ---
-
-## Cold-cache behavior
-
-Cold runs are still expensive because:
-
-- Downstream jobs still download the upstream workspace chain.
-- A fork starts with cold CircleCI caches because caches are repository-scoped.
-- CircleCI restores only the first matching key, so an unexpectedly narrow hit
-  can still leave later work to do if the cache contents are incomplete.
-- Saving a large cache still requires uploading the selected directories.
-
----
-
-## When to change this design
-
-Adjust the model only if one of these is true:
-
-- The seed board is no longer representative of the fork workspace.
-- The persisted workspace is too large and should be split further.
-- The modules cache key is too broad and causes low reuse.
-- CircleCI changes workspace or cache semantics.
-
-## Design invariants
-
-- Each coreboot fork saves both modules and coreboot caches, eliminating single-point-of-failure.
-- Cache key naming shows the dependency chain: modules includes coreboot includes musl.
-- Restore ordering must be explicit and largest-first. If two keys are valid,
-  CircleCI uses the first match only.
-- Restored build markers can be older than fresh checkout files. Without stamp refresh,
-  Make can rebuild musl-cross-make even after a correct modules-cache restore.
-- For ppc64, the middle fallback `coreboot+musl` improves reuse when
-  `modules` is absent but a richer cache than plain `musl` exists.
-- Each x86 coreboot fork saves its own modules cache keyed by `{coreboot_dir}`.
-  This prevents cross-fork contamination while enabling fork-specific reuse.
-- x86 coreboot forks avoid generic cross-fork fallback keys to prevent
-  restoring another fork's coreboot tree.
-- ppc64 uses decoupled musl-cross-make + coreboot jobs. Each saves its cache
-  immediately rather than at the end of a long combined build.
-- musl-cross-make module auto-detects existing crossgcc using wildcard check,
-  skipping rebuild when compiler already exists from cache.
-
-## First run observations (pipeline 3789 on circleci-cache-fix branch)
-
-Cold cache run on new pipeline structure:
-- x86-musl-cross-make: 30 min (vs baseline 14.5 min) - slower due to new overhead
-- ppc64-musl-cross-make: 16 min (vs baseline 18 min) - slightly faster
-
-The Make Board step takes longer in new pipeline because it persists more
-data after build (build/, install/, crossgcc/, packages/). The real test is
-second run when cache exists - verifies if wildcard fix skips rebuild.
 
 ## Cache hash inputs
 
-Cache key hashes intentionally exclude `.circleci/config.yml` to prevent cache
-invalidation on CircleCI configuration changes. Add back once cache model is stable
-(see TODO in `.circleci/config.yml` create_hashes job).
+Hashes intentionally exclude `.circleci/config.yml` to prevent cache
+invalidation on CI config changes.  Files used:
 
-Key files included in hashes:
-- `all_modules_and_patches.sha256sums`: `./Makefile`, `./flake.lock`, `./patches/`, `./modules/`
-- `coreboot_musl-cross-make.sha256sums`: `./flake.lock`, `./modules/coreboot`, `./modules/musl-cross-make*`, `./patches/coreboot*`
-- `musl-cross-make.sha256sums`: `./flake.lock`, `./modules/musl-cross-make*`
-
-
+- `all_modules_and_patches.sha256sums`: `./Makefile`, `./flake.lock`,
+  `./patches/`, `./modules/`
+- `coreboot_musl-cross-make.sha256sums`: `./flake.lock`,
+  `./modules/coreboot`, `./modules/musl-cross-make*`,
+  `./patches/coreboot*`
+- `musl-cross-make.sha256sums`: `./flake.lock`,
+  `./modules/musl-cross-make*`

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -94,41 +94,84 @@ coreboot-talos_2_repo := https://github.com/Dasharo/coreboot
 coreboot-talos_2_commit_hash := fc47236e9877f4113dfcce07fa928f52d4d2c8ee
 $(eval $(call coreboot_module,talos_2,))
 
-# coreboot-purism: builds its own complete toolchain (no dependency on 24.02.01)
+# coreboot-purism: builds its own complete toolchain
+# (util/crossgcc/sum/ matches upstream 24.02.01, but purism is the only
+#  maintained/CI consumer of that toolchain -- sharing would add bandwidth
+#  without saving any crossgcc builds.  Unmaintained boards using 24.02.01
+#  exist under unmaintained_boards/ but are not built in CI.)
 coreboot-purism_repo := https://source.puri.sm/firmware/coreboot.git
 coreboot-purism_commit_hash := bea9947a1279be7d4a72b38a601d0288d10d1cb8
 $(eval $(call coreboot_module,purism,))
 
-# Dasharo forks - based on various coreboot upstream releases
-# IMPORTANT: Dasharo forks CANNOT share toolchains with upstream coreboot releases
-# or with each other. Dasharo uses custom FSP packages (3rdparty/dasharo-blobs/)
-# with different/missing headers vs upstream (e.g. MemInfoHob.h, FirmwareVersionInfoHob.h).
-# Each Dasharo fork therefore builds its own crossgcc toolchain (empty second arg).
+# Dasharo forks - all from github.com/dasharo/coreboot
+#
+# IMPORTANT: "Buildstack" means two separate things:
+#   1. CROSSGCC = the compiler (GCC/binutils/clang/nasm/llvm).
+#      This is what we share across forks. It is a tool like /usr/bin/gcc:
+#      it compiles whatever C code you give it, regardless of FSP headers.
+#   2. FSP BLOBS = Intel firmware blobs + headers (3rdparty/dasharo-blobs/).
+#      These are INPUTS to the compiler, not part of the compiler itself.
+#      Each board still uses its own fork's FSP blobs when building its ROM.
+#
+# Why the old comment said "CANNOT share":
+#   The original comment confused "board ROMs differ" with "toolchains differ".
+#   Different FSP blobs mean board A's ROM can't run on board B. That's true.
+#   But the COMPILER used to build those ROMs is the same: all use gcc-14.2.0,
+#   binutils-2.43.1, clang-18.1.8 from identical source tarballs built with
+#   identical buildgcc scripts (zero diff in util/crossgcc/ across all forks).
+#
+# Evidence:
+#   - util/crossgcc/sum/ files are byte-identical (same source packages)
+#   - util/crossgcc/ build scripts are byte-identical (same build options)
+#   - util/crossgcc/ has zero references to dasharo-blobs/ or FSP headers
+#   - All 8 Dasharo boards build successfully using the shared compiler
+#   - Each board's .config still has its own fork-specific FSP options
+#
+# Toolchain sharing: dasharo_nv4x is the toolchain provider.  dasharo_v56,
+# dasharo_msi_z690, and dasharo_msi_z790 consume its crossgcc via the second
+# coreboot_module() argument.  No separate "common" module needed since the
+# crossgcc packages are identical across all forks -- a second git clone of the
+# same repo+commit for toolchain-only purposes would waste bandwidth.
+#
+# CI: .circleci/config.yml "Dasharo shared toolchain" section
+#  - novacustom-nv4x_adl [seed:coreboot-24.12] is the x86_coreboot seed
+#  - v560tu, z690a_ddr4, z790p_ddr4 are build jobs (no cache)
+#  - All other Dasharo boards depend on novacustom-nv4x_adl
+# Doc: doc/circleci.md "Dasharo shared toolchain" section
+#  - Cache model, job types, and FSP explanation
+#
+# If you add/remove a Dasharo fork here, update:
+#   1. .circleci/config.yml workflow (seed vs build job)
+#   2. doc/circleci.md seed-board list and Dasharo cluster section
+#
+# Re-verify when any Dasharo fork rebases upstream:
+#   diff -r build/x86/coreboot-dasharo_nv4x/util/crossgcc/sum/ \
+#          build/x86/coreboot-dasharo_NEW/util/crossgcc/sum/
 
-# NovaCustom V560TU/V540TU (Meteor Lake)
+# NovaCustom V560TU/V540TU (Meteor Lake) -- consumes nv4x toolchain
 #  Tag: novacustom_v56x_mtl_igpu_v1.0.1 (SHA: 6de027d1)
 coreboot-dasharo_v56_repo := https://github.com/dasharo/coreboot
 coreboot-dasharo_v56_commit_hash := 6de027d1f0a62753182237ce3d793e5ba0395139
-$(eval $(call coreboot_module,dasharo_v56,))
+$(eval $(call coreboot_module,dasharo_v56,dasharo_nv4x))
 coreboot-dasharo_v56_patch_version := unreleased
 
-# NovaCustom NV4x ADL / NitroPad NS50
+# NovaCustom NV4x ADL / NitroPad NS50 -- toolchain provider for all Dasharo
 #  Tag: novacustom_nv4x_adl_v1.8.0 (SHA: 281a7fec)
 coreboot-dasharo_nv4x_repo := https://github.com/dasharo/coreboot
 coreboot-dasharo_nv4x_commit_hash := 281a7fec1a1e7aed781b12a096c2fc0f87dc51b5
 $(eval $(call coreboot_module,dasharo_nv4x,))
 
-# MSI Z790 boards
+# MSI Z790 boards -- consumes nv4x toolchain
 #  Tag: msi_ms7e06_v0.9.4 (SHA: a5a05f13)
 coreboot-dasharo_msi_z790_repo := https://github.com/dasharo/coreboot
 coreboot-dasharo_msi_z790_commit_hash := a5a05f133471c0463609631b599cdd88a623561f
-$(eval $(call coreboot_module,dasharo_msi_z790,))
+$(eval $(call coreboot_module,dasharo_msi_z790,dasharo_nv4x))
 
-# MSI Z690 boards
+# MSI Z690 boards -- consumes nv4x toolchain
 #  Tag: msi_ms7d25_v1.1.6 (SHA: be7d58da)
 coreboot-dasharo_msi_z690_repo := https://github.com/dasharo/coreboot
 coreboot-dasharo_msi_z690_commit_hash := be7d58dac9365d8981dbb1f5c6bbbcce35df8636
-$(eval $(call coreboot_module,dasharo_msi_z690,))
+$(eval $(call coreboot_module,dasharo_msi_z690,dasharo_nv4x))
 
 # T480 is based on coreboot ~25.09 release
 #  coreboot 25.09 doesn't include Thunderbolt support and support of the lower USB-C port which is still under review at https://review.coreboot.org/c/coreboot/+/75286 and https://review.coreboot.org/c/coreboot/+/88490
@@ -176,8 +219,8 @@ modules-y += $(coreboot_toolchain_module)
 # The toolchain module won't build anything for this board, we just need
 # the module prepped so we can hook up the toolchain target
 $(coreboot_toolchain_module)_output := .nobuild
-$(coreboot-toolchain_module)_configure := echo -e 'all:\n\ttouch .nobuild' > Makefile.nobuild
-$(coreboot-toolchain_module)_target := -f Makefile.nobuild
+$(coreboot_toolchain_module)_configure := printf 'all:\n\ttouch .nobuild\n' > Makefile.nobuild
+$(coreboot_toolchain_module)_target := -f Makefile.nobuild
 endif
 
 $(coreboot_module)_configure := \


### PR DESCRIPTION
`dasharo_nv4x` is the toolchain provider.  `dasharo_v56`, `dasharo_msi_z690`, `dasharo_msi_z790` consume its crossgcc via the second `coreboot_module()` argument.  All Dasharo boards except `novacustom-nv4x_adl` are `build` jobs (no cache) -- they get crossgcc from workspace and clone fork source fresh.

Fix pre-existing hyphen/underscore variable name typo in `modules/coreboot` that made the toolchain-module nobuild override a silent no-op.  Fix pre-existing portability issue: `printf` instead of `echo -e`.

Rename CI jobs for clarity: `[cache keys]`, `[ME GBE IFD]`, `[cross compiler]`, `[seed:coreboot-VERSION]`.  Update `doc/circleci.md` to document the cache model, job types, and Dasharo shared toolchain design.

Add `blobs/lib.sh` with `check_outputs()` unifying hash verification across all 10 blob download scripts.  All scripts now check output file hashes before and after processing, reporting CHECKING/OK/MISSING/HASH MISMATCH per file.  Fix fallthrough bugs, variable name mismatches, and missing pre-checks.  (2 commits)