### PR TITLE
initrd/bin/kexec-save-default.sh: skip symlinks when finding crypttabfiles

### DIFF
--- a/initrd/bin/kexec-save-default.sh
+++ b/initrd/bin/kexec-save-default.sh
@@ -326,7 +326,7 @@ if [ "$save_key" = "y" ]; then
 
 	DEBUG "Extracting $current_default_initrd to find crypttab files"
 	unpack_initramfs.sh "$current_default_initrd" "$initrd_decompressed"
-	crypttab_files=$(find "$initrd_decompressed" | grep crypttab 2>/dev/null) || true
+	crypttab_files=$(find "$initrd_decompressed" -type f | grep crypttab 2>/dev/null) || true
 
 	if [ ! -z "$crypttab_files" ]; then
 		DEBUG "Found crypttab files in $current_default_initrd"


### PR DESCRIPTION
- NixOS initrds contain /etc/crypttab as a symlink to a Nix store path (e.g. /nix/store/[hash]-initrd-crypttab). When unpacked into /tmp/initrd_extract, the symlink target is an absolute path that does not exist on the Heads recovery system, making cat fail.
- find without -type f matched the dangling symlink, causing cat to error out inside a pipefail pipeline, which killed the crypttab parsing loop and caused kexec-save-default.sh to fail.
- Add -type f to only match regular files, skipping symlinks.

As a result, a crypttab is generated pointing key unsealed and injected TPM DUK through passphrase in additional cpio passed alongside initramfs on kexec call, and that injected cpio successfully decrypt my 2 luks container setup described under #2154

It is to note that unencrypted /boot support option from installer was sadly completely removed in the aftermath of https://github.com/linuxboot/heads/issues/1348. I am unaware of when /boot got completely removed, which I find sad, requiring manual partitioning. At least, this PR permits TPM DUK on "brainless" partitionning scheme, where iniramfs can decrypt rootfs partitioning with swap, without needing rootfs to be already decrypted. If someone is from/within NixOS and wants to tackle the installer issues, be my guest :)

Fixes https://github.com/linuxboot/heads/issues/2154


----

### Notes on NixOS installer custom partitioning requirements
- 2048M ext4 unencrypted, specify /boot mountpoint and **grub-bios ticked**
- 4096M swap, tick encrypted, put passphrase that will be same then rootfs
- Rest of unpartition space ext4, specify / mountpoint,  tick encrypted, put passphrase that will be same then swap