### PR TITLE
.circleci/config.yml: hash all blobs files in cache key to prevent dirty builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Creating blobs listing digest (for x86_blobs cache key)
           command: |
-            find ./blobs -type f -name "*.sh" | sort -h | xargs sha256sum > ./tmpDir/blobs_listing.sha256sums
+            find ./blobs -type f | sort -h | xargs sha256sum > ./tmpDir/blobs_listing.sha256sums
       - persist_to_workspace:
           root: ~/heads
           paths:


### PR DESCRIPTION
Fixes #2182.

## Bug

Since PR #2165 (July 31), every CircleCI build produces ROM artifacts with
the `-dirty` suffix. The ROM filename includes `-dirty` because
`GIT_STATUS` (Makefile line 4) evaluates to `dirty` via `git diff --exit-code`.

## Root cause

CircleCI caches the `blobs/` directory in a workspace. The cache key is
computed from only `*.sh` files under `blobs/`:

```yaml
find ./blobs -type f -name "*.sh" | sort -h | xargs sha256sum
```

PR #2165 changed two tracked files (`blobs/m900/README.md` and
`blobs/xx80/README.md`) but the cache key did not change because the
READMEs are not `*.sh`. The stale workspace containing old README
content was restored on top of the fresh checkout. `attach_workspace`
overwrites tracked files, so `git diff` detects modifications and
sets `GIT_STATUS=dirty`.

Pipeline 1397 (commit `7f00d9b9aaa`, pre-#2165) was the last clean
build. Pipeline 1400 (commit `a605d043030`, #2165 merge) is the
first dirty build. All subsequent pipelines inherited the stale cache.

## Fix

Hash **all** files under `blobs/` for the cache key, not just
`*.sh`. Any tracked blob file change now invalidates the cache,
preventing stale workspace content from overwriting fresh checkouts.