### PR TITLE
musl-cross-make version bump to 1.2.6

### DIFF
--- a/modules/musl-cross-make
+++ b/modules/musl-cross-make
@@ -4,11 +4,11 @@ ifeq "$(MUSL_CROSS_ONCE)" ""
 MUSL_CROSS_ONCE := 1
 modules-$(CONFIG_MUSL) += musl-cross-make
 
-musl-cross-make_version := fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c
+musl-cross-make_version := 227df8b99103f9c59f6570babf892978e293082f
 musl-cross-make_dir := musl-cross-make-$(musl-cross-make_version)
 musl-cross-make_url := https://github.com/richfelker/musl-cross-make/archive/$(musl-cross-make_version).tar.gz
 musl-cross-make_tar := musl-cross-make-$(musl-cross-make_version).tar.gz
-musl-cross-make_hash := 15b8e0a287d738a46e069e90d67a8d96213b357b79aaf3e8cf0cd40e4b230d9e
+musl-cross-make_hash := bb3fc7851088e1e5e1274ee56a0ab6ae176043d160fdf0b71027934b091f208a
 
 # Auto-detect crossgcc from cache restore before checking CROSS env var
 CROSS_PATH := $(pwd)/crossgcc/$(CONFIG_TARGET_ARCH)

--- a/patches/kexec-2.0.26/0006-remove-arch-i386.patch
+++ b/patches/kexec-2.0.26/0006-remove-arch-i386.patch
@@ -1,0 +1,27 @@
+# binutils 2.44 rejects .arch i386 in 64-bit mode when the assembler
+# encounters .code16/.code32 transitions. These i386 entry files are
+# part of the x86_64 purgatory build and are compiled with the default
+# 64-bit target. Removing .arch i386 lets the assembler accept the
+# mode switches without changing the emitted instructions.
+# Required after musl-cross-make bumped binutils from 2.33.1 to 2.44.
+--- a/purgatory/arch/i386/entry32-16.S	2026-06-27 13:46:16.320819657 -0400
++++ b/purgatory/arch/i386/entry32-16.S	2026-06-27 13:46:16.324819745 -0400
+@@ -20,7 +20,6 @@
+ #undef i386	
+ 	.text
+ 	.globl entry16, entry16_regs
+-	.arch i386
+ 	.balign 16
+ entry16:
+ 	.code32
+
+--- a/purgatory/arch/i386/entry32-16-debug.S	2026-06-27 13:46:16.320819657 -0400
++++ b/purgatory/arch/i386/entry32-16-debug.S	2026-06-27 13:46:16.324819745 -0400
+@@ -25,7 +25,6 @@
+ 	.globl entry16_debug_pre32
+ 	.globl entry16_debug_first32
+ 	.globl entry16_debug_old_first32
+-	.arch i386
+ 	.balign 16
+ entry16_debug:
+ 	.code32


### PR DESCRIPTION
Test: kexec (x86) works without regression. Low risk, but still. An attempt to see the kind of justifications that will be needed once #2135 will be implemented.

Waiting for talos-2 to build properly before merging.

See https://github.com/linuxboot/heads/pull/2136/commits/3dfec51cf06ec038821045701684e120ec238458 details for impact (low to none) and why.