### PR TITLE
initrd/bin/kexec-sign-config.sh: stop re-hashing stale default entry paths on -u update

### DIFF
--- a/initrd/bin/inject_firmware.sh
+++ b/initrd/bin/inject_firmware.sh
@@ -99,6 +99,14 @@ FW_INITRD="/tmp/inject_firmware_initrd.cpio.gz"
 dd if="$ORIG_INITRD" of="$FW_INITRD" bs=512 conv=sync status=none > /dev/null 2>&1
 # Pack up the new contents and append to the initrd.  Don't spend time
 # compressing this.
-(cd "$INITRD_ROOT"; find . | cpio -o -H newc) >>"$FW_INITRD"
+# Explicitly capture the cpio pipeline exit code: bash does not reliably
+# abort (... ) subshells on pipeline failures, so a cpio failure (disk
+# full, directory unreadable) would silently produce a truncated initrd.
+(
+	cpio_pipeline_exit=0
+	cd "$INITRD_ROOT" || exit 1
+	find . | cpio -o -H newc || cpio_pipeline_exit=$?
+	exit $cpio_pipeline_exit
+) >>"$FW_INITRD"
 # Use this initrd
 echo "$FW_INITRD"

--- a/initrd/bin/kexec-insert-key.sh
+++ b/initrd/bin/kexec-insert-key.sh
@@ -117,9 +117,16 @@ if [ "$unseal_failed" = "n" ]; then
 			done
 		done
 	fi
+	# Build the initramfs override cpio archive.
+	# Explicitly capture the cpio pipeline exit code rather than relying on
+	# set -e inside the subshell: bash does not reliably abort (...)
+	# subshells on pipeline failures, so a cpio failure (disk full, find
+	# error) would not be caught by an outer || die check alone.
 	(
-		cd "$INITRD_DIR"
-		find . -type f | cpio -H newc -o
+		cpio_pipeline_exit=0
+		cd "$INITRD_DIR" || exit 1
+		find . -type f | cpio -H newc -o || cpio_pipeline_exit=$?
+		exit $cpio_pipeline_exit
 	) >>"$SECRET_CPIO"
 fi
 STATUS_OK "Initrd prepared for kexec boot"

--- a/initrd/bin/kexec-save-default.sh
+++ b/initrd/bin/kexec-save-default.sh
@@ -306,8 +306,12 @@ fi
 rm "$stagedir"/kexec_default.*.txt 2>/dev/null || true
 echo "$entry" >"$stagedir/kexec_default.$index.txt"
 (
-	cd $bootdir && kexec-boot.sh -b "$bootdir" -e "$entry" -f |
-		xargs sha256sum >"$stagedir/kexec_default_hashes.txt"
+	hash_pipeline_exit=0
+	cd $bootdir || exit 1
+	kexec-boot.sh -b "$bootdir" -e "$entry" -f |
+		xargs sha256sum >"$stagedir/kexec_default_hashes.txt" ||
+		hash_pipeline_exit=$?
+	exit $hash_pipeline_exit
 ) || DIE "Failed to create hashes of boot files"
 if [ ! -r "$stagedir/kexec_default.$index.txt" -o ! -r "$stagedir/kexec_default_hashes.txt" ]; then
 	DIE "Failed to write default config to staging"

--- a/initrd/bin/kexec-sign-config.sh
+++ b/initrd/bin/kexec-sign-config.sh
@@ -51,18 +51,15 @@ done
 # update hashes in staging before signing
 if [ "$update" = "y" ]; then
 	(
+		hash_pipeline_exit=0
 		TRACE_FUNC
 		DEBUG "update=y: Updating kexec hashes in staging dir $stagedir"
 		cd /boot
-		find ./ -type f ! -path './kexec*' -print0 | xargs -0 sha256sum >"$stagedir/kexec_hashes.txt"
-		if [ -e /boot/kexec_default_hashes.txt ]; then
-			DEBUG "/boot/kexec_default_hashes.txt exists, updating in staging"
-			DEFAULT_FILES=$(cut -f3 -d ' ' </boot/kexec_default_hashes.txt)
-			echo "$DEFAULT_FILES" | xargs sha256sum >"$stagedir/kexec_default_hashes.txt"
-		fi
-
+		find ./ -type f ! -path './kexec*' -print0 | xargs -0 sha256sum >"$stagedir/kexec_hashes.txt" ||
+			hash_pipeline_exit=$?
 		#also save the file & directory structure to detect added files
 		print_tree >"$stagedir/kexec_tree.txt"
+		exit $hash_pipeline_exit
 	)
 	[ $? -eq 0 ] || DIE "$paramsdir: Failed to update hashes."
 fi

