### PR TITLE
Fix regression OEM factory reset for Nitrokey Storage 2

### DIFF
--- a/initrd/bin/oem-factory-reset.sh
+++ b/initrd/bin/oem-factory-reset.sh
@@ -701,6 +701,9 @@ gpg_key_factory_reset() {
 	if [ "$DONGLE_BRAND" = "Nitrokey Storage" ] && [ -x /bin/hotp_verification ]; then
 		STATUS "Resetting Nitrokey Storage AES keys"
 		hotp_verification regenerate ${ADMIN_PIN_DEF}
+		# see https://github.com/Nitrokey/heads/commit/397a46203bedcb77aeac24917e7fe254465128fb
+		STATUS "Restarting scdaemon to remove possible exclusive lock of dongle"
+		killall -9 scdaemon
 		STATUS_OK "Nitrokey Storage AES keys reset"
 	fi
 


### PR DESCRIPTION
This fixes a regression from https://github.com/linuxboot/heads/commit/eb84f1b52f8ad25f012eda2f5e96e8012251dfc3 that let the OEM Factory Reset fail for the Nitrokey Storage 2. 

The Original fix for this was: https://github.com/Nitrokey/heads/commit/397a46203bedcb77aeac24917e7fe254465128fb