### PR TITLE
README.md: add DeepWiki badge to trigger weekly documentation refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ significant frustration.
 
 More information is available in [the 33C3 presentation of building "Slightly more secure systems"](https://trmm.net/Heads_33c3).
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/linuxboot/heads)
+
 ## Documentation
 
 The `doc/` directory contains technical reference documentation for the


### PR DESCRIPTION
Closes #2127

Adds a DeepWiki badge to README.md that links to https://deepwiki.com/linuxboot/heads. The badge causes DeepWiki to periodically re-index the repository and refresh its AI-generated documentation.