### PR TITLE
build: complete warm-build hashes.txt coverage (bzImage, tools.cpio, initrd.cpio.xz FORCE; busybox symlinks fix; doc cleanup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -863,7 +863,8 @@ endif
 $(build)/$(initrd_dir)/tools.cpio: \
 	$(initrd_bins) \
 	$(initrd_libs) \
-	$(initrd_tools_dir)/etc/config
+	$(initrd_tools_dir)/etc/config \
+	FORCE
 	$(call do-cpio,$@,$(initrd_tools_dir))
 	@$(RM) -rf "$(initrd_tools_dir)"
 
@@ -921,10 +922,10 @@ $(build)/$(initrd_dir)/heads.cpio: $(HEADS_INITRD_FILES) FORCE
 
 # --- FINAL INITRD PACKAGING ---
 
-$(build)/$(initrd_dir)/initrd.cpio.xz: $(initrd-y)
+$(build)/$(initrd_dir)/initrd.cpio.xz: $(initrd-y) FORCE
 	$(call do,CPIO-XZ  ,$@,\
 	$(pwd)/bin/cpio-clean.pl \
-		$^ \
+		$(filter-out FORCE,$^) \
 	| xz \
 		--check=crc32 \
 		--lzma2=dict=1MiB \

--- a/Makefile
+++ b/Makefile
@@ -1103,7 +1103,7 @@ define overwrite_canary_if_coreboot_git
 endef
 
 real.clean:
-	@echo "Cleaning build artifacts and install directories, leaving crossgcc intact."
+	@echo "Removing module build output under build/ and clearing install/; downloaded sources (packages/) and crossgcc are left intact."
 	for dir in \
 		$(module_dirs) \
 		$(kernel_headers) \
@@ -1116,20 +1116,20 @@ real.clean:
 	$(call overwrite_canary_if_coreboot_git)
 
 real.gitclean:
-	@echo "Cleaning the repository using Git ignore file as a base..."
-	@echo "This will wipe everything not in the Git tree, but keep downloaded coreboot forks (detected as Git repos)."
+	@echo "Removing all untracked and ignored files (git clean -fxd)."
+	@echo "Git-tracked submodules and nested .git directories are preserved (e.g., coreboot forks)."
 	git clean -fxd
 	$(call overwrite_canary_if_coreboot_git)
 
 real.gitclean_keep_packages:
-	@echo "Cleaning the repository using Git ignore file as a base..."
-	@echo "This will wipe everything not in the Git tree, but keep the 'packages' directory."
+	@echo "Removing all untracked and ignored files (git clean -fxd), keeping packages/."
+	@echo "Preserves downloaded source tarballs in packages/ for reuse."
 	git clean -fxd -e "packages"
 	$(call overwrite_canary_if_coreboot_git)
 
 real.remove_canary_files-extract_patch_rebuild_what_changed:
-	@echo "Removing 'canary' files to force Heads to restart building board configurations..."
-	@echo "This will check package integrity, extract them, redo patching on files, and rebuild what needs to be rebuilt."
+	@echo "Removing .canary files (build stamps) to force rebuild of board configurations."
+	@echo "The next 'make' will then re-extract packages, re-apply patches, and rebuild changed targets (date-based)."
 	@echo "It will also reinstall the necessary files under './install'."
 	@echo "Limitations: If a patch creates a file in an extracted package directory, this approach may fail without further manual actions."
 	@echo "In such cases, Git will inform you about the file that couldn't be created as expected. Simply delete those files and relaunch the build."
@@ -1147,7 +1147,7 @@ real.remove_canary_files-extract_patch_rebuild_what_changed:
 	$(call overwrite_canary_if_coreboot_git)
 
 real.gitclean_keep_packages_and_build:
-	@echo "Cleaning the repository using Git ignore file as a base..."
-	@echo "This will wipe everything not in the Git tree, but keep the 'packages' and 'build' directories."
+	@echo "Removing all untracked and ignored files (git clean -fxd), keeping packages/ and build/."
+	@echo "Preserves downloaded sources and build artifacts for reuse."
 	git clean -fxd -e "packages" -e "build"
 	$(call overwrite_canary_if_coreboot_git)

--- a/doc/reproducible-builds.md
+++ b/doc/reproducible-builds.md
@@ -112,11 +112,16 @@ fetch_source_archive.sh.
 ## Verifying ROM Reproducibility
 
 ### Prerequisites
-- Same git commit on both CI and local
+- Same git commit on both CI and local (different commits produce different ROMs — see below)
 - Build with `docker_repro.sh` locally (same Docker image as CI)
-- For a complete `hashes.txt`, use `real.gitclean_keep_packages` first.
-  Warm (cached) builds produce partial `hashes.txt` — only rebuilt targets
-  re-append their hashes.
+- Clean working tree (no uncommitted changes) — a dirty tree adds `dirty` to GIT_STATUS in build metadata, which changes ROM output
+- Download CI `hashes.txt` from CircleCI artifacts for the same commit (see
+  [Downloading Heads](https://osresearch.net/Downloading) for details).
+  Example URL:
+  ```bash
+  wget -O /tmp/ci-hashes.txt \
+    "https://output.circle-artifacts.com/output/job/circleci-job-id/artifacts/0/build/x86/EOL_t480-hotp-maximized/hashes.txt"
+  ```
 
 ### Understanding hashes.txt
 
@@ -139,38 +144,36 @@ separated by `-----` lines:
 -----
 ```
 
-### GIT_HASH in /etc/config
+### Same commit: everything should match
 
-`tools.cpio` contains `./etc/config`, which embeds `GIT_HASH` from `git rev-parse HEAD`
-(in the `/etc/config` generation rule).  Every commit changes `GIT_HASH`, so `./etc/config` differs
-between ANY two commits.  This cascades: `./etc/config` → `tools.cpio` →
-`initrd.cpio.xz` → ROM.
+When CI and local build the **same git commit**, the ROM hash should match.
+If it does, the build is reproducible:
 
-When `./etc/config` is the **only** differing file inside `tools.cpio`, the
-build is still reproducible — all binaries (busybox, kexec, gpg, etc.) are
-byte-identical.  A binary mismatch (e.g. `./bin/busybox`) is the actual
-reproducibility bug to investigate.
-
-### Steps
-
-1. Build locally and download CI `hashes.txt` for the same commit.
-
-2. Compare ROM hashes — if they match, the build is reproducible. Done.
 ```bash
 grep '\.rom' /tmp/ci-hashes.txt build/x86/EOL_t480-hotp-maximized/hashes.txt
 ```
 
-3. If the ROM differs, step down: `initrd.cpio.xz`/`bzImage` → `tools.cpio` →
+If the ROM differs, step down: `initrd.cpio.xz`/`bzImage` → `tools.cpio` →
 individual files.  The innermost differing file (e.g. `./bin/busybox`) is the
 root cause — fix it and the cascade resolves.  `hashes.txt` records every file
-at every level, so no diffoscope is needed until you've identified what differs.
+at every level so no diffoscope is needed until you've identified what differs.
 
-4. For a comprehensive check:
+For a comprehensive same-commit check:
 ```bash
-diff <(grep '^[0-9a-f]\{64\}' /tmp/ci-hashes.txt | awk '{print $1}' | sort) \
-     <(grep '^[0-9a-f]\{64\}' build/x86/EOL_t480-hotp-maximized/hashes.txt | awk '{print $1}' | sort)
+diff <(grep '^[0-9a-f]\{64\}' /tmp/ci-hashes.txt | sort) \
+     <(grep '^[0-9a-f]\{64\}' build/x86/EOL_t480-hotp-maximized/hashes.txt | sort)
 ```
+Zero output = all hash and path entries match.
 
-`./etc/config` inside `tools.cpio` always differs between commits (contains
-`GIT_HASH`).  Its cascade through `tools.cpio`/`initrd.cpio.xz`/ROM is expected;
-only a binary mismatch is a reproducibility bug.
+### Different commits: ROMs always differ
+
+`tools.cpio` contains `./etc/config`, which embeds `GIT_HASH` from
+`git rev-parse HEAD`.  Every commit changes `GIT_HASH`, so `./etc/config`
+differs between ANY two commits.  This cascades: `./etc/config` → `tools.cpio`
+→ `initrd.cpio.xz` → ROM.  The ROM hash WILL differ between different commits —
+this is expected.
+
+When `./etc/config` is the **only** differing file inside `tools.cpio`, the
+build is still reproducible — all binaries (busybox, kexec, gpg, etc.) are
+byte-identical.  A binary mismatch is the actual reproducibility bug to
+investigate.

--- a/modules/busybox
+++ b/modules/busybox
@@ -11,6 +11,8 @@ busybox_hash := b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 busybox_configure := $(MAKE) CC="$(heads_cc)" oldconfig
 busybox_config := config/busybox.config
 busybox_output := busybox
+# Host compiler used by applets/busybox.mkll (busybox's Makefile uses gcc too)
+busybox_hostcc ?= gcc
 busybox_target := \
 	$(CROSS_TOOLS) \
 	$(MAKE_JOBS) \
@@ -33,10 +35,13 @@ initrd_bins += $(initrd_bin_dir)/busybox
 endif
 
 $(initrd_bin_dir)/busybox: $(build)/$(busybox_dir)/.build
+	# Regenerate busybox.links (may be missing after clean/cache restore)
 	$(call do,INSTALL,bin/busybox,\
 		cp $(build)/$(busybox_dir)/busybox \
 			$(initrd_bin_dir)/busybox && \
 		cd $(build)/$(busybox_dir) && \
+		HOSTCC="$(busybox_hostcc)" $(SHELL) applets/busybox.mkll include/autoconf.h include/applets.h > busybox.links && \
+		test -s busybox.links && \
 		$(SHELL) applets/install.sh $(initrd_bin_dir)/.. --symlinks \
 	)
 	# Remove busybox's reboot symlink that conflicts with our custom script

--- a/modules/linux
+++ b/modules/linux
@@ -200,9 +200,15 @@ $(build)/$(BOARD)/modules.cpio: $(build)/$(linux_dir)/.build FORCE
 # The output of the linux.intermediate is usually the bzImage in the
 # linux build directory.  We need to copy it into our board
 # specific directory for ease of locating it later.
-$(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build
-	$(call do-copy,$(dir $<)/$(linux_output),$@)
-	@touch $@ # force a timestamp update
+$(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build FORCE
+	$(call do-copy,$(dir $<)/$(linux_output),$@.tmp)
+	@if ! cmp --quiet "$@.tmp" "$@" ; then \
+		mv "$@.tmp" "$@" ; \
+		touch "$@" ; \
+	else \
+		echo "$(DATE) UNCHANGED $(@:$(pwd)/%=%)" ; \
+		rm "$@.tmp" ; \
+	fi
 	@sha256sum "$@" | tee -a "$(HASHES)"
 	@stat -c "%8s:%n" "$@" | tee -a "$(SIZES)"
 


### PR DESCRIPTION
Supersedes #2178. Completes the warm-build `hashes.txt` completeness work started in #2174. Fixes emergency bug introduced by #2174.

## Commit 1: `build: improve clean target @echo messages and fix reproducibility doc`

### Makefile clean targets
- Rewrite `real.gitclean` / `gitclean_keep_packages` / `gitclean_keep_packages_and_build` @echo messages to name the `git clean -fxd` command and describe exact preserve rules
- Tighten `real.remove_canary_files-extract_patch_rebuild_what_changed` @echo messages: make clear this target deletes `.canary` stamps and the re-extract/rebuild cascade happens on the next `make` invocation

### doc/reproducible-builds.md verification section
- Split verification into "Same commit: everything should match" vs "Different commits: ROMs always differ" (GIT_HASH in /etc/config causes expected cascade)
- Remove stale `real.gitclean_keep_packages` prerequisite -- after #2174 FORCE fixes, warm builds produce complete `hashes.txt`
- Remove incorrect warm-build partial-hashes.txt claim
- Add CI `hashes.txt` download reference with CircleCI artifact URL example
- Add clean working tree prerequisite (dirty tree sets `GIT_STATUS=dirty`, changing ROM output)
- Restore `bzImage` in same-commit step-down path
- Upgrade comprehensive diff from hash-only to hash+path comparison

## Commit 2: `modules/linux: add FORCE and UNCHANGED guard to bzImage rule; fix busybox symlinks`

### bzImage FORCE + UNCHANGED
- Add `FORCE` to bzImage copy/hash rule prerequisite -- matching the `modules.cpio` fix in #2174 -- so warm builds always re-run the recipe that records the kernel hash
- Replace direct `do-copy`-to-target with cmp-based UNCHANGED pattern: copy to `.tmp`, compare, `mv` only when changed, print `UNCHANGED` when identical, always append hash/size to `hashes.txt`
- When unchanged, preserve mtime to prevent cascading `.bundled` rebuild

### Emergency fix: busybox symlinks broken by #2174
- #2174 replaced `make install` with `applets/install.sh --symlinks` to avoid re-linking without `SOURCE_DATE_EPOCH`. However, `install.sh` reads symlink names from `busybox.links`, which was not regenerated and is missing after cache restore or `make clean`. Result: only the bare `busybox` binary was installed; all 137 applet symlinks (`[`, `ash`, `cat`, `cp`, `ls`, ...) were absent from `tools.cpio`, breaking the initrd.
- Fix: regenerate `busybox.links` via `applets/busybox.mkll` before calling `install.sh`, using `HOSTCC=gcc` (needed outside busybox's make context) and `include/autoconf.h` (busybox 1.36.1 uses this, not `config.h`), with a `test -s` guard so empty generation fails the build loudly.

## Verification (commit `c4c59764b64`)

Built locally with `./docker_repro.sh make BOARD=EOL_t480-hotp-maximized` (warm build, `clean` GIT_STATUS).

137 busybox symlinks now present in `tools.cpio`:
```
$ cpio -itv < tools.cpio | grep -c -- "-> busybox"
137
$ cpio -itv < tools.cpio | grep -- "-> busybox" | head -5
lrwx------   0 root    0 root    7 Dec 31  1969 bin/[ -> busybox
lrwx------   0 root    0 root    7 Dec 31  1969 bin/[[ -> busybox
lrwx------   0 root    0 root    7 Dec 31  1969 bin/ash -> busybox
lrwx------   0 root    0 root    7 Dec 31  1969 bin/cat -> busybox
lrwx------   0 root    0 root    7 Dec 31  1969 bin/cp -> busybox
```

Local ROM hash: [pending]
CI cross-check: [pending CircleCI pipeline for `c4c59764b64`]
