### PR TITLE
doc/BOARDS_AND_TESTERS.md : make clear @nestire board owner of T480

### DIFF
--- a/doc/BOARDS_AND_TESTERS.md
+++ b/doc/BOARDS_AND_TESTERS.md
@@ -58,8 +58,8 @@ xx4x (Haswell: Intel 4th Gen CPU)
 
 xx8x (Kaby Lake Refresh: Intel 8th Gen Mobile : ESU ended 12/31/2024)
 ===
-- [ ] t480: @gaspar-ilom @doritos4mlady @MattClifton76 @notgivenby @akunterkontrolle
-- [ ] t480s: @thickfont @kjkent @HarleyGodfrey @nestire
+- [ ] t480: @gaspar-ilom @doritos4mlady @MattClifton76 @notgivenby @akunterkontrolle @nestire (Nitrokey)
+- [ ] t480s: @thickfont @kjkent @HarleyGodfrey @nestire (Nitrokey)
 
 Librem
 ===


### PR DESCRIPTION
as sold by Nitrokey (issue: https://github.com/linuxboot/heads/issues/2159)