### PR TITLE
modules/gpg2: add --build for deterministic configure output

### DIFF
--- a/modules/gpg2
+++ b/modules/gpg2
@@ -12,12 +12,17 @@ gpg2_depends := libgpg-error libgcrypt libksba libassuan npth libusb $(musl_dep)
 # be generated with the correct paths, but then re-write them when
 # we use the install target so that they will be copied to the correct
 # location.
+# --build is required because autoconf's config.guess probes the Docker
+# host kernel (uname -r, /proc) -- Docker containers share the host kernel,
+# not a virtualized one.  Different CircleCI runners have different host
+# kernels, producing different build triplets and non-reproducible output.
 gpg2_configure := \
 	$(CROSS_TOOLS) \
 	CFLAGS="-Os"  \
 	./configure \
-	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
+	--build $(MUSL_ARCH)-elf-linux \
 	--host $(MUSL_ARCH)-linux-musl \
+	CPPFLAGS="-I$(INSTALL)/include/libusb-1.0" \
 	--prefix "/" \
 	--libexecdir "/bin" \
 	--disable-all-tests \

--- a/patches/gpg2-2.4.0/0001-force-cross-compile.patch
+++ b/patches/gpg2-2.4.0/0001-force-cross-compile.patch
@@ -1,0 +1,12 @@
+diff -u --recursive gnupg-2.4.0/configure gnupg-2.4.0/configure
+--- gnupg-2.4.0/configure	2016-08-17 09:20:25.000000000 -0400
++++ gnupg-2.4.0/configure	2018-01-20 16:55:14.502067084 -0500
+@@ -572,7 +572,7 @@
+ ac_clean_files=
+ ac_config_libobj_dir=.
+ LIBOBJS=
+-cross_compiling=no
++cross_compiling=yes
+ subdirs=
+ MFLAGS=
+ MAKEFLAGS=

--- a/patches/gpg2-2.4.0/0002-redirect-tty-to-stderr.patch
+++ b/patches/gpg2-2.4.0/0002-redirect-tty-to-stderr.patch
@@ -1,15 +1,3 @@
-diff -u --recursive gnupg-2.4.0/configure gnupg-2.4.0/configure
---- gnupg-2.4.0/configure	2016-08-17 09:20:25.000000000 -0400
-+++ gnupg-2.4.0/configure	2018-01-20 16:55:14.502067084 -0500
-@@ -572,7 +572,7 @@
- ac_clean_files=
- ac_config_libobj_dir=.
- LIBOBJS=
--cross_compiling=no
-+cross_compiling=yes
- subdirs=
- MFLAGS=
- MAKEFLAGS=
 --- gnupg-2.4.0/common/ttyio.c.orig	2023-03-24 02:37:40.384435064 +0100
 +++ gnupg-2.4.0/common/ttyio.c	2023-03-24 02:38:21.825961221 +0100
 @@ -186,7 +186,7 @@

--- a/patches/gpg2-2.4.0/0003-fix-ac-unique-file.patch
+++ b/patches/gpg2-2.4.0/0003-fix-ac-unique-file.patch
@@ -1,0 +1,11 @@
+--- gnupg-2.4.0/configure	2026-07-28 08:00:00.000000000 -0400
++++ gnupg-2.4.0/configure	2026-07-28 08:00:01.000000000 -0400
+@@ -585,7 +585,7 @@
+ PACKAGE_BUGREPORT='https://bugs.gnupg.org'
+ PACKAGE_URL=''
+ 
+-ac_unique_file="sm/gpgsm.c"
++ac_unique_file="agent/gpg-agent.c"
+ # Factoring default headers for most tests.
+ ac_includes_default="\
+ #include <stdio.h>


### PR DESCRIPTION
Without --build, config.guess probes the Docker host kernel and produces
different build triplets on different CI runners, causing gpg-agent output to
differ between CI and local builds at the same commit.

Add --build x86_64-elf-linux following the proven pattern from modules/gpg
(v1.4.21). Convert single patch to multi-patch directory:
  - 0001-force-cross-compile.patch: set cross_compiling=yes
  - 0002-redirect-tty-to-stderr.patch: redirect tty for initrd
  - 0003-fix-ac-unique-file.patch: fix source check for --build + --disable-gpgsm

Verified: CI pipeline on tlaurion/heads shows gpg-agent hash matches clean
local build at the same commit.