### PR TITLE
initrd/bin/kexec-boot.sh: skip --append=$cmdadd on ELF binaries without kernel args

### DIFF
--- a/initrd/bin/kexec-boot.sh
+++ b/initrd/bin/kexec-boot.sh
@@ -89,11 +89,17 @@ if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
 fi
 
 module_number="1"
+# Track whether the kernel line had command-line arguments (e.g. restval
+# is non-empty for Linux kernels, empty for standalone ELF binaries such
+# as memtest86+).  Used below to avoid forcing --append=$cmdadd on ELF
+# binaries that take no kernel arguments.
+kernel_had_args=""
 while read line; do
 	key=$(echo $line | cut -d\  -f1)
 	firstval=$(echo $line | cut -d\  -f2)
 	restval=$(echo $line | cut -d\  -f3-)
 	if [ "$key" = "kernel" ]; then
+		kernel_had_args="$restval"
 		fix_file_path
 		if [ "$kexectype" = "xen" ]; then
 			# always use xen with custom arguments
@@ -158,7 +164,12 @@ EOF
 
 if [ "$adjusted_cmd_line" = "n" ]; then
 	if [ "$kexectype" = "elf" ]; then
-		kexeccmd="$kexeccmd --append=\"$cmdadd\""
+		# Only pass $cmdadd if the kernel line had arguments --
+		# standalone ELF binaries (e.g. memtest86+) take no kernel
+		# command line and adding --append with ISO params breaks kexec.
+		if [ -n "$kernel_had_args" ]; then
+			kexeccmd="$kexeccmd --append=\"$cmdadd\""
+		fi
 	else
 		DIE "Failed to add required kernel commands: $cmdadd"
 	fi


### PR DESCRIPTION
Otherwise memtest+ (ELF) don't kexec (untested use case; bugfix of #2130)

- Track whether the parsed kernel line carried arguments (kernel_had_args=$restval) before processing the boot entry.
- Gate the ELF fallback --append=$cmdadd on kernel_had_args being non-empty, so standalone ELF binaries such as memtest86+ that declare zero kernel arguments do not get ISO-specific kernel parameters (iso-scan/filename=, findiso=, etc.) forced onto them, which causes kexec to fail.


Tested:

- [x] qemu kexec boot of memtest on pureos dvd
- [x] qemu boot of ubuntu 26.04 installed with installation defaults 
- [x] qemu boot of qubesos 4.3.1 dvd
- [x] v540tu boot of debian 13.x
- [x] v540tu of memtest on pureos dvd

![PXL_20260627_192942790.jpg](https://github.com/user-attachments/assets/60000c1c-1c59-4663-96fe-a22ac18f5094)



