### PR TITLE
initrd: replace all direct killall with release_scdaemon

### DIFF
--- a/initrd/bin/oem-factory-reset.sh
+++ b/initrd/bin/oem-factory-reset.sh
@@ -701,6 +701,9 @@ gpg_key_factory_reset() {
 	if [ "$DONGLE_BRAND" = "Nitrokey Storage" ] && [ -x /bin/hotp_verification ]; then
 		STATUS "Resetting Nitrokey Storage AES keys"
 		hotp_verification regenerate ${ADMIN_PIN_DEF}
+		# see https://github.com/Nitrokey/heads/commit/397a46203bedcb77aeac24917e7fe254465128fb
+		STATUS "Restarting scdaemon to remove possible exclusive lock of dongle"
+		release_scdaemon
 		STATUS_OK "Nitrokey Storage AES keys reset"
 	fi
 
@@ -1389,7 +1392,7 @@ assert_signable
 
 # clear gpg-agent and scdaemon cache so that next gpg calls don't have stale state
 # scdaemon holds exclusive CCID lock to dongle - must be killed to allow fresh card access
-killall gpg-agent scdaemon >/dev/null 2>&1 || true
+release_scdaemon
 # clear local keyring
 rm -rf /.gnupg/*.kbx /.gnupg/*.gpg >/dev/null 2>&1 || true
 

--- a/initrd/bin/seal-hotpkey.sh
+++ b/initrd/bin/seal-hotpkey.sh
@@ -63,7 +63,7 @@ STATUS_OK "$DONGLE_BRAND detection ready for HOTP configuration"
 TRACE_FUNC
 
 # Make sure no conflicting GPG related services are running, gpg-agent will respawn
-DO_WITH_DEBUG killall gpg-agent scdaemon >/dev/null 2>&1 || true
+DO_WITH_DEBUG release_scdaemon
 
 # Query hotp_verification info and extract numeric PIN retry counter.
 # Retries up to N times on communication failure.  Dies if the dongle

--- a/initrd/etc/functions.sh
+++ b/initrd/etc/functions.sh
@@ -808,6 +808,7 @@ hotpkey_fw_display() {
 # immediately.  Both must be killed; gpg-agent and scdaemon respawn on demand
 # for the next GPG operation.
 release_scdaemon() {
+	TRACE_FUNC
 	DEBUG "release_scdaemon: killing gpg-agent and scdaemon to release CCID lock"
 	killall gpg-agent scdaemon >/dev/null 2>&1 || true
 }


### PR DESCRIPTION
Supersedes #2167.

- oem-factory-reset.sh: add release_scdaemon after NK Storage AES key reset
  to release CCID lock (fixes regression from eb84f1b5)
- oem-factory-reset.sh: replace inline killall at top of main with release_scdaemon
- seal-hotpkey.sh: replace inline killall with DO_WITH_DEBUG release_scdaemon
- No direct killall to gpg-agent/scdaemon remains outside release_scdaemon body