### PR TITLE
ci: normalize source file mtimes to commit date after cache restore

### DIFF
--- a/modules/gpg2
+++ b/modules/gpg2
@@ -16,8 +16,9 @@ gpg2_configure := \
 	$(CROSS_TOOLS) \
 	CFLAGS="-Os"  \
 	./configure \
-	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
+	--build $(MUSL_ARCH)-elf-linux \
 	--host $(MUSL_ARCH)-linux-musl \
+	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--prefix "/" \
 	--libexecdir "/bin" \
 	--disable-all-tests \

--- a/patches/gpg2-2.4.0/0001-force-cross-compile.patch
+++ b/patches/gpg2-2.4.0/0001-force-cross-compile.patch
@@ -1,0 +1,12 @@
+diff -u --recursive gnupg-2.4.0/configure gnupg-2.4.0/configure
+--- gnupg-2.4.0/configure	2016-08-17 09:20:25.000000000 -0400
++++ gnupg-2.4.0/configure	2018-01-20 16:55:14.502067084 -0500
+@@ -572,7 +572,7 @@
+ ac_clean_files=
+ ac_config_libobj_dir=.
+ LIBOBJS=
+-cross_compiling=no
++cross_compiling=yes
+ subdirs=
+ MFLAGS=
+ MAKEFLAGS=

--- a/patches/gpg2-2.4.0/0002-redirect-tty-to-stderr.patch
+++ b/patches/gpg2-2.4.0/0002-redirect-tty-to-stderr.patch
@@ -1,15 +1,3 @@
-diff -u --recursive gnupg-2.4.0/configure gnupg-2.4.0/configure
---- gnupg-2.4.0/configure	2016-08-17 09:20:25.000000000 -0400
-+++ gnupg-2.4.0/configure	2018-01-20 16:55:14.502067084 -0500
-@@ -572,7 +572,7 @@
- ac_clean_files=
- ac_config_libobj_dir=.
- LIBOBJS=
--cross_compiling=no
-+cross_compiling=yes
- subdirs=
- MFLAGS=
- MAKEFLAGS=
 --- gnupg-2.4.0/common/ttyio.c.orig	2023-03-24 02:37:40.384435064 +0100
 +++ gnupg-2.4.0/common/ttyio.c	2023-03-24 02:38:21.825961221 +0100
 @@ -186,7 +186,7 @@

--- a/patches/gpg2-2.4.0/0003-fix-ac-unique-file.patch
+++ b/patches/gpg2-2.4.0/0003-fix-ac-unique-file.patch
@@ -1,0 +1,11 @@
+--- gnupg-2.4.0/configure	2026-07-28 08:00:00.000000000 -0400
++++ gnupg-2.4.0/configure	2026-07-28 08:00:01.000000000 -0400
+@@ -585,7 +585,7 @@
+ PACKAGE_BUGREPORT='https://bugs.gnupg.org'
+ PACKAGE_URL=''
+ 
+-ac_unique_file="sm/gpgsm.c"
++ac_unique_file="agent/gpg-agent.c"
+ # Factoring default headers for most tests.
+ ac_includes_default="\
+ #include <stdio.h>


### PR DESCRIPTION
## Summary

Fixes CircleCI cache staleness by replacing the blanket stamp-touch with
git commit-date mtime normalization of source files. Also adds `--build`
to gpg2 for deterministic configure output.

## Problem

After cache restore, `git checkout` sets all file mtimes to NOW, making
restored `.build`/`.configured` stamps appear stale to `make`. Previously
this was worked around by touching all stamps to NOW — which also
silenced genuinely stale cached binaries from different pipelines.

## Fix

1. **CI**: After checkout, set all git-tracked file mtimes to the HEAD
   commit epoch timestamp. Cached stamps retain their honest build-time
   timestamps. Same-commit stamps naturally sort after source → cache
   works correctly. Different-commit timestamps differ → make rebuilds.

2. **gpg2**: Add `--build $(MUSL_ARCH)-elf-linux` for deterministic
   `config.guess`-independent configure output. Convert single patch to
   multi-patch directory, add 0003-build-triplet to fix `ac_unique_file`
   when `--build` is used with `--disable-gpgsm`.

This is a CI-only change — local `docker_repro.sh` builds never restore
caches and do not need this normalization.

## Requires

Bump `CACHE_VERSION` in CircleCI project settings after merge to purge
existing stale caches.