--- a/initrd/bin/oem-factory-reset.sh
+++ b/initrd/bin/oem-factory-reset.sh
@@ -902,14 +902,24 @@ generate_checksums() {
 	fi
 
 	STATUS "Generating /boot file hashes"
+	# Generate fresh kexec_hashes.txt and kexec_tree.txt in a subshell.
+	# Explicitly capture the pipeline exit code rather than relying on
+	# set -e -o pipefail inside the subshell: bash does not reliably abort
+	# (...) subshells on pipeline failures (enforcement depends on the type
+	# of the first command in the subshell), so a sha256sum failure on a
+	# stale path would be silently masked by print_tree returning 0.
 	(
-		set -e -o pipefail
+		hash_pipeline_exit=0
 		cd /boot
 		find ./ -type f ! -path './kexec*' -print0 |
-			xargs -0 sha256sum >/boot/kexec_hashes.txt 2>/dev/null
+			xargs -0 sha256sum >/boot/kexec_hashes.txt 2>/dev/null ||
+			hash_pipeline_exit=$?
 		print_tree >/boot/kexec_tree.txt
+		exit $hash_pipeline_exit
 	)
-	[ $? -eq 0 ] || whiptail_error_die "Error generating kexec hashes"
+	if [ $? -ne 0 ]; then
+		whiptail_error_die "Error generating kexec hashes"
+	fi
 	STATUS_OK "/boot file hashes generated"
 
 	# Collect relative basenames so sha256sum output is path-independent and

--- a/initrd/bin/root-hashes-gui.sh
+++ b/initrd/bin/root-hashes-gui.sh
@@ -49,7 +49,16 @@ update_root_checksums() {
 	STATUS "Calculating hashes for all files in $CONFIG_ROOT_DIRLIST_PRETTY"
 	# Intentional wordsplit
 	# shellcheck disable=SC2086
-	(cd "$ROOT_MOUNT" && find ${CONFIG_ROOT_DIRLIST} -type f ! -name '*kexec*' -print0 | xargs -0 sha256sum) >"${HASH_FILE}"
+	(
+		hash_pipeline_exit=0
+		# Explicitly check cd since set -e inside (... ) subshells does not
+		# reliably abort on failure (enforcement depends on the first command
+		# type), and a cd failure would leave find running in the wrong dir.
+		cd "$ROOT_MOUNT" || exit 1
+		find ${CONFIG_ROOT_DIRLIST} -type f ! -name '*kexec*' -print0 |
+			xargs -0 sha256sum || hash_pipeline_exit=$?
+		exit $hash_pipeline_exit
+	) >"${HASH_FILE}"
 
 	# switch back to ro mode
 	mount -o ro,remount /boot

--- a/initrd/etc/luks-functions.sh
+++ b/initrd/etc/luks-functions.sh
@@ -434,7 +434,17 @@ luks_reencrypt() {
 			WARN "$luks_container: unsupported LUKS version '$luks_version', skipping"
 			continue
 		fi
-		mapfile -t used_keyslots < <(cryptsetup luksDump "$luks_container" | grep -E "$ks_regex" | sed "$ks_sed")
+		# Process substitution (< <(...)) silently loses the exit code of the
+		# pipeline inside it, so a cryptsetup failure would produce an empty
+		# array with no error indication.  Capture the output and check the
+		# pipeline status explicitly.
+		luks_dump_output=""
+		luks_dump_output=$(cryptsetup luksDump "$luks_container" 2>/dev/null) ||
+			{
+				WARN "$luks_container: luksDump failed, cannot identify key slots"
+				continue
+			}
+		mapfile -t used_keyslots < <(printf '%s\n' "$luks_dump_output" | grep -E "$ks_regex" | sed "$ks_sed")
 		DEBUG "$luks_container: used keyslots: ${used_keyslots[*]}"
 
 		DRK_KEYSLOT=""


### PR DESCRIPTION
[Updated 2026-07-07: this description has been significantly revised since first opened. See commits and comments for full history.]

Remove the -u block that re-hashed file paths extracted from the old kexec_default_hashes.txt.  Those paths are from a previously saved default boot entry.  When a distro replaces a versioned boot file in-place (e.g. xen-4.19.4.gz to xen-4.19.5.gz), the old path no longer exists on disk and sha256sum fails.

The re-hash was redundant: the find ./ -type f ! -path "./kexec*" -print0 | xargs -0 sha256sum command in the same -u block already generates a complete, fresh hash of all current /boot files.  The user re-saves the default boot entry from the boot menu to regenerate kexec_default_hashes.txt with current paths.

### Root cause

The rehash also behaved unpredictably across bash builds.  Before commit 1f6a9759405 (2025-02-07), the subshell had no TRACE_FUNC and set -e was not enforced on the pipeline failure: the sha256sum error was silently masked by print_tree returning 0, the subshell exited 0, and a partial hash file was signed.  After 1f6a9759405 placed TRACE_FUNC as the first command inside the subshell, set -e became enforced, making the same pipeline failure fatally abort the subshell before print_tree could mask it.

This is a known bug in bash 5.1 execute_cmd.c: when the first command in a (... ) subshell is a builtin (cd), the executing subshell path pollutes the builtin_ignoring_errexit state, causing exit_immediately_on_error to be set to 0.  When the first command is a function call, the execute_shell_function() path uses its own setjmp/longjmp context that does not touch the errexit state.  Fixed in bash 5.2 and documented in [BashFAQ/105](https://mywiki.wooledge.org/BashFAQ/105).

### Additional fixes

This PR also includes a second commit that hardens every (... ) subshell with a pipeline across the codebase against the same class of bug, using an explicit exit code capture pattern:

    pipeline_exit=0
    cmd | other_cmd || pipeline_exit=$?
    exit $pipeline_exit

Files changed:
- initrd/bin/oem-factory-reset.sh — hash generation subshell
- initrd/bin/root-hashes-gui.sh — root hash computation subshell
- initrd/bin/kexec-insert-key.sh — initramfs cpio archive subshell
- initrd/bin/inject_firmware.sh — firmware initrd injection subshell
- initrd/bin/kexec-save-default.sh — default boot hash creation subshell
- initrd/etc/luks-functions.sh — DRK keyslot detection process substitution

### Mitigation on unpatched firmware

    mount -o remount,rw /boot
    touch /boot/xen-4.19.4.gz
    mount -o remount,ro /boot

Then re-run Update checksums.  With the file existing, rehashing will work as expected saying files changed as usual.  Then set a new default from the boot menu to regenerate kexec_default_hashes.txt with current paths.