### PR TITLE
build: refine reproducibility artifacts (relative paths, bzImage guard, busybox compiler, hashes.txt in zip, doc fixes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,12 +271,28 @@ else
 # verification before flashing (see flash-gui.sh).  The ZIP package format
 # allows other metadata that might be needed to added in the future without
 # breaking backward compatibility.
+# --- UPDATE PACKAGE (ZIP) ---
+#
+# The update zip contains three files:
+#   <rom-file>      - The Heads ROM image (16 MiB flashable image)
+#   sha256sum.txt   - SHA-256 of the ROM only (for update integrity checks)
+#   hashes.txt      - Per-file hash manifest for reproducibility
+#                      verification (same-commit CI comparison) and
+#                      future flash-gui.sh introspection: compare the
+#                      current ROM's files against the update ZIP's
+#                      hashes.txt to report which scripts, modules,
+#                      or kernel changed before deciding to flash
 $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 	rm -rf "$(board_build)/update_pkg"
 	mkdir -p "$(board_build)/update_pkg"
 	cp "$<" "$(board_build)/update_pkg/"
+	cp "$(HASHES)" "$(board_build)/update_pkg/"
+	# Append the ROM entry to the update's hashes.txt copy; the
+	# main $(HASHES) file is updated only later in the all: rule,
+	# after the zip was already assembled.
+	sha256sum "$(board_build:$(pwd)/%=%)/$(CB_OUTPUT_FILE)" >> "$(board_build)/update_pkg/$(notdir $(HASHES))"
 	cd "$(board_build)/update_pkg" && sha256sum "$(CB_OUTPUT_FILE)" >sha256sum.txt
-	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt
+	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt "$(notdir $(HASHES))"
 
 # Only add the hash and size if split_8mb4mb.mk is not included
 ifeq ($(wildcard split_8mb4mb.mk),)

--- a/Makefile
+++ b/Makefile
@@ -281,8 +281,8 @@ $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 # Only add the hash and size if split_8mb4mb.mk is not included
 ifeq ($(wildcard split_8mb4mb.mk),)
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
-	@sha256sum $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(SIZES)"
+	@sha256sum $(board_build:$(pwd)/%=%)/$(CB_OUTPUT_FILE) | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(board_build:$(pwd)/%=%)/$(CB_OUTPUT_FILE) | tee -a "$(SIZES)"
 else
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
 endif
@@ -300,8 +300,8 @@ $(error "$(BOARD): neither CONFIG_COREBOOT nor CONFIG_LINUXBOOT is set?")
 endif
 
 all payload:
-	@sha256sum $< | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" $< | tee -a "$(SIZES)"
+	@sha256sum $(<:$(pwd)/%=%) | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(<:$(pwd)/%=%) | tee -a "$(SIZES)"
 
 # Validate coreboot CBFS size against IFD BIOS region
 validate_cbfs_ifd:
@@ -407,8 +407,8 @@ define do-cpio =
 		echo "$(DATE) UNCHANGED $(1:$(pwd)/%=%)" ; \
 		rm "$1.tmp" ; \
 	fi
-	@sha256sum "$1" | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" "$1" | tee -a "$(SIZES)"
+	@sha256sum "$(1:$(pwd)/%=%)" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$(1:$(pwd)/%=%)" | tee -a "$(SIZES)"
 	$(call do,HASHES   , $1,\
 		( cd "$2"; \
 		echo "-----" ; \

--- a/doc/reproducible-builds.md
+++ b/doc/reproducible-builds.md
@@ -13,7 +13,9 @@ produce the same build triplet instead of probing the Docker host kernel.
 `-Wa,--no-pad-sections` prevents gas from padding section ends (non-deterministic
 alignment).  `--with-debug-prefix-map=$(pwd)=.` normalizes build paths in debug
 info.  `--enable-compressed-debug-sections=no` disables zlib debug-section
-compression.  `SOURCE_DATE_EPOCH` from the pinned musl-cross-make commit epoch
+compression.  `SOURCE_DATE_EPOCH=0` (extracted tarballs lack .git; the build system cannot
+derive a commit timestamp from extracted tarballs, so `modules/musl-cross-make` falls back to
+`echo 0` when `git log` fails)
 prevents `__DATE__`/`__TIME__` embedding during the GCC build.
 
 ## Userland compiler flags
@@ -122,6 +124,18 @@ fetch_source_archive.sh.
   wget -O /tmp/ci-hashes.txt \
     "https://output.circle-artifacts.com/output/job/circleci-job-id/artifacts/0/build/x86/EOL_t480-hotp-maximized/hashes.txt"
   ```
+
+### Output files
+
+A build produces these hash-related files under `build/<arch>/<board>/`:
+
+| File | Content |
+|---|---|
+| `hashes.txt` | SHA-256 of every build artifact (cpio archives, bzImage, ROM) plus per-file hashes inside each cpio.  Reset at each `make` invocation; appended by each build rule.  The authoritative source for reproducibility verification. |
+| `sizes.txt` | Byte sizes of each artifact, matching the hashes.txt entries. |
+| `sha256sum.txt` | SHA-256 of the final ROM only.  Packaged inside the update zip for integrity checks during flash updates. |
+
+Both `hashes.txt` and `sha256sum.txt` are included in the update zip for offline reproducibility verification.
 
 ### Understanding hashes.txt
 

--- a/modules/busybox
+++ b/modules/busybox
@@ -11,8 +11,6 @@ busybox_hash := b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 busybox_configure := $(MAKE) CC="$(heads_cc)" oldconfig
 busybox_config := config/busybox.config
 busybox_output := busybox
-# Host compiler used by applets/busybox.mkll (busybox's Makefile uses gcc too)
-busybox_hostcc ?= gcc
 busybox_target := \
 	$(CROSS_TOOLS) \
 	$(MAKE_JOBS) \
@@ -36,11 +34,15 @@ endif
 
 $(initrd_bin_dir)/busybox: $(build)/$(busybox_dir)/.build
 	# Regenerate busybox.links (may be missing after clean/cache restore)
+	# mkll only runs the preprocessor (-E) on generated headers;
+	# using the cross-compiler keeps the build chain
+	# self-contained (no host tools assumed)
 	$(call do,INSTALL,bin/busybox,\
 		cp $(build)/$(busybox_dir)/busybox \
 			$(initrd_bin_dir)/busybox && \
 		cd $(build)/$(busybox_dir) && \
-		HOSTCC="$(busybox_hostcc)" $(SHELL) applets/busybox.mkll include/autoconf.h include/applets.h > busybox.links && \
+		HOSTCC="$(heads_cc)" \
+		$(SHELL) applets/busybox.mkll include/autoconf.h include/applets.h > busybox.links && \
 		test -s busybox.links && \
 		$(SHELL) applets/install.sh $(initrd_bin_dir)/.. --symlinks \
 	)

--- a/modules/linux
+++ b/modules/linux
@@ -211,8 +211,8 @@ $(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build FORCE
 		echo "$(DATE) UNCHANGED $(@:$(pwd)/%=%)" ; \
 		rm "$@.tmp" ; \
 	fi
-	@sha256sum "$@" | tee -a "$(HASHES)"
-	@stat -c "%8s:%n" "$@" | tee -a "$(SIZES)"
+	@sha256sum "$(@:$(pwd)/%=%)" | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" "$(@:$(pwd)/%=%)" | tee -a "$(SIZES)"
 
 # Build kernel second time, now that initrd is built.
 $(build)/$(BOARD)/$(LINUX_IMAGE_FILE).bundled: \
@@ -222,7 +222,7 @@ $(build)/$(BOARD)/$(LINUX_IMAGE_FILE).bundled: \
 	$(MAKE) -C "$(build)/$(linux_dir)" $(linux_target)
 	$(call do-copy,$(build)/$(linux_dir)/$(linux_output),$@)
 	@touch $@ # force a timestamp update
-	@sha256sum "$@" | tee -a "$(HASHES)"
+	@sha256sum "$(@:$(pwd)/%=%)" | tee -a "$(HASHES)"
 
 # If loadkeys is shipped, include the actual default keymap used by the kernel,
 # so loadkeys --default really resets the keymap to the default state.

--- a/modules/linux
+++ b/modules/linux
@@ -201,8 +201,10 @@ $(build)/$(BOARD)/modules.cpio: $(build)/$(linux_dir)/.build FORCE
 # linux build directory.  We need to copy it into our board
 # specific directory for ease of locating it later.
 $(build)/$(BOARD)/$(LINUX_IMAGE_FILE): $(build)/$(linux_dir)/.build FORCE
-	$(call do-copy,$(dir $<)/$(linux_output),$@.tmp)
-	@if ! cmp --quiet "$@.tmp" "$@" ; then \
+	$(call do,INSTALL  ,$(dir $<)/$(linux_output) => $@.tmp,\
+		cp -a "$(dir $<)/$(linux_output)" "$@.tmp" \
+	)
+	@if [ ! -f "$@" ] || ! cmp --quiet "$@.tmp" "$@" ; then \
 		mv "$@.tmp" "$@" ; \
 		touch "$@" ; \
 	else \


### PR DESCRIPTION
Small refinements on top of the already-merged #2179.

## Changes

1. **doc/reproducible-builds.md**: fix misleading SOURCE_DATE_EPOCH wording; document `hashes.txt`/`sha256sum.txt`/`sizes.txt` output files

2. **modules/linux**: improve bzImage UNCHANGED guard - plain `cp -a` instead of `do-copy` (no tmp hash noise); `[ ! -f "$@" ]` guard on first-build cmp

3. **modules/busybox**: use `HOSTCC="$(heads_cc)"` (musl-cross compiler) instead of host `gcc` for `busybox.mkll` - only runs the preprocessor (-E), so no target binaries are produced; using the cross-compiler keeps the build chain self-contained (no host tools assumed)

4. **all**: use relative paths in all hashes.txt/sizes.txt entries - `$(build)` = `$(pwd)/build/...` produced absolute paths, creating path-prefix noise in CI-vs-local diffs. Fix `do-cpio`, bzImage rule, `all:` ROM recipe, and `all payload:` recipe.

5. **Makefile**: include hashes.txt in update zip - enables future introspection: hash files in the running firmware against the update's hashes.txt, instantly showing which files are identical and which differ. The update's hashes.txt copy also gets the ROM entry appended before zipping (the main HASHES file receives it only after the zip is assembled). Only makes the file available; the tool is deferred.

## Verification

Local warm build (earlier head of this stack): `./docker_repro.sh make BOARD=EOL_t480-hotp-maximized` - success, ROM https://github.com/linuxboot/heads/pull/2181/commits/9547e87095f8c0fc00c145d8c99d6f5dbb11c23f, 0 errors. x230 split-board build with the current zip/hashes changes: update-zip hashes.txt contains the ROM entry exactly once, main hashes.txt unaffected.

CI cross-check: 
```

cd /tmp/ci-t480 && L=/home/user/heads/build/x86/EOL_t480-hotp-maximized; echo "=== zip-internal hashes.txt: CI vs LOCAL (sorted, minus header) ==="; diff <(unzip -p ci.zip hashes.txt | sort | tail -n +1 | grep -v '^2026-') <(unzip -p "$L/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip" hashes.txt | sort | grep -v '^2026-') && echo "ALL 444 ENTRIES IDENTICAL (excluding build-time header)"; echo; echo "=== zip headers ==="; unzip -p ci.zip hashes.txt | head -1; unzip -p "$L/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip" hashes.txt | head -1; echo; echo "=== zip ROM entries count ==="; unzip -p ci.zip hashes.txt | grep -c '\.rom'; unzip -p "$L/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip" hashes.txt | grep -c '\.rom'; echo; echo "=== sha256sum.txt ==="; unzip -p ci.zip sha256sum.txt; unzip -p "$L/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip" sha256sum.txt; echo; echo "=== whole-zip hash ==="; sha256sum ci.zip "$L/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip"
=== zip-internal hashes.txt: CI vs LOCAL (sorted, minus header) ===
ALL 444 ENTRIES IDENTICAL (excluding build-time header)

=== zip headers ===
2026-08-07 18:35:41+00:00 9547e87095f8c0fc00c145d8c99d6f5dbb11c23f clean
2026-08-07 19:03:27+00:00 9547e87095f8c0fc00c145d8c99d6f5dbb11c23f clean

=== zip ROM entries count ===
1
1

=== sha256sum.txt ===
d6b5cdb376844b619abfc71b24c40332344a48088045730b1c1449aa9a816c07  heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.rom
d6b5cdb376844b619abfc71b24c40332344a48088045730b1c1449aa9a816c07  heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.rom

=== whole-zip hash ===
e209d08a946a48add45bd69ad1f6a2413b652caf4c738e31ec1b2c1bbe77ddc7  ci.zip
1726cac033ebbdb73c8e59e5f423081f7af799171c011d6ac9ace9e3bce89cea  /home/user/heads/build/x86/EOL_t480-hotp-maximized/heads-EOL_t480-hotp-maximized-202608071425-v0.2.1-3124-g9547e87.zip

```