### PR TITLE
modules/musl-cross-make: fix cross-compiler reproducibility

### DIFF
--- a/modules/musl-cross-make
+++ b/modules/musl-cross-make
@@ -42,11 +42,13 @@ else
 # No need to build i386 for x86 since coreboot uses its own compiler
 musl-cross-make_configure := \
 	echo -e >> Makefile 'musl-target:' ; \
-	echo -e >> Makefile '\t$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ;
+	echo -e >> Makefile '\t$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ; \
+	echo -e 'BUILD = x86_64-pc-linux-gnu\nCOMMON_CONFIG += CFLAGS="-Wa,--no-pad-sections"\nCOMMON_CONFIG += --with-debug-prefix-map=$(pwd)=.\nBINUTILS_CONFIG += --enable-compressed-debug-sections=no' >> config.mak
 
 CROSS_PATH ?= $(pwd)/crossgcc/$(CONFIG_TARGET_ARCH)
 
-musl-cross-make_target := \
+musl-cross-make_target = \
+	SOURCE_DATE_EPOCH=$(shell cd $(build)/$(musl-cross-make_dir) && git log -1 --format=%ct 2>/dev/null || echo 0) \
 	OUTPUT="$(CROSS_PATH)" \
 	MAKE="$(MAKE)" \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
The musl-cross-make version bump (fd6be58 -> 227df8b) upgraded binutils
from 2.33.1 to 2.44.  Gas 2.44 introduced section-end padding by default
and changed NOP padding behavior on x86, making object file output
non-deterministic between build runs.

Fix:
- Pass -Wa,--no-pad-sections via CFLAGS to restore gas 2.33.1 behavior
- Disable debug section compression (--enable-compressed-debug-sections=no)

Additionally fix two pre-existing reproducibility gaps:
- Override BUILD triplet (x86_64-pc-linux-gnu) via config.mak to prevent
  config.guess from probing the Docker host kernel (different CI runners
  have different host kernels)
- Export SOURCE_DATE_EPOCH from the pinned musl-cross-make commit epoch
  to prevent __DATE__/__TIME__ embedding during the GCC build

Expected: two clean builds of the same commit produce identical
cross-compiler output regardless of which CI runner executes the build.