### PR TITLE
build: complete warm-build hashes.txt coverage (fix #2174 gaps; busybox symlinks; doc cleanup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,12 +271,24 @@ else
 # verification before flashing (see flash-gui.sh).  The ZIP package format
 # allows other metadata that might be needed to added in the future without
 # breaking backward compatibility.
+# --- UPDATE PACKAGE (ZIP) ---
+#
+# The update zip contains three files:
+#   <rom-file>      - The Heads ROM image (16 MiB flashable image)
+#   sha256sum.txt   - SHA-256 of the ROM only (for update integrity checks)
+#   hashes.txt      - Per-file hash manifest for reproducibility
+#                      verification (same-commit CI comparison) and
+#                      future flash-gui.sh introspection: compare the
+#                      current ROM's files against the update ZIP's
+#                      hashes.txt to report which scripts, modules,
+#                      or kernel changed before deciding to flash
 $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 	rm -rf "$(board_build)/update_pkg"
 	mkdir -p "$(board_build)/update_pkg"
 	cp "$<" "$(board_build)/update_pkg/"
+	cp "$(HASHES)" "$(board_build)/update_pkg/"
 	cd "$(board_build)/update_pkg" && sha256sum "$(CB_OUTPUT_FILE)" >sha256sum.txt
-	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt
+	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt "$(notdir $(HASHES))"
 
 # Only add the hash and size if split_8mb4mb.mk is not included
 ifeq ($(wildcard split_8mb4mb.mk),)

--- a/Makefile
+++ b/Makefile
@@ -281,8 +281,8 @@ $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 # Only add the hash and size if split_8mb4mb.mk is not included
 ifeq ($(wildcard split_8mb4mb.mk),)
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
-	@sha256sum $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(SIZES)"
+	@sha256sum $(board_build:$(pwd)/%=%)/$(CB_OUTPUT_FILE) | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(board_build:$(pwd)/%=%)/$(CB_OUTPUT_FILE) | tee -a "$(SIZES)"
 else
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
 endif
@@ -300,8 +300,8 @@ $(error "$(BOARD): neither CONFIG_COREBOOT nor CONFIG_LINUXBOOT is set?")
 endif
 
 all payload:
-	@sha256sum $< | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" $< | tee -a "$(SIZES)"
+	@sha256sum $(<:$(pwd)/%=%) | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(<:$(pwd)/%=%) | tee -a "$(SIZES)"
 
 # Validate coreboot CBFS size against IFD BIOS region
 validate_cbfs_ifd:
@@ -407,8 +407,8 @@ define do-cpio =
 		echo "$(DATE) UNCHANGED $(1:$(pwd)/%=%)" ; \
 		rm "$1.tmp" ; \
 	fi
-	@sha256sum "$1" | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" "$1" | tee -a "$(SIZES)"
+	@sha256sum "$(1:$(pwd)/%=%)" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$(1:$(pwd)/%=%)" | tee -a "$(SIZES)"
 	$(call do,HASHES   , $1,\
 		( cd "$2"; \
 		echo "-----" ; \

--- a/doc/reproducible-builds.md
+++ b/doc/reproducible-builds.md
@@ -13,7 +13,9 @@ produce the same build triplet instead of probing the Docker host kernel.
 `-Wa,--no-pad-sections` prevents gas from padding section ends (non-deterministic
 alignment).  `--with-debug-prefix-map=$(pwd)=.` normalizes build paths in debug
 info.  `--enable-compressed-debug-sections=no` disables zlib debug-section
-compression.  `SOURCE_DATE_EPOCH` from the pinned musl-cross-make commit epoch
+compression.  `SOURCE_DATE_EPOCH=0` (extracted tarballs lack .git; the build system cannot
+derive a commit timestamp from extracted tarballs, so `modules/musl-cross-make` falls back to
+`echo 0` when `git log` fails)
 prevents `__DATE__`/`__TIME__` embedding during the GCC build.
 
 ## Userland compiler flags
@@ -122,6 +124,18 @@ fetch_source_archive.sh.
   wget -O /tmp/ci-hashes.txt \
     "https://output.circle-artifacts.com/output/job/circleci-job-id/artifacts/0/build/x86/EOL_t480-hotp-maximized/hashes.txt"
   ```
+
+### Output files
+
+A build produces these hash-related files under `build/<arch>/<board>/`:
+
+| File | Content |
+|---|---|
+| `hashes.txt` | SHA-256 of every build artifact (cpio archives, bzImage, ROM) plus per-file hashes inside each cpio.  Reset at each `make` invocation; appended by each build rule.  The authoritative source for reproducibility verification. |
+| `sizes.txt` | Byte sizes of each artifact, matching the hashes.txt entries. |
+| `sha256sum.txt` | SHA-256 of the final ROM only.  Packaged inside the update zip for integrity checks during flash updates. |
+
+Both `hashes.txt` and `sha256sum.txt` are included in the update zip for offline reproducibility verification.
 
 ### Understanding hashes.txt
 

--- a/modules/busybox
+++ b/modules/busybox
@@ -11,8 +11,6 @@ busybox_hash := b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 busybox_configure := $(MAKE) CC="$(heads_cc)" oldconfig
 busybox_config := config/busybox.config
 busybox_output := busybox
-# Host compiler used by applets/busybox.mkll (busybox's Makefile uses gcc too)
-busybox_hostcc ?= gcc
 busybox_target := \
 	$(CROSS_TOOLS) \
 	$(MAKE_JOBS) \
@@ -36,11 +34,15 @@ endif
 
 $(initrd_bin_dir)/busybox: $(build)/$(busybox_dir)/.build
 	# Regenerate busybox.links (may be missing after clean/cache restore)
+	# mkll only runs the preprocessor (-E): cross-compiler is
+	# identical to host gcc for text-only header parsing and keeps
+	# the build chain self-contained (no host tools assumed)
 	$(call do,INSTALL,bin/busybox,\
 		cp $(build)/$(busybox_dir)/busybox \
 			$(initrd_bin_dir)/busybox && \
 		cd $(build)/$(busybox_dir) && \
-		HOSTCC="$(busybox_hostcc)" $(SHELL) applets/busybox.mkll include/autoconf.h include/applets.h > busybox.links && \
+		HOSTCC="$(heads_cc)" \
+		$(SHELL) applets/busybox.mkll include/autoconf.h include/applets.h > busybox.links && \
 		test -s busybox.links && \
 		$(SHELL) applets/install.sh $(initrd_bin_dir)/.. --symlinks \
 	)

--- a/modules/linux
+++ b/modules/linux
@@ -201,8 +201,10 @@ $(build)/$(BOARD)/modules.cpio: $(build)/$(linux_dir)/.build FORCE
 # linux build directory.  We need to copy it into our board
 # specific directory for ease of locating it later.
 $(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build FORCE
-	$(call do-copy,$(dir $<)/$(linux_output),$@.tmp)
-	@if ! cmp --quiet "$@.tmp" "$@" ; then \
+	$(call do,INSTALL  ,$< => $@.tmp,\
+		cp -a "$(dir $<)/$(linux_output)" "$@.tmp" \
+	)
+	@if [ ! -f "$@" ] || ! cmp --quiet "$@.tmp" "$@" ; then \
 		mv "$@.tmp" "$@" ; \
 		touch "$@" ; \
 	else \

--- a/modules/linux
+++ b/modules/linux
@@ -211,8 +211,8 @@ $(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build FORCE
 		echo "$(DATE) UNCHANGED $(@:$(pwd)/%=%)" ; \
 		rm "$@.tmp" ; \
 	fi
-	@sha256sum "$@" | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" "$@" | tee -a "$(SIZES)"
+	@sha256sum "$(@:$(pwd)/%=%)" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$(@:$(pwd)/%=%)" | tee -a "$(SIZES)"
 
 # Build kernel second time, now that initrd is built.
 $(build)/$(BOARD)/$(LINUX_IMAGE_FILE).bundled: \


### PR DESCRIPTION
Advances the reproducibility work from #2174 and supersedes the closed #2178.

#2174 added FORCE to modules.cpio for complete warm-build hashes.txt, but three gaps remained:
- bzImage, tools.cpio, and initrd.cpio.xz lacked FORCE -- their hashes missing on warm builds
- The busybox reproducible install change silently broke all 137 applet symlinks, leaving only the bare binary in the initrd

## What each commit does

**Commit 1** (`build: improve clean target @echo messages and fix reproducibility doc`, supersedes #2178):
- Clearer Makefile clean target messages
- Doc restructured into same/different-commit verification sections
- Fixed SOURCE_DATE_EPOCH claim (always 0, not pinned commit epoch)
- Restored bzImage in step-down path

**Commit 2** (`modules/linux: add FORCE and UNCHANGED guard to bzImage rule`, completes #2174):
- FORCE on bzImage copy/hash rule -- matching modules.cpio precedent
- cmp-based UNCHANGED guard with plain cp -a (no tmp hash noise)
- First-build cmp guard with [ ! -f "$@" ] (no stderr noise)

**Commit 3** (`modules/busybox: fix missing applet symlinks`, fixes regression from #2174):
- Regenerates busybox.links before install.sh (was missing after cache restore/make clean)
- Uses include/autoconf.h + HOSTCC=gcc + test -s guard

**Commit 4** (`Makefile: add FORCE to tools.cpio and initrd.cpio.xz`, completes #2174):
- Last two hashes.txt writers without FORCE
- filter-out FORCE prevents initrd recipe from leaking FORCE into cpio-clean.pl

## Verification

Local warm build at `792cb42f8b0`: clean, all UNCHANGED patterns fire, 137 busybox symlinks present, no errors.

CI cross-check: [pending]
