### PR TITLE
initrd/bin/kexec-seal-key.sh tpmr.sh doc/tpm.md: fix PCR5 mismatch between LUKS DUK seal and unseal when CONFIG_USB_KEYBOARD_REQUIRED=y

### DIFF
--- a/doc/tpm.md
+++ b/doc/tpm.md
@@ -185,10 +185,14 @@ to a dedicated LUKS key slot and sealed to TPM NVRAM with the policy below.
 | 6 | `calcfuturepcr 6 /tmp/luksDump.txt` | Pre-computed LUKS header measurement |
 | 7 | `pcrread` (current value) | User CBFS files |
 
-PCR 5 is conditional: if the board loads extra kernel modules (USB HID,
-libata, HOTP token), the actual post-load PCR 5 value is used. If no extra
-modules are loaded, `calcfuturepcr 5` computes the zeroed (never-extended)
-future value. This means the seal is valid only for the expected module set.
+PCR 5 is conditional on whether the board loads extra kernel modules
+(USB HID, libata, HOTP token).  The condition in `kexec-seal-key.sh`
+checks `CONFIG_USER_USB_KEYBOARD`, `CONFIG_USB_KEYBOARD_REQUIRED`, the
+presence of `/lib/modules/libata.ko`, and `/bin/hotp_verification`.
+If any is true, the actual post-load PCR 5 value is read from hardware
+via `tpmr.sh pcrread`.  If none are true, `calcfuturepcr 5` computes
+the zeroed (never-extended) future value.  This means the seal is valid
+only for the expected module set.
 
 PCR 6 is pre-computed: `calcfuturepcr 6 /tmp/luksDump.txt` replays the
 LUKS header extension to compute the expected post-measurement value. If
@@ -424,7 +428,8 @@ To verify that a new board's coreboot config matches the expected RoT:
 | Feature | TPM 1.2 | TPM 2.0 |
 | --- | --- | --- |
 | PCR hash | SHA-1 (20 bytes) | SHA-256 (32 bytes) |
-| Sealing | `tpm sealfile2` | `tpm2 nvdefine` + policy session |
+| Sealing | `tpm sealfile2 -ix <pcr> <hash> ...` (specify PCRs and expected values) | `tpm2 nvdefine` + policy session |
+| Unsealing | `tpm unsealfile` (no PCR args — TPM enforces from baked blob) | `tpm2 unseal` with policy session |
 | Counter | `tpm nv*` | `tpm2 nvincrement` |
 | Auth sessions | Not used | Required for policy-based unseal |
 | `kexec_finalize` | No-op | Extends PCRs, then `tpm2 shutdown` |

--- a/initrd/bin/kexec-seal-key.sh
+++ b/initrd/bin/kexec-seal-key.sh
@@ -286,7 +286,7 @@ tpmr.sh pcrread -a 2 "$pcrf"
 tpmr.sh pcrread -a 3 "$pcrf"
 # Note that PCR 4 needs to be set with the "normal-boot" path value, read it from event log.
 tpmr.sh calcfuturepcr 4 >>"$pcrf"
-if [ "$CONFIG_USER_USB_KEYBOARD" = "y" ] || [ -r /lib/modules/libata.ko ] || [ -x /bin/hotp_verification ]; then
+if [ "$CONFIG_USER_USB_KEYBOARD" = "y" ] || [ "$CONFIG_USB_KEYBOARD_REQUIRED" = "y" ] || [ -r /lib/modules/libata.ko ] || [ -x /bin/hotp_verification ]; then
 	DEBUG "Sealing LUKS TPM Disk Unlock Key with PCR5 involvement (additional kernel modules are loaded per board config)..."
 	# Here, we take pcr 5 into consideration if modules are expected to be measured+loaded
 	tpmr.sh pcrread -a 5 "$pcrf"

--- a/initrd/bin/tpmr.sh
+++ b/initrd/bin/tpmr.sh
@@ -885,9 +885,11 @@ tpm1_unseal() {
 	file="$4"
 	pass="$5"
 
-	# pcrl (the PCR list) is unused in TPM1.  The TPM itself knows which
-	# PCRs were used to seal and checks them.  We can't verify that it's
-	# correct either, so just ignore it in TPM1.
+	# pcrl is unused here because tpm unsealfile (unsealfile.c) does not
+	# accept PCR arguments — only tpm sealfile2 (sealfile2.c -ix ...) does.
+	# The blob baked at seal time encodes which PCRs were selected and
+	# their expected values; TPM_Unseal() enforces PCR matching against
+	# current hardware PCRs automatically from the baked digest.
 
 	sealed_file="$SECRET_DIR/tpm1_unseal_sealed.bin"
 	at_exit cleanup_shred "$sealed_file"


### PR DESCRIPTION
Fixes #2125 

When CONFIG_USB_KEYBOARD_REQUIRED=y, Heads loads USB kernel modules at boot and extends PCR 5 with their hashes.  The LUKS DUK sealing policy includes PCR 5, so the sealed blob stores the PCR 5 value present at seal time.

The condition that decides whether PCR 5 has non-zero involvement at seal time checked CONFIG_USER_USB_KEYBOARD (a Makefile variable that defaults the USB keyboard GUI toggle to 'on') but not CONFIG_USB_KEYBOARD_REQUIRED.  Boards with the latter but not the former would seal the DUK with PCR 5 = 0 (calcfuturepcr 5 returns zero when no firmware measured into that PCR), while at unseal time on the next boot PCR 5 had been extended by the loaded USB modules.

This produced:

  tpm stdout: Error PCR mismatch from TPM_Unseal

TOTP unseal was unaffected because it excludes PCR 5 from its sealing policy.

Fix: add CONFIG_USB_KEYBOARD_REQUIRED to the condition so that boards requiring USB keyboards seal PCR 5 with the actual module-extended value, matching what the TPM sees at unseal time.

Additionally:
- Fix misleading comment in tpm1_unseal(): pcrl is not accepted by unsealfile.c, which has no -ix flag — only sealfile2.c has it.  The sealed blob carries the PCR constraints baked in by TPM_Seal() and TPM_Unseal() enforces them automatically.
- doc/tpm.md: add Unsealing row to TPM1 vs TPM2 comparison table.
- doc/tpm.md: expand PCR 5 description to list the exact condition variables checked by kexec-seal-key.sh.